### PR TITLE
ci: add development branch to CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
 
 # Minimal permissions for security (ISE best practice)
-# Triggered on PRs to main and pushes to main
+# Triggered on PRs to main/development and pushes to main/development
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

Adds `development` branch to CI workflow triggers so automated checks run on PRs targeting development.

## Changes

- Updated `.github/workflows/ci.yml`:
  - `push.branches`: `[main]` → `[main, development]`
  - `pull_request.branches`: `[main]` → `[main, development]`

## Rationale

PR #107 had no automated checks because CI only ran on PRs to `main`. This fix ensures all PRs receive automated validation.

## Verification

- No changes to CI logic
- Only trigger configuration updated
- Minimal, focused change

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)