### PR TITLE
feat: improve welcome page UX with inline consent and clearer trial messaging

### DIFF
--- a/src/app/welcome/components/index.ts
+++ b/src/app/welcome/components/index.ts
@@ -1,5 +1,7 @@
-export { WelcomeStep } from './welcome-step';
-export { InfoStep } from './info-step';
-export { PrinciplesStep } from './principles-step';
-export { MaestriStep } from './maestri-step';
-export { ReadyStep } from './ready-step';
+export { WelcomeStep } from "./welcome-step";
+export { InfoStep } from "./info-step";
+export { PrinciplesStep } from "./principles-step";
+export { MaestriStep } from "./maestri-step";
+export { ReadyStep } from "./ready-step";
+export { TrialLimitsBanner } from "./trial-limits-banner";
+export { WelcomeFooter } from "./welcome-footer";

--- a/src/app/welcome/components/quick-start.tsx
+++ b/src/app/welcome/components/quick-start.tsx
@@ -10,6 +10,7 @@ import {
   SkipForward,
   LogIn,
   UserPlus,
+  Sparkles,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -24,13 +25,10 @@ interface QuickStartProps {
 /**
  * Quick Start Section for MirrorBuddy Welcome Page
  *
- * Provides clear CTAs for:
- * - Start with voice (recommended)
- * - Start without voice
- * - Skip to dashboard
- * - Update profile (returning users)
- *
- * Part of Wave 3: Welcome Experience Enhancement
+ * Provides clear CTAs with distinct trial vs authenticated paths:
+ * - Trial options clearly marked as "Prova Gratuita"
+ * - Login/register options prominently displayed
+ * - Visual separation between entry paths
  */
 export function QuickStart({
   isReturningUser,
@@ -44,7 +42,7 @@ export function QuickStart({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 0.9 }}
-      className="w-full max-w-md mx-auto px-4"
+      className="w-full max-w-lg mx-auto px-4"
       aria-labelledby="quickstart-heading"
     >
       <h2 id="quickstart-heading" className="sr-only">
@@ -77,73 +75,89 @@ export function QuickStart({
           )}
         </div>
       ) : (
-        <div className="flex flex-col items-center gap-4">
-          {/* Primary: Start with voice */}
-          <Button
-            size="lg"
-            onClick={onStartWithVoice}
-            className="w-full sm:w-auto bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white px-8 py-6 text-lg rounded-xl shadow-lg shadow-purple-500/25 hover:shadow-xl hover:shadow-purple-500/30 transition-all"
-          >
-            <Mic className="w-5 h-5 mr-2" aria-hidden="true" />
-            Inizia con Melissa
-            <ArrowRight className="w-5 h-5 ml-2" aria-hidden="true" />
-          </Button>
-
-          {/* Secondary: Start without voice */}
-          <Button
-            size="lg"
-            variant="outline"
-            onClick={onStartWithoutVoice}
-            className="w-full sm:w-auto px-8 py-6 text-lg rounded-xl border-2 border-gray-200 dark:border-gray-700"
-          >
-            <MousePointer className="w-5 h-5 mr-2" aria-hidden="true" />
-            Continua senza voce
-          </Button>
-
-          {/* Skip link */}
-          <button
-            onClick={onSkip}
-            className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors underline-offset-2 hover:underline mt-2"
-          >
-            <SkipForward className="w-4 h-4" aria-hidden="true" />
-            Salta intro e inizia subito
-          </button>
-
-          {/* Authentication options */}
-          <div className="w-full mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
-            <p className="text-center text-sm text-gray-600 dark:text-gray-400 mb-3">
-              Hai già un account?
+        <div className="flex flex-col items-center gap-6">
+          {/* Authentication Section - Now First */}
+          <div className="w-full p-5 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-2xl border border-blue-200 dark:border-blue-800/50">
+            <p className="text-center text-sm font-medium text-blue-800 dark:text-blue-200 mb-4">
+              Hai un account beta?
             </p>
             <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Link href="/login">
+              <Link href="/login" className="w-full sm:w-auto">
                 <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-blue-600 dark:text-blue-400"
+                  size="lg"
+                  className="w-full bg-blue-600 hover:bg-blue-700 text-white"
                 >
                   <LogIn className="w-4 h-4 mr-2" aria-hidden="true" />
                   Accedi
                 </Button>
               </Link>
-              <span className="hidden sm:inline text-gray-300 dark:text-gray-600">
-                |
-              </span>
-              <Link href="/invite/request">
+              <Link href="/invite/request" className="w-full sm:w-auto">
                 <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-purple-600 dark:text-purple-400"
+                  size="lg"
+                  variant="outline"
+                  className="w-full border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-300"
                 >
                   <UserPlus className="w-4 h-4 mr-2" aria-hidden="true" />
-                  Richiedi accesso beta
+                  Richiedi accesso
                 </Button>
               </Link>
             </div>
           </div>
+
+          {/* Divider */}
+          <div className="flex items-center w-full gap-4">
+            <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              oppure
+            </span>
+            <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+          </div>
+
+          {/* Trial Section */}
+          <div className="w-full space-y-4">
+            {/* Trial Badge */}
+            <div className="flex items-center justify-center gap-2">
+              <Sparkles className="w-4 h-4 text-amber-500" />
+              <span className="text-sm font-medium text-amber-700 dark:text-amber-300">
+                Prova Gratuita - Nessuna registrazione
+              </span>
+            </div>
+
+            {/* Primary: Start trial with voice */}
+            <Button
+              size="lg"
+              onClick={onStartWithVoice}
+              className="w-full bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white px-8 py-6 text-lg rounded-xl shadow-lg shadow-purple-500/25 hover:shadow-xl hover:shadow-purple-500/30 transition-all"
+            >
+              <Mic className="w-5 h-5 mr-2" aria-hidden="true" />
+              Prova Gratis con Melissa
+              <ArrowRight className="w-5 h-5 ml-2" aria-hidden="true" />
+            </Button>
+
+            {/* Secondary: Start trial without voice */}
+            <Button
+              size="lg"
+              variant="outline"
+              onClick={onStartWithoutVoice}
+              className="w-full px-8 py-6 text-lg rounded-xl border-2 border-gray-200 dark:border-gray-700"
+            >
+              <MousePointer className="w-5 h-5 mr-2" aria-hidden="true" />
+              Prova senza voce
+            </Button>
+
+            {/* Skip link */}
+            <button
+              onClick={onSkip}
+              className="w-full flex items-center justify-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors underline-offset-2 hover:underline mt-2"
+            >
+              <SkipForward className="w-4 h-4" aria-hidden="true" />
+              Salta intro e prova subito
+            </button>
+          </div>
         </div>
       )}
 
-      {/* Voice indicator for new users */}
+      {/* Settings reminder for new users */}
       {!isReturningUser && (
         <motion.p
           initial={{ opacity: 0 }}

--- a/src/app/welcome/components/trial-limits-banner.tsx
+++ b/src/app/welcome/components/trial-limits-banner.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { motion } from "framer-motion";
+import Link from "next/link";
+import { MessageSquare, Users, Wrench, Gift, ArrowRight } from "lucide-react";
+
+interface TrialLimit {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}
+
+const TRIAL_LIMITS: TrialLimit[] = [
+  {
+    icon: <MessageSquare className="w-5 h-5" />,
+    label: "Messaggi",
+    value: "10 per sessione",
+  },
+  {
+    icon: <Users className="w-5 h-5" />,
+    label: "Maestri",
+    value: "3 disponibili",
+  },
+  {
+    icon: <Wrench className="w-5 h-5" />,
+    label: "Strumenti",
+    value: "Base",
+  },
+];
+
+/**
+ * Trial Limits Banner - Transparent communication of trial mode limitations
+ *
+ * Shows users exactly what they get in trial mode:
+ * - 10 messages per session
+ * - 3 Maestri available
+ * - Limited tools
+ *
+ * Includes CTA to request full beta access.
+ */
+export function TrialLimitsBanner() {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.7 }}
+      className="w-full max-w-2xl mx-auto px-4 mb-8"
+      aria-labelledby="trial-banner-heading"
+    >
+      <div className="bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-900/20 dark:to-orange-900/20 rounded-2xl border border-amber-200 dark:border-amber-800/50 p-6">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-10 h-10 bg-amber-100 dark:bg-amber-800/30 rounded-xl flex items-center justify-center">
+            <Gift className="w-5 h-5 text-amber-600 dark:text-amber-400" />
+          </div>
+          <div>
+            <h3
+              id="trial-banner-heading"
+              className="font-semibold text-amber-900 dark:text-amber-100"
+            >
+              Modalità Prova Gratuita
+            </h3>
+            <p className="text-sm text-amber-700 dark:text-amber-300">
+              Esplora MirrorBuddy senza registrazione
+            </p>
+          </div>
+        </div>
+
+        {/* Limits Grid */}
+        <div className="grid grid-cols-3 gap-4 mb-5">
+          {TRIAL_LIMITS.map((limit, index) => (
+            <div
+              key={index}
+              className="flex flex-col items-center text-center p-3 bg-white/60 dark:bg-gray-800/40 rounded-xl"
+            >
+              <div className="text-amber-600 dark:text-amber-400 mb-2">
+                {limit.icon}
+              </div>
+              <span className="text-xs text-gray-600 dark:text-gray-400">
+                {limit.label}
+              </span>
+              <span className="text-sm font-medium text-gray-900 dark:text-white">
+                {limit.value}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* CTA */}
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-3 pt-4 border-t border-amber-200/50 dark:border-amber-700/50">
+          <p className="text-sm text-amber-800 dark:text-amber-200">
+            Vuoi accesso completo a tutti i Maestri e strumenti?
+          </p>
+          <Link
+            href="/invite/request"
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 rounded-lg transition-colors"
+          >
+            Richiedi accesso beta
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
+      </div>
+    </motion.section>
+  );
+}
+
+export default TrialLimitsBanner;

--- a/src/app/welcome/components/welcome-footer.tsx
+++ b/src/app/welcome/components/welcome-footer.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { motion } from "framer-motion";
+import Link from "next/link";
+import { Shield, Bot, Lock, AlertTriangle } from "lucide-react";
+import { InlineConsent } from "@/components/consent/inline-consent";
+
+interface ComplianceBadge {
+  icon: React.ReactNode;
+  label: string;
+  description: string;
+}
+
+const COMPLIANCE_BADGES: ComplianceBadge[] = [
+  {
+    icon: <Shield className="w-4 h-4" />,
+    label: "GDPR",
+    description: "Conforme al regolamento europeo",
+  },
+  {
+    icon: <Lock className="w-4 h-4" />,
+    label: "COPPA",
+    description: "Protezione minori",
+  },
+  {
+    icon: <AlertTriangle className="w-4 h-4" />,
+    label: "Anti-hijacking",
+    description: "Controlli di sicurezza AI",
+  },
+];
+
+const LEGAL_LINKS = [
+  { href: "/privacy", label: "Privacy Policy" },
+  { href: "/terms", label: "Termini di Servizio" },
+  { href: "/cookies", label: "Cookie Policy" },
+];
+
+/**
+ * Welcome Footer - Comprehensive footer with compliance elements
+ *
+ * Includes:
+ * - Inline cookie consent
+ * - Legal links (privacy, terms, cookies)
+ * - AI disclaimer badge
+ * - Compliance badges (GDPR, COPPA, anti-hijacking)
+ * - Copyright notice
+ */
+export function WelcomeFooter() {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <motion.footer
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ delay: 1.2 }}
+      className="w-full mt-12 border-t border-gray-200 dark:border-gray-800"
+      role="contentinfo"
+      aria-label="Footer con informazioni legali e consenso cookie"
+    >
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        {/* Cookie Consent */}
+        <div className="mb-8">
+          <InlineConsent />
+        </div>
+
+        {/* AI Disclaimer */}
+        <div className="flex items-center justify-center gap-2 mb-6 px-4 py-2 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800/50">
+          <Bot className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+          <span className="text-sm text-blue-800 dark:text-blue-200">
+            Creato con AI - le risposte possono contenere errori
+          </span>
+        </div>
+
+        {/* Compliance Badges */}
+        <div className="flex flex-wrap items-center justify-center gap-4 mb-6">
+          {COMPLIANCE_BADGES.map((badge, index) => (
+            <div
+              key={index}
+              className="flex items-center gap-2 px-3 py-1.5 bg-gray-100 dark:bg-gray-800 rounded-full"
+              title={badge.description}
+            >
+              <span className="text-green-600 dark:text-green-400">
+                {badge.icon}
+              </span>
+              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                {badge.label}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Legal Links */}
+        <nav
+          className="flex flex-wrap items-center justify-center gap-4 mb-6"
+          aria-label="Link legali"
+        >
+          {LEGAL_LINKS.map((link, index) => (
+            <Link
+              key={index}
+              href={link.href}
+              className="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors underline-offset-2 hover:underline"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+
+        {/* Copyright */}
+        <p className="text-center text-xs text-gray-500 dark:text-gray-500">
+          © {currentYear} MirrorBuddy. Tutti i diritti riservati.
+        </p>
+      </div>
+    </motion.footer>
+  );
+}
+
+export default WelcomeFooter;

--- a/src/components/consent/index.ts
+++ b/src/components/consent/index.ts
@@ -1,4 +1,5 @@
 export { CookieConsentWall } from "./cookie-consent-wall";
+export { InlineConsent } from "./inline-consent";
 export {
   hasConsent,
   getConsent,

--- a/src/components/consent/inline-consent.tsx
+++ b/src/components/consent/inline-consent.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useSyncExternalStore } from "react";
+import Link from "next/link";
+import { Cookie, Check } from "lucide-react";
+import {
+  saveConsent,
+  syncConsentToServer,
+} from "@/lib/consent/consent-storage";
+import {
+  subscribeToConsent,
+  getConsentSnapshot,
+  getServerConsentSnapshot,
+  updateConsentSnapshot,
+} from "@/lib/consent/consent-store";
+
+interface InlineConsentProps {
+  /** Optional callback when consent changes */
+  onConsentChange?: (consented: boolean) => void;
+  /** Compact mode for tight spaces */
+  compact?: boolean;
+}
+
+/**
+ * Inline Consent Component - Non-blocking cookie consent for footer
+ *
+ * Provides a checkbox-style consent mechanism that integrates
+ * into the welcome page footer instead of blocking the UI.
+ *
+ * GDPR compliant - user must actively accept.
+ */
+export function InlineConsent({
+  onConsentChange,
+  compact = false,
+}: InlineConsentProps) {
+  // Use useSyncExternalStore to avoid setState-in-effect issues
+  const consented = useSyncExternalStore(
+    subscribeToConsent,
+    getConsentSnapshot,
+    getServerConsentSnapshot,
+  );
+  const [analyticsEnabled, setAnalyticsEnabled] = useState(true);
+
+  const handleAccept = async () => {
+    const consent = saveConsent(analyticsEnabled);
+    await syncConsentToServer(consent);
+    updateConsentSnapshot(true);
+    onConsentChange?.(true);
+  };
+
+  // Already consented
+  if (consented) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-green-600 dark:text-green-400">
+        <Check className="w-4 h-4" />
+        <span>Cookie accettati</span>
+        <span className="text-gray-400">•</span>
+        <Link
+          href="/cookies"
+          className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 underline-offset-2 hover:underline"
+        >
+          Gestisci
+        </Link>
+      </div>
+    );
+  }
+
+  // Compact version
+  if (compact) {
+    return (
+      <div className="flex items-center gap-3">
+        <button
+          onClick={handleAccept}
+          className="flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          <Cookie className="w-4 h-4" />
+          Accetta i cookie
+        </button>
+        <Link
+          href="/cookies"
+          className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 underline-offset-2 hover:underline"
+        >
+          Info
+        </Link>
+      </div>
+    );
+  }
+
+  // Full version with analytics toggle
+  return (
+    <div className="flex flex-col gap-3 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
+      <div className="flex items-start gap-3">
+        <Cookie className="w-5 h-5 text-amber-500 mt-0.5 flex-shrink-0" />
+        <div className="flex-1">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">
+            Cookie e Privacy
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Utilizziamo cookie essenziali per il funzionamento.{" "}
+            <Link
+              href="/cookies"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Scopri di più
+            </Link>
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={analyticsEnabled}
+            onChange={(e) => setAnalyticsEnabled(e.target.checked)}
+            className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          />
+          <span className="text-xs text-gray-600 dark:text-gray-300">
+            Includi analytics
+          </span>
+        </label>
+        <button
+          onClick={handleAccept}
+          className="px-4 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+        >
+          Accetto
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default InlineConsent;

--- a/src/lib/consent/consent-store.ts
+++ b/src/lib/consent/consent-store.ts
@@ -1,0 +1,46 @@
+/**
+ * Consent Store - External store for consent state
+ *
+ * Shared between CookieConsentWall and InlineConsent components.
+ * Uses useSyncExternalStore pattern to avoid setState-in-effect issues.
+ */
+
+import { hasConsent } from "./consent-storage";
+
+// External store for consent state
+const consentSubscribers = new Set<() => void>();
+let consentSnapshot: boolean | null = null;
+
+/**
+ * Subscribe to consent changes
+ */
+export function subscribeToConsent(callback: () => void) {
+  consentSubscribers.add(callback);
+  return () => consentSubscribers.delete(callback);
+}
+
+/**
+ * Get current consent snapshot (client-side)
+ */
+export function getConsentSnapshot() {
+  // Initialize snapshot on first call (lazy)
+  if (consentSnapshot === null) {
+    consentSnapshot = hasConsent();
+  }
+  return consentSnapshot;
+}
+
+/**
+ * Get consent snapshot for server-side rendering
+ */
+export function getServerConsentSnapshot() {
+  return false; // Server-side, assume no consent
+}
+
+/**
+ * Update consent state and notify all subscribers
+ */
+export function updateConsentSnapshot(consented: boolean) {
+  consentSnapshot = consented;
+  consentSubscribers.forEach((cb) => cb());
+}


### PR DESCRIPTION
## Summary

- **F-01**: Clear trial mode messaging with prominent `TrialLimitsBanner` showing limitations (10 messages, 3 Maestri, limited tools)
- **F-02**: Integrated cookie consent in footer via `InlineConsent` component (non-blocking)
- **F-03**: `WelcomeFooter` with legal links (Privacy Policy, Terms of Service, Cookie Policy)
- **F-04**: AI disclaimer badge ("Creato con AI - le risposte possono contenere errori")
- **F-05**: Compliance badges (GDPR, COPPA, Anti-hijacking)
- **F-06**: Clearer CTAs distinguishing trial vs login/register paths

## Changes

### New Components
- `InlineConsent` - Non-blocking consent toggle for footer
- `TrialLimitsBanner` - Prominent banner showing trial limitations
- `WelcomeFooter` - Footer with consent, legal links, badges
- `consent-store.ts` - Shared external store for consent state

### Modified Components
- `QuickStart` - Reorganized CTAs with auth section first, trial section below
- `LandingPage` - Integrated new components, simplified trial flow
- `Providers` - Added `ConditionalCookieConsent` to skip blocking wall on welcome page
- `CookieConsentWall` - Refactored to use shared consent store

## Visual Hierarchy (after implementation)
1. Hero section with mascot
2. Maestri showcase
3. Support section
4. Features section
5. **TrialLimitsBanner** (new - clear trial info)
6. **QuickStart with clearer CTAs** (modified)
7. **WelcomeFooter** (new - consent + legal + badges)

## Test plan
- [ ] Visit `/welcome` as new user - verify trial banner shows limitations
- [ ] Verify footer shows inline consent, legal links, AI disclaimer, compliance badges
- [ ] Accept cookies in footer - verify state updates correctly
- [ ] Verify blocking consent wall still works on other routes (e.g., `/`)
- [ ] Test CTA buttons - trial buttons clearly marked, auth section prominent
- [ ] Verify build passes: `npm run lint && npm run typecheck && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)