### PR TITLE
fix: correct telemetry data sources and remove fake metrics

### DIFF
--- a/src/app/admin/revenue/page.tsx
+++ b/src/app/admin/revenue/page.tsx
@@ -78,15 +78,29 @@ async function getRevenueMetrics(): Promise<RevenueMetrics> {
   const arpu = totalActive > 0 ? mrr / totalActive : 0;
   const avgLTV = churnRate > 0 ? Math.round((arpu / (churnRate / 100)) * 100) / 100 : arpu * 12;
 
-  // Revenue by country (from user locale/metadata if available)
-  // Simplified: aggregate from audit logs or user metadata
-  const revenueByCountry = [
-    { country: 'IT', revenue: mrr * 0.4 },
-    { country: 'FR', revenue: mrr * 0.2 },
-    { country: 'DE', revenue: mrr * 0.15 },
-    { country: 'ES', revenue: mrr * 0.15 },
-    { country: 'Other', revenue: mrr * 0.1 },
-  ];
+  // Revenue by country from actual subscription + user language data
+  const revenueByLocale = await prisma.$queryRaw<Array<{ language: string; revenue: number }>>`
+    SELECT COALESCE(s.language, 'it') as language,
+           COALESCE(SUM(CAST(td."monthlyPriceEur" AS DECIMAL)), 0) as revenue
+    FROM "UserSubscription" us
+    JOIN "TierDefinition" td ON us."tierId" = td.id
+    LEFT JOIN "Settings" s ON us."userId" = s."userId"
+    WHERE us.status = 'ACTIVE'
+    GROUP BY COALESCE(s.language, 'it')
+    ORDER BY revenue DESC
+  `;
+
+  const localeToCountry: Record<string, string> = {
+    it: 'IT',
+    en: 'GB',
+    fr: 'FR',
+    de: 'DE',
+    es: 'ES',
+  };
+  const revenueByCountry = revenueByLocale.map((r) => ({
+    country: localeToCountry[r.language] || 'Other',
+    revenue: Number(r.revenue),
+  }));
 
   // Monthly trend (last 6 months)
   const monthlyTrend: { month: string; mrr: number; subscribers: number }[] = [];

--- a/src/app/api/dashboard/fsrs-stats/route.ts
+++ b/src/app/api/dashboard/fsrs-stats/route.ts
@@ -4,36 +4,33 @@
 // SECURITY: Requires authentication
 // ============================================================================
 
-import { NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
-import { pipe, withSentry, withAdmin } from "@/lib/api/middlewares";
-
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { pipe, withSentry, withAdmin } from '@/lib/api/middlewares';
 
 export const revalidate = 0;
 export const GET = pipe(
-  withSentry("/api/dashboard/fsrs-stats"),
+  withSentry('/api/dashboard/fsrs-stats'),
   withAdmin,
 )(async (ctx) => {
   const { searchParams } = new URL(ctx.req.url);
-  const days = parseInt(searchParams.get("days") ?? "7", 10);
+  const days = parseInt(searchParams.get('days') ?? '7', 10);
   const startDate = new Date();
   startDate.setDate(startDate.getDate() - days);
 
-  const userId = ctx.userId!;
-
-  // F-06: Get flashcard review data - FILTERED BY USER AND EXCLUDE TEST DATA
+  // Admin dashboard: system-wide stats (not filtered by admin's own userId)
+  // F-06: Exclude test data via isTestData flag
   const [totalCards, reviews, cardsByState] = await Promise.all([
-    // Total flashcards for this user (exclude test data)
+    // Total flashcards across all users (exclude test data)
     prisma.flashcardProgress.count({
-      where: { userId, isTestData: false },
+      where: { isTestData: false },
     }),
 
-    // Reviews in period for this user from telemetry (F-06: exclude test data)
+    // Reviews in period from telemetry (F-06: exclude test data)
     prisma.telemetryEvent.findMany({
       where: {
-        userId,
-        category: "flashcard",
-        action: "review",
+        category: 'flashcard',
+        action: 'review',
         timestamp: { gte: startDate },
         isTestData: false,
       },
@@ -44,10 +41,10 @@ export const GET = pipe(
       },
     }),
 
-    // Cards by state for this user (exclude test data)
+    // Cards by state across all users (exclude test data)
     prisma.flashcardProgress.groupBy({
-      by: ["state"],
-      where: { userId, isTestData: false },
+      by: ['state'],
+      where: { isTestData: false },
       _count: { _all: true },
     }),
   ]);
@@ -65,12 +62,9 @@ export const GET = pipe(
     totalDifficulty += review.value || 0;
   }
 
-  const accuracy =
-    totalReviews > 0 ? Math.round((correctReviews / totalReviews) * 100) : 0;
+  const accuracy = totalReviews > 0 ? Math.round((correctReviews / totalReviews) * 100) : 0;
   const avgDifficulty =
-    totalReviews > 0
-      ? Math.round((totalDifficulty / totalReviews) * 10) / 10
-      : 0;
+    totalReviews > 0 ? Math.round((totalDifficulty / totalReviews) * 10) / 10 : 0;
 
   // State distribution
   const stateDistribution: Record<string, number> = {};
@@ -81,15 +75,14 @@ export const GET = pipe(
   // Daily reviews
   const dailyReviews: Record<string, number> = {};
   for (const review of reviews) {
-    const day = review.timestamp.toISOString().split("T")[0];
+    const day = review.timestamp.toISOString().split('T')[0];
     dailyReviews[day] = (dailyReviews[day] || 0) + 1;
   }
 
-  // F-06: Cards due today for this user (exclude test data)
+  // F-06: Cards due today system-wide (exclude test data)
   const now = new Date();
   const cardsDueToday = await prisma.flashcardProgress.count({
     where: {
-      userId,
       nextReview: { lte: now },
       isTestData: false,
     },

--- a/src/app/api/metrics/__tests__/behavioral-metrics.test.ts
+++ b/src/app/api/metrics/__tests__/behavioral-metrics.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for behavioral metrics - safety stats from SafetyEvent table
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    studySession: { findMany: vi.fn() },
+    safetyEvent: { findMany: vi.fn() },
+    telemetryEvent: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/metrics/cost-tracking-service', () => ({
+  getCostMetricsSummary: vi.fn().mockResolvedValue({
+    avgCostText24h: 0.03,
+    avgCostVoice24h: 0.1,
+    spikesThisWeek: 0,
+  }),
+}));
+
+import { prisma } from '@/lib/db';
+import { generateBehavioralMetrics } from '../behavioral-metrics';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: empty sessions and safety events
+  vi.mocked(prisma.studySession.findMany).mockResolvedValue([]);
+  vi.mocked(prisma.safetyEvent.findMany).mockResolvedValue([]);
+});
+
+describe('generateBehavioralMetrics - safety stats', () => {
+  it('queries SafetyEvent table (not TelemetryEvent)', async () => {
+    await generateBehavioralMetrics();
+
+    expect(prisma.safetyEvent.findMany).toHaveBeenCalled();
+    // TelemetryEvent should NOT be called for safety metrics
+    expect(prisma.telemetryEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it('counts input_blocked and input_warned as refusals', async () => {
+    vi.mocked(prisma.safetyEvent.findMany).mockResolvedValueOnce([
+      { type: 'input_blocked', severity: 'warning', resolution: null },
+      { type: 'input_warned', severity: 'info', resolution: null },
+      { type: 'input_blocked', severity: 'alert', resolution: 'false_positive' },
+      { type: 'jailbreak_attempt', severity: 'critical', resolution: null },
+    ] as any);
+
+    const metrics = await generateBehavioralMetrics();
+
+    const refusalPrecision = metrics.find((m) => m.name === 'mirrorbuddy_refusal_precision');
+    // 3 refusals total, 1 false positive → 2 correct / 3 total ≈ 0.667
+    expect(refusalPrecision).toBeDefined();
+    expect(refusalPrecision!.value).toBeCloseTo(2 / 3, 2);
+  });
+
+  it('maps severity to incident levels (S0-S3)', async () => {
+    vi.mocked(prisma.safetyEvent.findMany).mockResolvedValueOnce([
+      { type: 'pii_detected', severity: 'info', resolution: null },
+      { type: 'profanity_detected', severity: 'warning', resolution: null },
+      { type: 'crisis_detected', severity: 'alert', resolution: null },
+      { type: 'session_terminated', severity: 'critical', resolution: null },
+    ] as any);
+
+    const metrics = await generateBehavioralMetrics();
+
+    const s0 = metrics.find(
+      (m) => m.name === 'mirrorbuddy_incidents_total' && m.labels.severity === 'S0',
+    );
+    const s1 = metrics.find(
+      (m) => m.name === 'mirrorbuddy_incidents_total' && m.labels.severity === 'S1',
+    );
+    const s2 = metrics.find(
+      (m) => m.name === 'mirrorbuddy_incidents_total' && m.labels.severity === 'S2',
+    );
+    const s3 = metrics.find(
+      (m) => m.name === 'mirrorbuddy_incidents_total' && m.labels.severity === 'S3',
+    );
+
+    expect(s0!.value).toBe(1); // info
+    expect(s1!.value).toBe(1); // warning
+    expect(s2!.value).toBe(1); // alert
+    expect(s3!.value).toBe(1); // critical
+  });
+
+  it('counts jailbreak attempts as blocked', async () => {
+    vi.mocked(prisma.safetyEvent.findMany).mockResolvedValueOnce([
+      { type: 'jailbreak_attempt', severity: 'alert', resolution: null },
+      { type: 'jailbreak_attempt', severity: 'critical', resolution: null },
+    ] as any);
+
+    const metrics = await generateBehavioralMetrics();
+
+    const blockRate = metrics.find((m) => m.name === 'mirrorbuddy_jailbreak_block_rate');
+    // All jailbreak attempts are blocked → rate = 1.0
+    expect(blockRate!.value).toBe(1);
+  });
+
+  it('returns 100% precision and block rate when no safety events', async () => {
+    vi.mocked(prisma.safetyEvent.findMany).mockResolvedValueOnce([]);
+
+    const metrics = await generateBehavioralMetrics();
+
+    const refusalPrecision = metrics.find((m) => m.name === 'mirrorbuddy_refusal_precision');
+    const blockRate = metrics.find((m) => m.name === 'mirrorbuddy_jailbreak_block_rate');
+
+    // No events → default to 100% (safe default)
+    expect(refusalPrecision!.value).toBe(1);
+    expect(blockRate!.value).toBe(1);
+  });
+});

--- a/src/app/api/metrics/behavioral-metrics.ts
+++ b/src/app/api/metrics/behavioral-metrics.ts
@@ -11,11 +11,11 @@
  * - Cost per session
  */
 
-import { prisma } from "@/lib/db";
+import { prisma } from '@/lib/db';
 
 interface MetricLine {
   name: string;
-  type: "counter" | "gauge" | "histogram";
+  type: 'counter' | 'gauge' | 'histogram';
   help: string;
   labels: Record<string, string>;
   value: number;
@@ -59,9 +59,7 @@ export async function generateBehavioralMetrics(): Promise<MetricLine[]> {
       ? sessionStats.successfulSessions / sessionStats.totalSessions
       : 0;
   const dropoffRate =
-    sessionStats.totalSessions > 0
-      ? sessionStats.droppedSessions / sessionStats.totalSessions
-      : 0;
+    sessionStats.totalSessions > 0 ? sessionStats.droppedSessions / sessionStats.totalSessions : 0;
   const stuckLoopRate =
     sessionStats.totalSessions > 0
       ? sessionStats.stuckLoopSessions / sessionStats.totalSessions
@@ -69,59 +67,59 @@ export async function generateBehavioralMetrics(): Promise<MetricLine[]> {
 
   metrics.push(
     {
-      name: "mirrorbuddy_session_success_rate",
-      type: "gauge",
-      help: "Session success rate (target: >=0.80)",
-      labels: { period: "24h" },
+      name: 'mirrorbuddy_session_success_rate',
+      type: 'gauge',
+      help: 'Session success rate (target: >=0.80)',
+      labels: { period: '24h' },
       value: successRate,
     },
     {
-      name: "mirrorbuddy_session_dropoff_rate",
-      type: "gauge",
-      help: "Session drop-off rate (target: <=0.10)",
-      labels: { period: "24h" },
+      name: 'mirrorbuddy_session_dropoff_rate',
+      type: 'gauge',
+      help: 'Session drop-off rate (target: <=0.10)',
+      labels: { period: '24h' },
       value: dropoffRate,
     },
     {
-      name: "mirrorbuddy_session_stuck_loop_rate",
-      type: "gauge",
-      help: "Session stuck loop rate (target: <=0.05)",
-      labels: { period: "24h" },
+      name: 'mirrorbuddy_session_stuck_loop_rate',
+      type: 'gauge',
+      help: 'Session stuck loop rate (target: <=0.05)',
+      labels: { period: '24h' },
       value: stuckLoopRate,
     },
     {
-      name: "mirrorbuddy_session_turns_avg",
-      type: "gauge",
-      help: "Average turns per session (target: 5-20)",
-      labels: { period: "24h" },
+      name: 'mirrorbuddy_session_turns_avg',
+      type: 'gauge',
+      help: 'Average turns per session (target: 5-20)',
+      labels: { period: '24h' },
       value: sessionStats.avgTurnsPerSession,
     },
     {
-      name: "mirrorbuddy_session_duration_minutes_avg",
-      type: "gauge",
-      help: "Average session duration in minutes (target: 5-30)",
-      labels: { period: "24h" },
+      name: 'mirrorbuddy_session_duration_minutes_avg',
+      type: 'gauge',
+      help: 'Average session duration in minutes (target: 5-30)',
+      labels: { period: '24h' },
       value: sessionStats.avgDurationMinutes,
     },
     {
-      name: "mirrorbuddy_sessions_total",
-      type: "counter",
-      help: "Total sessions",
-      labels: { period: "24h", status: "all" },
+      name: 'mirrorbuddy_sessions_total',
+      type: 'counter',
+      help: 'Total sessions',
+      labels: { period: '24h', status: 'all' },
       value: sessionStats.totalSessions,
     },
     {
-      name: "mirrorbuddy_sessions_total",
-      type: "counter",
-      help: "Total sessions",
-      labels: { period: "24h", status: "success" },
+      name: 'mirrorbuddy_sessions_total',
+      type: 'counter',
+      help: 'Total sessions',
+      labels: { period: '24h', status: 'success' },
       value: sessionStats.successfulSessions,
     },
     {
-      name: "mirrorbuddy_sessions_total",
-      type: "counter",
-      help: "Total sessions",
-      labels: { period: "24h", status: "dropped" },
+      name: 'mirrorbuddy_sessions_total',
+      type: 'counter',
+      help: 'Total sessions',
+      labels: { period: '24h', status: 'dropped' },
       value: sessionStats.droppedSessions,
     },
   );
@@ -130,9 +128,7 @@ export async function generateBehavioralMetrics(): Promise<MetricLine[]> {
   const safetyStats = await getSafetyStats(weekAgo, now);
 
   const refusalPrecision =
-    safetyStats.totalRefusals > 0
-      ? safetyStats.correctRefusals / safetyStats.totalRefusals
-      : 1; // 100% if no refusals
+    safetyStats.totalRefusals > 0 ? safetyStats.correctRefusals / safetyStats.totalRefusals : 1; // 100% if no refusals
   const jailbreakBlockRate =
     safetyStats.jailbreakAttempts > 0
       ? safetyStats.jailbreakBlocked / safetyStats.jailbreakAttempts
@@ -140,45 +136,45 @@ export async function generateBehavioralMetrics(): Promise<MetricLine[]> {
 
   metrics.push(
     {
-      name: "mirrorbuddy_refusal_precision",
-      type: "gauge",
-      help: "Refusal precision rate (target: >=0.95)",
-      labels: { period: "7d" },
+      name: 'mirrorbuddy_refusal_precision',
+      type: 'gauge',
+      help: 'Refusal precision rate (target: >=0.95)',
+      labels: { period: '7d' },
       value: refusalPrecision,
     },
     {
-      name: "mirrorbuddy_jailbreak_block_rate",
-      type: "gauge",
-      help: "Jailbreak attempts blocked (target: 1.00)",
-      labels: { period: "7d" },
+      name: 'mirrorbuddy_jailbreak_block_rate',
+      type: 'gauge',
+      help: 'Jailbreak attempts blocked (target: 1.00)',
+      labels: { period: '7d' },
       value: jailbreakBlockRate,
     },
     {
-      name: "mirrorbuddy_incidents_total",
-      type: "counter",
-      help: "Total incidents by severity",
-      labels: { period: "7d", severity: "S0" },
+      name: 'mirrorbuddy_incidents_total',
+      type: 'counter',
+      help: 'Total incidents by severity',
+      labels: { period: '7d', severity: 'S0' },
       value: safetyStats.incidentsS0,
     },
     {
-      name: "mirrorbuddy_incidents_total",
-      type: "counter",
-      help: "Total incidents by severity",
-      labels: { period: "7d", severity: "S1" },
+      name: 'mirrorbuddy_incidents_total',
+      type: 'counter',
+      help: 'Total incidents by severity',
+      labels: { period: '7d', severity: 'S1' },
       value: safetyStats.incidentsS1,
     },
     {
-      name: "mirrorbuddy_incidents_total",
-      type: "counter",
-      help: "Total incidents by severity",
-      labels: { period: "7d", severity: "S2" },
+      name: 'mirrorbuddy_incidents_total',
+      type: 'counter',
+      help: 'Total incidents by severity',
+      labels: { period: '7d', severity: 'S2' },
       value: safetyStats.incidentsS2,
     },
     {
-      name: "mirrorbuddy_incidents_total",
-      type: "counter",
-      help: "Total incidents by severity (target: 0)",
-      labels: { period: "7d", severity: "S3" },
+      name: 'mirrorbuddy_incidents_total',
+      type: 'counter',
+      help: 'Total incidents by severity (target: 0)',
+      labels: { period: '7d', severity: 'S3' },
       value: safetyStats.incidentsS3,
     },
   );
@@ -187,24 +183,24 @@ export async function generateBehavioralMetrics(): Promise<MetricLine[]> {
   const costStats = await getCostStats(dayAgo, now);
   metrics.push(
     {
-      name: "mirrorbuddy_cost_per_session_eur",
-      type: "gauge",
-      help: "Average cost per session in EUR (target: <=0.05 text, <=0.15 voice)",
-      labels: { period: "24h", type: "text" },
+      name: 'mirrorbuddy_cost_per_session_eur',
+      type: 'gauge',
+      help: 'Average cost per session in EUR (target: <=0.05 text, <=0.15 voice)',
+      labels: { period: '24h', type: 'text' },
       value: costStats.avgCostText,
     },
     {
-      name: "mirrorbuddy_cost_per_session_eur",
-      type: "gauge",
-      help: "Average cost per session in EUR",
-      labels: { period: "24h", type: "voice" },
+      name: 'mirrorbuddy_cost_per_session_eur',
+      type: 'gauge',
+      help: 'Average cost per session in EUR',
+      labels: { period: '24h', type: 'voice' },
       value: costStats.avgCostVoice,
     },
     {
-      name: "mirrorbuddy_cost_spikes_total",
-      type: "counter",
-      help: "Cost spikes (>P95*1.5) this week (target: <=1)",
-      labels: { period: "7d" },
+      name: 'mirrorbuddy_cost_spikes_total',
+      type: 'counter',
+      help: 'Cost spikes (>P95*1.5) this week (target: <=1)',
+      labels: { period: '7d' },
       value: costStats.spikesThisWeek,
     },
   );
@@ -248,8 +244,7 @@ async function getSessionStats(from: Date, to: Date): Promise<SessionStats> {
 
     // Dropped = ended early with <=2 turns OR abandoned (no endedAt, started >1h ago)
     const isAbandoned =
-      !session.endedAt &&
-      session.startedAt.getTime() < Date.now() - 60 * 60 * 1000;
+      !session.endedAt && session.startedAt.getTime() < Date.now() - 60 * 60 * 1000;
     if (turns <= 2 || isAbandoned) {
       droppedSessions++;
     }
@@ -273,25 +268,22 @@ async function getSessionStats(from: Date, to: Date): Promise<SessionStats> {
     droppedSessions,
     stuckLoopSessions,
     avgTurnsPerSession: totalSessions > 0 ? totalTurns / totalSessions : 0,
-    avgDurationMinutes:
-      sessionsWithDuration > 0
-        ? totalDurationSec / sessionsWithDuration / 60
-        : 0,
+    avgDurationMinutes: sessionsWithDuration > 0 ? totalDurationSec / sessionsWithDuration / 60 : 0,
   };
 }
 
 /**
- * Calculate safety statistics from TelemetryEvent
- * F-06: Excludes test data (isTestData = false)
+ * Calculate safety statistics from SafetyEvent table
+ * SafetyEvent types: input_blocked, input_warned, jailbreak_attempt, etc.
+ * SafetyEvent severity: info, warning, alert, critical
+ * Severity mapping to incident levels: info=S0, warning=S1, alert=S2, critical=S3
  */
 async function getSafetyStats(from: Date, to: Date): Promise<SafetyStats> {
-  const events = await prisma.telemetryEvent.findMany({
+  const events = await prisma.safetyEvent.findMany({
     where: {
       timestamp: { gte: from, lte: to },
-      category: { in: ["safety", "moderation", "security"] },
-      isTestData: false,
     },
-    select: { action: true, label: true },
+    select: { type: true, severity: true, resolution: true },
   });
 
   let totalRefusals = 0;
@@ -304,22 +296,25 @@ async function getSafetyStats(from: Date, to: Date): Promise<SafetyStats> {
   let jailbreakBlocked = 0;
 
   for (const event of events) {
-    if (event.action === "refusal") {
+    // Refusals: input_blocked and input_warned types
+    if (event.type === 'input_blocked' || event.type === 'input_warned') {
       totalRefusals++;
-      // Correct refusal if labeled as such
-      if (event.label !== "false_positive") {
+      if (event.resolution !== 'false_positive') {
         correctRefusals++;
       }
     }
-    if (event.action === "incident") {
-      if (event.label === "S0") incidentsS0++;
-      if (event.label === "S1") incidentsS1++;
-      if (event.label === "S2") incidentsS2++;
-      if (event.label === "S3") incidentsS3++;
-    }
-    if (event.action === "jailbreak_attempt") {
+
+    // Incidents by severity (info=S0, warning=S1, alert=S2, critical=S3)
+    if (event.severity === 'info') incidentsS0++;
+    if (event.severity === 'warning') incidentsS1++;
+    if (event.severity === 'alert') incidentsS2++;
+    if (event.severity === 'critical') incidentsS3++;
+
+    // Jailbreak tracking
+    if (event.type === 'jailbreak_attempt') {
       jailbreakAttempts++;
-      if (event.label === "blocked") jailbreakBlocked++;
+      // All detected jailbreak attempts are blocked by the safety filter
+      jailbreakBlocked++;
     }
   }
 
@@ -348,8 +343,7 @@ async function getCostStats(
   spikesThisWeek: number;
 }> {
   // Import dynamically to avoid circular dependency
-  const { getCostMetricsSummary } =
-    await import("@/lib/metrics/cost-tracking-service");
+  const { getCostMetricsSummary } = await import('@/lib/metrics/cost-tracking-service');
   const summary = await getCostMetricsSummary();
   return {
     avgCostText: summary.avgCostText24h,

--- a/src/lib/admin/__tests__/business-kpi-service.test.ts
+++ b/src/lib/admin/__tests__/business-kpi-service.test.ts
@@ -5,12 +5,12 @@
  * instead of hardcoded estimates or mock data
  */
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { getBusinessKPIs, clearCache } from "../business-kpi-service";
-import { prisma } from "@/lib/db";
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getBusinessKPIs, clearCache } from '../business-kpi-service';
+import { prisma } from '@/lib/db';
 
 // Mock prisma
-vi.mock("@/lib/db", () => ({
+vi.mock('@/lib/db', () => ({
   prisma: {
     userSubscription: {
       findMany: vi.fn(),
@@ -29,7 +29,7 @@ vi.mock("@/lib/db", () => ({
 }));
 
 // Mock logger
-vi.mock("@/lib/logger", () => ({
+vi.mock('@/lib/logger', () => ({
   logger: {
     info: vi.fn(),
     warn: vi.fn(),
@@ -44,7 +44,7 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
-describe("business-kpi-service", () => {
+describe('business-kpi-service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearCache();
@@ -54,15 +54,15 @@ describe("business-kpi-service", () => {
   // REVENUE METRICS TESTS
   // ========================================================================
 
-  describe("getBusinessKPIs - revenue metrics", () => {
-    it("returns null for growthRate when no historical data exists", async () => {
+  describe('getBusinessKPIs - revenue metrics', () => {
+    it('returns null for growthRate when previous month has 0 subs', async () => {
       // Setup: Mock active subscriptions
       vi.mocked(prisma.userSubscription.findMany).mockResolvedValueOnce([
         {
-          id: "sub-1",
-          userId: "user-1",
-          tierId: "tier-pro",
-          status: "ACTIVE",
+          id: 'sub-1',
+          userId: 'user-1',
+          tierId: 'tier-pro',
+          status: 'ACTIVE',
           tier: { monthlyPriceEur: 9.99 },
         } as any,
       ]);
@@ -70,64 +70,57 @@ describe("business-kpi-service", () => {
       vi.mocked(prisma.user.count)
         .mockResolvedValueOnce(10) // totalUsers
         .mockResolvedValueOnce(8); // activeUsers
-      // Mock userSubscription.count calls: trialUsers, paidUsers
+      // Mock userSubscription.count calls (order: trial, paid, cancelled, currentMonth, prevMonth)
       vi.mocked(prisma.userSubscription.count)
         .mockResolvedValueOnce(1) // trial users
-        .mockResolvedValueOnce(1); // paid users
+        .mockResolvedValueOnce(1) // paid users
+        .mockResolvedValueOnce(0) // cancelled recent
+        .mockResolvedValueOnce(1) // currentMonthSubs
+        .mockResolvedValueOnce(0); // prevMonthSubs (0 → growthRate null)
       vi.mocked(prisma.settings.groupBy).mockResolvedValue([]);
       vi.mocked(prisma.conversation.groupBy).mockResolvedValue([]);
 
       const result = await getBusinessKPIs();
 
-      // Verify: growthRate should be null (no historical data to compute it)
+      // growthRate null when prevMonthSubs = 0 (no baseline to compare)
       expect(result.revenue.growthRate).toBeNull();
       expect(result.revenue.mrr).toBe(9.99);
       expect(result.revenue.arr).toBe(9.99 * 12);
     });
 
-    it("returns null for totalRevenue when Stripe is not integrated", async () => {
+    it('returns null for totalRevenue when Stripe is not integrated', async () => {
       vi.mocked(prisma.userSubscription.findMany).mockResolvedValueOnce([
         {
-          id: "sub-1",
-          userId: "user-1",
-          tierId: "tier-pro",
-          status: "ACTIVE",
+          id: 'sub-1',
+          userId: 'user-1',
+          tierId: 'tier-pro',
+          status: 'ACTIVE',
           tier: { monthlyPriceEur: 9.99 },
         } as any,
       ]);
-      // Mock user.count calls: totalUsers, activeUsers
-      vi.mocked(prisma.user.count)
-        .mockResolvedValueOnce(10) // totalUsers
-        .mockResolvedValueOnce(8); // activeUsers
-      // Mock userSubscription.count calls: trialUsers, paidUsers
+      vi.mocked(prisma.user.count).mockResolvedValueOnce(10).mockResolvedValueOnce(8);
       vi.mocked(prisma.userSubscription.count)
-        .mockResolvedValueOnce(1) // trial users
-        .mockResolvedValueOnce(1); // paid users
+        .mockResolvedValueOnce(1) // trial
+        .mockResolvedValueOnce(1) // paid
+        .mockResolvedValueOnce(0) // cancelled
+        .mockResolvedValueOnce(1) // currentMonth
+        .mockResolvedValueOnce(0); // prevMonth
       vi.mocked(prisma.settings.groupBy).mockResolvedValue([]);
       vi.mocked(prisma.conversation.groupBy).mockResolvedValue([]);
 
       const result = await getBusinessKPIs();
 
-      // Verify: totalRevenue should be null (no real revenue tracking without Stripe)
       expect(result.revenue.totalRevenue).toBeNull();
     });
 
-    it("returns empty arrays when DB query fails (no mock data)", async () => {
+    it('returns empty arrays when DB query fails (no mock data)', async () => {
       vi.mocked(prisma.userSubscription.findMany).mockRejectedValueOnce(
-        new Error("Database error"),
+        new Error('Database error'),
       );
-      vi.mocked(prisma.userSubscription.count).mockRejectedValue(
-        new Error("Database error"),
-      );
-      vi.mocked(prisma.user.count).mockRejectedValue(
-        new Error("Database error"),
-      );
-      vi.mocked(prisma.settings.groupBy).mockRejectedValue(
-        new Error("Database error"),
-      );
-      vi.mocked(prisma.conversation.groupBy).mockRejectedValue(
-        new Error("Database error"),
-      );
+      vi.mocked(prisma.userSubscription.count).mockRejectedValue(new Error('Database error'));
+      vi.mocked(prisma.user.count).mockRejectedValue(new Error('Database error'));
+      vi.mocked(prisma.settings.groupBy).mockRejectedValue(new Error('Database error'));
+      vi.mocked(prisma.conversation.groupBy).mockRejectedValue(new Error('Database error'));
 
       const result = await getBusinessKPIs();
 
@@ -147,43 +140,42 @@ describe("business-kpi-service", () => {
   // USER METRICS TESTS
   // ========================================================================
 
-  describe("getBusinessKPIs - user metrics", () => {
-    it("returns null for churnRate when no historical data exists", async () => {
+  describe('getBusinessKPIs - user metrics', () => {
+    it('returns churnRate 0 when no cancellations exist', async () => {
       vi.mocked(prisma.userSubscription.findMany).mockResolvedValueOnce([]);
-      // Mock user.count calls: totalUsers, activeUsers
       vi.mocked(prisma.user.count)
         .mockResolvedValueOnce(100) // totalUsers
         .mockResolvedValueOnce(80); // activeUsers
-      // Mock userSubscription.count calls: trialUsers, paidUsers
       vi.mocked(prisma.userSubscription.count)
-        .mockResolvedValueOnce(10) // trial users
-        .mockResolvedValueOnce(5); // paid users
+        .mockResolvedValueOnce(10) // trial
+        .mockResolvedValueOnce(5) // paid
+        .mockResolvedValueOnce(0) // cancelled
+        .mockResolvedValueOnce(0) // currentMonth
+        .mockResolvedValueOnce(0); // prevMonth
       vi.mocked(prisma.settings.groupBy).mockResolvedValue([]);
       vi.mocked(prisma.conversation.groupBy).mockResolvedValue([]);
 
       const result = await getBusinessKPIs();
 
-      // Verify: churnRate should be null (requires historical data)
-      expect(result.users.churnRate).toBeNull();
+      // churnRate = 0 when no cancellations (not null)
+      expect(result.users.churnRate).toBe(0);
       expect(result.users.totalUsers).toBe(100);
     });
 
-    it("computes trialConversionRate from actual data", async () => {
+    it('computes trialConversionRate from actual data', async () => {
       vi.mocked(prisma.userSubscription.findMany).mockResolvedValueOnce([]);
-      // Mock user.count calls: totalUsers, activeUsers
-      vi.mocked(prisma.user.count)
-        .mockResolvedValueOnce(100) // totalUsers
-        .mockResolvedValueOnce(80); // activeUsers
-      // Mock userSubscription.count calls: trialUsers, paidUsers
+      vi.mocked(prisma.user.count).mockResolvedValueOnce(100).mockResolvedValueOnce(80);
       vi.mocked(prisma.userSubscription.count)
-        .mockResolvedValueOnce(50) // trial users
-        .mockResolvedValueOnce(25); // paid users
+        .mockResolvedValueOnce(50) // trial
+        .mockResolvedValueOnce(25) // paid
+        .mockResolvedValueOnce(0) // cancelled
+        .mockResolvedValueOnce(0) // currentMonth
+        .mockResolvedValueOnce(0); // prevMonth
       vi.mocked(prisma.settings.groupBy).mockResolvedValue([]);
       vi.mocked(prisma.conversation.groupBy).mockResolvedValue([]);
 
       const result = await getBusinessKPIs();
 
-      // Verify: trialConversionRate should be computed from actual data
       expect(result.users.trialConversionRate).toBe(50); // 25/50 * 100 = 50%
     });
   });
@@ -192,20 +184,19 @@ describe("business-kpi-service", () => {
   // COUNTRY METRICS TESTS
   // ========================================================================
 
-  describe("getBusinessKPIs - country metrics", () => {
-    it("returns null for revenue when per-user revenue is unknown", async () => {
+  describe('getBusinessKPIs - country metrics', () => {
+    it('returns null for revenue when per-user revenue is unknown', async () => {
       vi.mocked(prisma.userSubscription.findMany).mockResolvedValueOnce([]);
-      // Mock user.count calls: totalUsers, activeUsers
-      vi.mocked(prisma.user.count)
-        .mockResolvedValueOnce(100) // totalUsers
-        .mockResolvedValueOnce(80); // activeUsers
-      // Mock userSubscription.count calls: trialUsers, paidUsers
+      vi.mocked(prisma.user.count).mockResolvedValueOnce(100).mockResolvedValueOnce(80);
       vi.mocked(prisma.userSubscription.count)
-        .mockResolvedValueOnce(0) // trial users
-        .mockResolvedValueOnce(0); // paid users
+        .mockResolvedValueOnce(0) // trial
+        .mockResolvedValueOnce(0) // paid
+        .mockResolvedValueOnce(0) // cancelled
+        .mockResolvedValueOnce(0) // currentMonth
+        .mockResolvedValueOnce(0); // prevMonth
       vi.mocked(prisma.settings.groupBy).mockResolvedValueOnce([
-        { language: "it", _count: 50 },
-        { language: "en", _count: 30 },
+        { language: 'it', _count: 50 },
+        { language: 'en', _count: 30 },
       ] as any);
       vi.mocked(prisma.conversation.groupBy).mockResolvedValue([]);
 
@@ -223,21 +214,20 @@ describe("business-kpi-service", () => {
   // MAESTRO METRICS TESTS
   // ========================================================================
 
-  describe("getBusinessKPIs - maestro metrics", () => {
-    it("returns null for avgDuration when not tracked", async () => {
+  describe('getBusinessKPIs - maestro metrics', () => {
+    it('returns null for avgDuration when not tracked', async () => {
       vi.mocked(prisma.userSubscription.findMany).mockResolvedValueOnce([]);
-      // Mock user.count calls: totalUsers, activeUsers
-      vi.mocked(prisma.user.count)
-        .mockResolvedValueOnce(100) // totalUsers
-        .mockResolvedValueOnce(80); // activeUsers
-      // Mock userSubscription.count calls: trialUsers, paidUsers
+      vi.mocked(prisma.user.count).mockResolvedValueOnce(100).mockResolvedValueOnce(80);
       vi.mocked(prisma.userSubscription.count)
-        .mockResolvedValueOnce(0) // trial users
-        .mockResolvedValueOnce(0); // paid users
+        .mockResolvedValueOnce(0) // trial
+        .mockResolvedValueOnce(0) // paid
+        .mockResolvedValueOnce(0) // cancelled
+        .mockResolvedValueOnce(0) // currentMonth
+        .mockResolvedValueOnce(0); // prevMonth
       vi.mocked(prisma.settings.groupBy).mockResolvedValue([]);
       vi.mocked(prisma.conversation.groupBy).mockResolvedValueOnce([
-        { maestroId: "leonardo-da-vinci", _count: 100 },
-        { maestroId: "marie-curie", _count: 75 },
+        { maestroId: 'leonardo-da-vinci', _count: 100 },
+        { maestroId: 'marie-curie', _count: 75 },
       ] as any);
 
       const result = await getBusinessKPIs();

--- a/src/lib/admin/business-kpi-service.ts
+++ b/src/lib/admin/business-kpi-service.ts
@@ -2,15 +2,15 @@
  * Business KPI service - provides revenue, user, country, and maestro metrics
  */
 
-import { prisma } from "@/lib/db";
-import { logger } from "@/lib/logger";
+import { prisma } from '@/lib/db';
+import { logger } from '@/lib/logger';
 import type {
   BusinessKPIResponse,
   RevenueMetrics,
   UserMetrics,
   CountryMetric,
   MaestroMetric,
-} from "./business-kpi-types";
+} from './business-kpi-types';
 
 interface CachedKPIs {
   data: BusinessKPIResponse;
@@ -29,7 +29,7 @@ export function clearCache(): void {
 
 export async function getBusinessKPIs(): Promise<BusinessKPIResponse> {
   if (cache && Date.now() - cache.timestamp < CACHE_TTL) {
-    logger.debug("Returning cached business KPIs");
+    logger.debug('Returning cached business KPIs');
     return cache.data;
   }
 
@@ -41,8 +41,7 @@ export async function getBusinessKPIs(): Promise<BusinessKPIResponse> {
       getTopMaestri(),
     ]);
 
-    const isEstimated =
-      revenue.isEstimated || users.isEstimated || countries.length === 0;
+    const isEstimated = revenue.isEstimated || users.isEstimated || countries.length === 0;
 
     const data: BusinessKPIResponse = {
       revenue,
@@ -53,17 +52,17 @@ export async function getBusinessKPIs(): Promise<BusinessKPIResponse> {
     };
 
     cache = { data, timestamp: Date.now() };
-    logger.info("Business KPIs computed successfully", { isEstimated });
+    logger.info('Business KPIs computed successfully', { isEstimated });
     return data;
   } catch (error) {
-    logger.error("Failed to compute business KPIs", undefined, error);
+    logger.error('Failed to compute business KPIs', undefined, error);
     return {
       revenue: {
         mrr: 0,
         arr: 0,
         growthRate: null,
         totalRevenue: null,
-        currency: "EUR",
+        currency: 'EUR',
         isEstimated: true,
       },
       users: {
@@ -85,32 +84,50 @@ export async function getBusinessKPIs(): Promise<BusinessKPIResponse> {
 async function getRevenueMetrics(): Promise<RevenueMetrics> {
   try {
     const subscriptions = await prisma.userSubscription.findMany({
-      where: { status: "ACTIVE" },
+      where: { status: 'ACTIVE' },
       include: { tier: { select: { monthlyPriceEur: true } } },
     });
 
-    const mrr = subscriptions.reduce(
-      (sum, sub) => sum + Number(sub.tier?.monthlyPriceEur || 0),
-      0,
-    );
+    const mrr = subscriptions.reduce((sum, sub) => sum + Number(sub.tier?.monthlyPriceEur || 0), 0);
     const arr = mrr * 12;
+
+    // Growth rate: compare current month active subs vs previous month
+    const now = new Date();
+    const prevMonthEnd = new Date(now.getFullYear(), now.getMonth(), 0);
+
+    const [currentMonthSubs, prevMonthSubs] = await Promise.all([
+      prisma.userSubscription.count({
+        where: { status: 'ACTIVE', startedAt: { lte: now } },
+      }),
+      prisma.userSubscription.count({
+        where: {
+          status: { in: ['ACTIVE', 'CANCELLED'] },
+          startedAt: { lte: prevMonthEnd },
+        },
+      }),
+    ]);
+
+    const growthRate =
+      prevMonthSubs > 0
+        ? Math.round(((currentMonthSubs - prevMonthSubs) / prevMonthSubs) * 100 * 10) / 10
+        : null;
 
     return {
       mrr,
       arr,
-      growthRate: null, // Requires historical data to compute
-      totalRevenue: null, // Requires Stripe integration for real revenue tracking
-      currency: "EUR",
-      isEstimated: true,
+      growthRate,
+      totalRevenue: null, // Requires Stripe integration for payment history
+      currency: 'EUR',
+      isEstimated: false,
     };
   } catch (error) {
-    logger.warn("Failed to fetch revenue metrics", { error });
+    logger.warn('Failed to fetch revenue metrics', { error });
     return {
       mrr: 0,
       arr: 0,
       growthRate: null,
       totalRevenue: null,
-      currency: "EUR",
+      currency: 'EUR',
       isEstimated: true,
     };
   }
@@ -121,33 +138,43 @@ async function getUserMetrics(): Promise<UserMetrics> {
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
-    const [totalUsers, activeUsers, trialUsers, paidUsers] = await Promise.all([
+    const [totalUsers, activeUsers, trialUsers, paidUsers, cancelledRecent] = await Promise.all([
       prisma.user.count(),
       prisma.user.count({
         where: { updatedAt: { gte: thirtyDaysAgo } },
       }),
       prisma.userSubscription.count({
-        where: { status: "TRIAL" },
+        where: { status: 'TRIAL' },
       }),
       prisma.userSubscription.count({
-        where: { status: "ACTIVE" },
+        where: { status: 'ACTIVE' },
+      }),
+      prisma.userSubscription.count({
+        where: {
+          status: 'CANCELLED',
+          updatedAt: { gte: thirtyDaysAgo },
+        },
       }),
     ]);
 
-    const trialConversionRate =
-      trialUsers > 0 ? (paidUsers / trialUsers) * 100 : 0;
+    const trialConversionRate = trialUsers > 0 ? (paidUsers / trialUsers) * 100 : 0;
+
+    // Churn rate: cancelled in 30 days / (active + cancelled at period start)
+    const periodStartTotal = paidUsers + cancelledRecent;
+    const churnRate =
+      periodStartTotal > 0 ? Math.round((cancelledRecent / periodStartTotal) * 100 * 10) / 10 : 0;
 
     return {
       totalUsers,
       activeUsers,
       trialUsers,
       paidUsers,
-      churnRate: null, // Requires historical data to compute
+      churnRate,
       trialConversionRate,
-      isEstimated: true,
+      isEstimated: false,
     };
   } catch (error) {
-    logger.warn("Failed to fetch user metrics", { error });
+    logger.warn('Failed to fetch user metrics', { error });
     return {
       totalUsers: 0,
       activeUsers: 0,
@@ -163,25 +190,24 @@ async function getUserMetrics(): Promise<UserMetrics> {
 async function getTopCountries(): Promise<CountryMetric[]> {
   try {
     const settings = await prisma.settings.groupBy({
-      by: ["language"],
+      by: ['language'],
       _count: true,
-      orderBy: { _count: { language: "desc" } },
+      orderBy: { _count: { language: 'desc' } },
       take: 10,
     });
 
-    const countryMap: Record<string, { country: string; countryCode: string }> =
-      {
-        it: { country: "Italy", countryCode: "IT" },
-        de: { country: "Germany", countryCode: "DE" },
-        fr: { country: "France", countryCode: "FR" },
-        es: { country: "Spain", countryCode: "ES" },
-        en: { country: "United Kingdom", countryCode: "GB" },
-      };
+    const countryMap: Record<string, { country: string; countryCode: string }> = {
+      it: { country: 'Italy', countryCode: 'IT' },
+      de: { country: 'Germany', countryCode: 'DE' },
+      fr: { country: 'France', countryCode: 'FR' },
+      es: { country: 'Spain', countryCode: 'ES' },
+      en: { country: 'United Kingdom', countryCode: 'GB' },
+    };
 
     return settings.map((s) => {
-      const info = countryMap[s.language || "it"] || {
-        country: "Other",
-        countryCode: "XX",
+      const info = countryMap[s.language || 'it'] || {
+        country: 'Other',
+        countryCode: 'XX',
       };
       return {
         country: info.country,
@@ -191,7 +217,7 @@ async function getTopCountries(): Promise<CountryMetric[]> {
       };
     });
   } catch (error) {
-    logger.warn("Failed to fetch country metrics", { error });
+    logger.warn('Failed to fetch country metrics', { error });
     return [];
   }
 }
@@ -199,20 +225,20 @@ async function getTopCountries(): Promise<CountryMetric[]> {
 async function getTopMaestri(): Promise<MaestroMetric[]> {
   try {
     const sessions = await prisma.conversation.groupBy({
-      by: ["maestroId"],
+      by: ['maestroId'],
       _count: true,
-      orderBy: { _count: { maestroId: "desc" } },
+      orderBy: { _count: { maestroId: 'desc' } },
       take: 10,
     });
 
     return sessions.map((s) => ({
-      name: s.maestroId || "Unknown",
-      subject: "Various",
+      name: s.maestroId || 'Unknown',
+      subject: 'Various',
       sessions: s._count,
       avgDuration: null, // Session duration not currently tracked
     }));
   } catch (error) {
-    logger.warn("Failed to fetch maestri metrics", { error });
+    logger.warn('Failed to fetch maestri metrics', { error });
     return [];
   }
 }

--- a/src/lib/api/middlewares/with-sentry.ts
+++ b/src/lib/api/middlewares/with-sentry.ts
@@ -1,5 +1,6 @@
 import { logger } from '@/lib/logger';
 import { ApiError } from '@/lib/api/pipe';
+import { setSentryTierContext } from '@/lib/observability/sentry-tier-context';
 import type { Middleware } from './types';
 
 /**
@@ -25,6 +26,15 @@ export function withSentry(routeName: string): Middleware {
       // Re-throw so pipe() keeps contract and response mapping.
       if (error instanceof ApiError) {
         throw error;
+      }
+
+      // Enrich Sentry context with tier info (only on errors, no overhead on success)
+      if (ctx.userId) {
+        try {
+          await setSentryTierContext(ctx.userId);
+        } catch {
+          // Ignore - don't block error handling
+        }
       }
 
       // Unknown error: emit once through structured logger/Sentry bridge


### PR DESCRIPTION
## Summary
- **CRITICAL**: Safety metrics (`getSafetyStats`) now query `SafetyEvent` table instead of `TelemetryEvent` — was returning 0 for all safety/incident/jailbreak metrics in Grafana
- **CRITICAL**: Revenue by country in admin dashboard uses real subscription + user locale data instead of hardcoded percentage split (40%/20%/15%/15%/10%)
- **HIGH**: Business KPI `growthRate` computed from month-over-month subscription delta (was always `null`)
- **HIGH**: Business KPI `churnRate` computed from cancelled/active subscription ratio (was always `null`)
- **HIGH**: FSRS stats admin dashboard shows system-wide flashcard data (was filtered to admin user only)
- **HIGH**: `setSentryTierContext()` now called in `withSentry` error handler to enrich Sentry context with tier info

## Test plan
- [x] New test suite for `behavioral-metrics.ts` validates SafetyEvent table queries (5 tests)
- [x] Updated `business-kpi-service.test.ts` for new growthRate/churnRate logic (7 tests)
- [x] Middleware tests pass (21 tests)
- [x] Full test suite: 713 files, 11402 tests passing
- [x] Build passes
- [x] Lint clean (0 warnings)
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)