### PR TITLE
fix(ci): use production env vars for staging build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1790,10 +1790,10 @@ jobs:
         run: npm install -g vercel@latest
 
       - name: Pull Vercel Environment
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Staging (Preview)
         id: deploy


### PR DESCRIPTION
## Fix

Staging deploy failed because `vercel build` (without `--prod`) pulls **preview** environment variables which don't have `DATABASE_URL` configured.

**Fix**: Use `vercel pull --environment=production` + `vercel build --prod` for the build step (same env vars as production), but deploy without `--prod` (creates staging/preview URL).

**Build** = production env vars → **Deploy** = preview destination.

## Test plan
- CI should pass with staging deploy succeeding this time