### PR TITLE
fix: E2E race condition on parallel user creation

### DIFF
--- a/src/lib/auth/__tests__/session-auth.test.ts
+++ b/src/lib/auth/__tests__/session-auth.test.ts
@@ -156,15 +156,16 @@ describe('Session Auth', () => {
         value: userId,
       });
       vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
-      vi.mocked(prisma.user.create).mockResolvedValue({ id: userId } as never);
+      vi.mocked(prisma.user.upsert).mockResolvedValue({ id: userId } as never);
 
       const result = await validateAuth();
 
       expect(result.authenticated).toBe(true);
       expect(result.userId).toBe(userId);
-      expect(prisma.user.create).toHaveBeenCalledWith(
+      expect(prisma.user.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({
+          where: { id: userId },
+          create: expect.objectContaining({
             id: userId,
             role: 'USER',
           }),
@@ -193,14 +194,14 @@ describe('Session Auth', () => {
         value: userId,
       });
       vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
-      vi.mocked(prisma.user.create).mockResolvedValue({ id: userId } as never);
+      vi.mocked(prisma.user.upsert).mockResolvedValue({ id: userId } as never);
 
       const result = await validateAuth();
 
       expect(result.authenticated).toBe(true);
-      expect(prisma.user.create).toHaveBeenCalledWith(
+      expect(prisma.user.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({
+          create: expect.objectContaining({
             role: 'ADMIN',
           }),
         }),
@@ -220,7 +221,7 @@ describe('Session Auth', () => {
       vi.mocked(prisma.user.findUnique)
         .mockResolvedValueOnce(null) // First check
         .mockResolvedValueOnce({ id: userId } as never); // After race condition
-      vi.mocked(prisma.user.create).mockRejectedValue({ code: 'P2002' });
+      vi.mocked(prisma.user.upsert).mockRejectedValue({ code: 'P2002' });
 
       const result = await validateAuth();
 

--- a/src/lib/auth/session-auth.ts
+++ b/src/lib/auth/session-auth.ts
@@ -96,8 +96,10 @@ export async function validateAuth(): Promise<AuthResult> {
         // Use try-catch to handle race conditions where concurrent requests
         // may try to create the same user simultaneously
         try {
-          const created = await prisma.user.create({
-            data: {
+          const created = await prisma.user.upsert({
+            where: { id: userId },
+            update: {},
+            create: {
               id: userId,
               role: isAdminSession ? 'ADMIN' : 'USER',
               profile: { create: {} },


### PR DESCRIPTION
## Summary
- Replace `prisma.user.create` with `prisma.user.upsert` in `session-auth.ts` E2E auto-user creation
- Prevents `duplicate key value violates unique constraint User_pkey` when parallel Playwright workers hit `validateAuth()` simultaneously

## Root cause
E2E admin fixtures create session cookies with unique IDs, but when multiple API requests fire concurrently, `validateAuth()` tries to auto-create the same user twice via `create()`. The existing P2002 catch didn't reliably handle the nested relation creation failure.

## Test plan
- `npx vitest run src/lib/auth/__tests__/session-auth.test.ts` — 25/25 pass
- Updated 3 test mocks from `create` to `upsert` assertions