### PR TITLE
chore(env): add VERCEL_TEAM_ID placeholder to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,7 @@ GRAFANA_SERVICE_ACCOUNT_TOKEN=your-grafana-service-account-token
 #
 # Full token rotation guide: docs/operations/VERCEL-TOKEN-MANAGEMENT.md
 VERCEL_TOKEN=your-vercel-personal-access-token
+VERCEL_TEAM_ID=team_xxxxxxxxxxxxxxxxxxxxxxxxx
 
 # ============================================================================
 # DATABASE (PostgreSQL with pgvector required)


### PR DESCRIPTION
## Summary
- Add `VERCEL_TEAM_ID=team_xxxxxxxxxxxxxxxxxxxxxxxxx` placeholder to `.env.example`
- Matches the variable already in `.env`, `pre-push-vercel.sh` SKIP_PATTERNS, and `fix-vercel-env-vars.sh` SKIP_VARS

🤖 Generated with [Claude Code](https://claude.com/claude-code)