### PR TITLE
chore: reduce benchmark schedule from nightly to quarterly

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -1,8 +1,8 @@
-name: nightly-benchmark
+name: quarterly-benchmark
 
 on:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "0 2 1 */3 *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Cron: `0 2 * * *` (nightly) → `0 2 1 */3 *` (quarterly)
- `workflow_dispatch` retained for manual runs
- No real users yet — nightly bruciava centinaia di chiamate OpenAI/notte

🤖 Generated with [Claude Code](https://claude.com/claude-code)