### PR TITLE
fix: resolve 2 Sentry production issues (RSC fetch + study kit 401)

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -126,6 +126,18 @@ if (dsn) {
       const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
       const isIOSSafari = /iPad|iPhone|iPod/i.test(ua) && /Safari/i.test(ua) && !/Chrome/i.test(ua);
 
+      // Filter transient Next.js RSC navigation failures (handled by browser fallback)
+      if (errorMessage.includes('Failed to fetch RSC payload')) return null;
+      if (event.logger === 'console') {
+        const args = (event as SentryEvent).extra?.arguments;
+        if (
+          Array.isArray(args) &&
+          args.some((a) => typeof a === 'string' && a.includes('Failed to fetch RSC payload'))
+        ) {
+          return null;
+        }
+      }
+
       // Filter known iOS Safari transient errors (not app bugs)
       if (isIOSSafari) {
         if (errorMessage.includes('Load failed') && errorMessage.includes('TypeError')) return null;

--- a/src/components/study-kit/StudyKitList.tsx
+++ b/src/components/study-kit/StudyKitList.tsx
@@ -39,6 +39,10 @@ export function StudyKitList({ onSelect, className }: StudyKitListProps) {
       }
 
       const response = await fetch(url);
+      if (response.status === 401) {
+        setStudyKits([]);
+        return;
+      }
       if (!response.ok) {
         throw new Error('Failed to load study kits');
       }
@@ -47,7 +51,7 @@ export function StudyKitList({ onSelect, className }: StudyKitListProps) {
       setStudyKits(data.studyKits);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load');
-      logger.warn('Failed to load study kits', { error: String(err) });
+      logger.debug('Failed to load study kits', { error: String(err) });
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary

- Filter transient Next.js RSC navigation failures in Sentry `beforeSend` (MIRRORBUDDY-1N)
- Handle 401 gracefully in StudyKitList: empty state instead of error (MIRRORBUDDY-1M)
- Downgrade study kit load failure log from warn→debug

## Test plan

- `npx tsc --noEmit` ✅
- `npm run test:unit` ✅ (12,025 tests, 799 files)
- Both Sentry issues resolved as 'resolved in next release'