### PR TITLE
fix: eliminate duplicate /api/realtime/token fetch in WebRTC connection

### DIFF
--- a/src/lib/hooks/voice-session/types.ts
+++ b/src/lib/hooks/voice-session/types.ts
@@ -23,6 +23,14 @@ export interface ConnectionInfo {
   characterType?: 'maestro' | 'coach' | 'buddy';
   /** Previous messages to inject into voice session for context continuity */
   initialMessages?: Array<{ role: 'user' | 'assistant'; content: string }>;
+  /** Azure resource name for GA protocol (from /api/realtime/token) */
+  azureResource?: string;
+  /** WebRTC endpoint URL for preview protocol (from /api/realtime/token) */
+  webrtcEndpoint?: string;
+  /** Azure deployment name (from /api/realtime/token) */
+  deployment?: string;
+  /** Transport mode: webrtc or websocket */
+  transport?: 'webrtc' | 'websocket';
 }
 
 export interface ConversationMemory {

--- a/src/lib/hooks/voice-session/webrtc-connection.ts
+++ b/src/lib/hooks/voice-session/webrtc-connection.ts
@@ -143,9 +143,25 @@ export class WebRTCConnection {
 
   /**
    * Fetch server token config to determine protocol mode (GA vs preview).
-   * The server decides the protocol; the client follows.
+   * Reuses connectionInfo fields if already populated by the caller
+   * (e.g. from the overlay fetch), avoiding a duplicate /api/realtime/token request.
    */
   private async fetchServerConfig(): Promise<void> {
+    const ci = this.config.connectionInfo;
+    if (ci.azureResource || ci.webrtcEndpoint) {
+      this.serverConfig = {
+        azureResource: ci.azureResource,
+        webrtcEndpoint: ci.webrtcEndpoint,
+        deployment: ci.deployment,
+      };
+      logger.debug('[WebRTC] Server config from connectionInfo (no extra fetch)', {
+        protocol: this.isGAProtocol ? 'GA' : 'preview',
+        hasAzureResource: !!this.serverConfig.azureResource,
+        hasWebrtcEndpoint: !!this.serverConfig.webrtcEndpoint,
+      });
+      return;
+    }
+
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 10000);
     try {


### PR DESCRIPTION
## Summary

- **WebRTCConnection.fetchServerConfig()** was making a duplicate GET to `/api/realtime/token` even though the overlay/hook already fetched the same data and passed it via `connectionInfo`
- This doubled requests per voice call, hitting the 30/min rate limit faster and triggering a cascade of Sentry errors (MIRRORBUDDY-1K, 19, 10, 15)
- Now `fetchServerConfig()` reuses `azureResource`/`webrtcEndpoint`/`deployment` from `connectionInfo` if present, falling back to the fetch only when needed

## Test plan

- 52/52 voice session unit tests pass
- Typecheck clean
- ESLint + Prettier clean
- Safe fallback: if `connectionInfo` lacks the fields (edge case), original fetch behavior is preserved