### PR TITLE
fix(sentry): reduce duplicate voice noise events

### DIFF
--- a/e2e/production-smoke/17-full-app-verification.spec.ts
+++ b/e2e/production-smoke/17-full-app-verification.spec.ts
@@ -13,7 +13,7 @@
  * to avoid side effects and AI costs.
  */
 
-import { test, expect, PROD_URL, openMobileMenu } from './fixtures';
+import { test, expect, PROD_URL } from './fixtures';
 import { request as pwRequest } from '@playwright/test';
 
 /** Navigate to Astuccio — mobile uses direct URL (bottom-nav is Link, not button) */
@@ -22,7 +22,10 @@ async function goToAstuccio(page: import('@playwright/test').Page, isMobile: boo
     await page.goto('/it/astuccio');
   } else {
     await page.goto('/it');
-    await page.getByRole('button', { name: /Astuccio/i }).first().click();
+    await page
+      .getByRole('button', { name: /Astuccio/i })
+      .first()
+      .click();
   }
   await expect(page.getByRole('heading', { name: 'Carica', level: 2 })).toBeVisible({
     timeout: 15000,

--- a/src/lib/hooks/voice-session/voice-diagnostics.ts
+++ b/src/lib/hooks/voice-session/voice-diagnostics.ts
@@ -49,7 +49,7 @@ export function getAudioContextInfo(): Record<string, string | number | boolean 
     testContext.close();
     return info;
   } catch (error) {
-    logger.error('[VoiceErrorLogger] Failed to get audio context info', {}, error);
+    logger.debug('[VoiceErrorLogger] Failed to get audio context info', { error: String(error) });
     return {
       audioContextAvailable: false,
       error: String(error),
@@ -87,7 +87,7 @@ export async function getAudioDevices(): Promise<Record<string, unknown>> {
       })),
     };
   } catch (error) {
-    logger.error('[VoiceErrorLogger] Failed to enumerate audio devices', {}, error);
+    logger.debug('[VoiceErrorLogger] Failed to enumerate audio devices', { error: String(error) });
     return {
       available: false,
       error: String(error),
@@ -119,7 +119,9 @@ export async function checkMicrophonePermissions(): Promise<
       canTry: permissionStatus.state !== 'denied',
     };
   } catch (error) {
-    logger.error('[VoiceErrorLogger] Failed to check microphone permissions', {}, error);
+    logger.debug('[VoiceErrorLogger] Failed to check microphone permissions', {
+      error: String(error),
+    });
     return {
       permissionsAPI: false,
       status: 'Error checking permissions',
@@ -162,7 +164,9 @@ export async function logVoiceDiagnosticsReport(): Promise<void> {
       });
     }
   } catch (error) {
-    logger.error('[VoiceErrorLogger] Failed to generate diagnostics report', {}, error);
+    logger.debug('[VoiceErrorLogger] Failed to generate diagnostics report', {
+      error: String(error),
+    });
   }
 }
 
@@ -194,6 +198,8 @@ export function logMediaStreamTracks(stream: MediaStream, label: string = 'Media
 
     logger.debug('[VoiceSession] MediaStream tracks', context);
   } catch (error) {
-    logger.error('[VoiceErrorLogger] Failed to log media stream tracks', {}, error);
+    logger.debug('[VoiceErrorLogger] Failed to log media stream tracks', {
+      error: String(error),
+    });
   }
 }

--- a/src/lib/hooks/voice-session/voice-error-logger.ts
+++ b/src/lib/hooks/voice-session/voice-error-logger.ts
@@ -52,7 +52,7 @@ export function getDeviceInfo(): Record<string, string | number | boolean> {
       onLine: navigator.onLine,
     };
   } catch (error) {
-    logger.error('[VoiceErrorLogger] Failed to get device info', {}, error);
+    logger.debug('[VoiceErrorLogger] Failed to get device info', { error: String(error) });
     return { error: 'Failed to get device info' };
   }
 }
@@ -86,7 +86,9 @@ export function getWebRTCCapabilities(): Record<string, boolean> {
       WebRTC: !!window.RTCPeerConnection && isMediaDevicesAvailable(),
     };
   } catch (error) {
-    logger.error('[VoiceErrorLogger] Failed to check WebRTC capabilities', {}, error);
+    logger.debug('[VoiceErrorLogger] Failed to check WebRTC capabilities', {
+      error: String(error),
+    });
     return { error: true };
   }
 }

--- a/src/lib/hooks/voice-session/webrtc-connection.ts
+++ b/src/lib/hooks/voice-session/webrtc-connection.ts
@@ -132,7 +132,9 @@ export class WebRTCConnection {
       const message = error instanceof Error ? error.message : 'Unknown WebRTC error';
       const connectionTime = Date.now() - startTime;
       logVoiceError('WebRTCConnectionFailed', message, { connectionTime });
-      logger.error('[WebRTC] Connection failed', { errorDetails: message });
+      logger.debug('[WebRTC] Connection failed (already reported via logVoiceError)', {
+        errorDetails: message,
+      });
       // Propagate a marked error to prevent duplicate Sentry events in upstream handlers
       const wrappedError = new Error(message);
       (wrappedError as Error & { _voiceRootCause: boolean })._voiceRootCause = true;
@@ -339,7 +341,7 @@ export class WebRTCConnection {
     };
     channel.onerror = (event) => {
       logVoiceError('DataChannelError', event.error?.message || 'Unknown error');
-      logger.error('[WebRTC] Data channel error', {
+      logger.debug('[WebRTC] Data channel error (already reported via logVoiceError)', {
         errorDetails: event.error,
       });
     };
@@ -348,7 +350,7 @@ export class WebRTCConnection {
         this.config.onDataChannelMessage?.(JSON.parse(event.data));
       } catch (error) {
         logVoiceError('DataChannelParseError', `Failed to parse: ${String(error)}`);
-        logger.error('[WebRTC] Failed to parse message');
+        logger.debug('[WebRTC] Failed to parse message (already reported via logVoiceError)');
       }
     };
   }
@@ -358,7 +360,7 @@ export class WebRTCConnection {
     try {
       this.dataChannel.send(JSON.stringify(event));
     } catch (_error) {
-      logger.error('[WebRTC] Failed to send message');
+      logger.debug('[WebRTC] Failed to send message');
     }
   }
 


### PR DESCRIPTION
## Summary
- reduce duplicate Sentry noise in voice WebRTC paths by avoiding double error emissions
- downgrade non-critical voice diagnostics probe failures to debug
- remove unused openMobileMenu import in production smoke test (CI lint clean)

## Test plan
- ./scripts/ci-summary.sh --full
- ./scripts/ci-summary.sh --i18n
- pre-push vercel checks pass