### PR TITLE
docs: enforce NightMaintenance routing

### DIFF
--- a/.github/agents/night-maintenance.agent.md
+++ b/.github/agents/night-maintenance.agent.md
@@ -3,7 +3,7 @@ name: 'night-maintenance'
 description: 'Recurring overnight maintenance: CI watch, release promotion, post-production smoke validation, Sentry triage, issue/changelog/version hygiene.'
 tools: ['search/codebase', 'read', 'terminalLastCommand']
 model: ['GPT-5.3-Codex']
-version: '1.0.0'
+version: '1.1.0'
 ---
 
 Run the NightMaintenance operational loop for MirrorBuddy.
@@ -16,6 +16,7 @@ Run the NightMaintenance operational loop for MirrorBuddy.
 4. Run post-production smoke suite and production status check; investigate any flaky/failing case before closure.
 5. Review unresolved Sentry issues, resolve only non-regressing legacy noise, and record results.
 6. Sync issue state, CHANGELOG, and version bump policy before final report.
+7. While waiting on CI/deploy, emit heartbeat updates at least every 5 minutes with current blocker and ETA-to-next-check.
 
 ## Required Checks
 
@@ -25,6 +26,7 @@ Run the NightMaintenance operational loop for MirrorBuddy.
 `npm run test:smoke:prod`  
 `npm run production:status`  
 `sentry-cli issues list --query "is:unresolved"`  
+`gh issue list --repo FightTheStroke/MirrorBuddy --state open --limit 50`  
 `npm audit --audit-level=high`
 
 ## Flake Triage Rules
@@ -33,6 +35,17 @@ Run the NightMaintenance operational loop for MirrorBuddy.
 2. If mobile smoke clicks are intercepted, pre-dismiss transient overlays (e.g., iOS install banner via localStorage key `ios-install-banner-dismissed`) in fixtures before first navigation.
 3. For compliance/content checks that are timing-sensitive, prefer `waitUntil: 'domcontentloaded'` plus `expect.poll(...)` over single immediate assertions.
 4. Before closing maintenance, rerun failing tests targeted first, then rerun full `npm run test:smoke:prod`; mark closure only on a full green run or documented non-blocking flaky quarantine.
+
+## Nightly Guardrails
+
+1. Use bounded polling only: check CI/deploy state every 30–60s; never leave unbounded watchers running without heartbeat output.
+2. If `gh workflow run .github/workflows/promote-to-production.yml` returns 403/permission errors, fallback to `vercel promote <staging-url>` and re-verify health/version immediately after.
+3. Closure is valid only with all evidence present: main CI green, production health/version aligned, post-prod smoke+status green, Sentry unresolved reviewed, and issue state synced.
+
+## Global Guardian Handoff
+
+1. Any global Nightly Guardian (for example from `~/.claude`) MUST load and follow this file when operating inside MirrorBuddy.
+2. The project-specific contract in this file has precedence over generic cross-repo defaults for release/Sentry/issue hygiene.
 
 ## Output
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,14 @@ AI-powered educational platform for students with learning differences.
 - 80% test coverage business logic, 100% critical paths
 - Parameterized queries only (Prisma)
 
+## NightMaintenance Routing (MANDATORY)
+
+- Trigger this flow whenever work includes **Sentry unresolved triage**, **GitHub incident/bug issue hygiene**, or **post-production verification**.
+- Canonical runbook: `.github/agents/night-maintenance.agent.md` (must be used as source of truth for check order and closure criteria).
+- While CI/deploy is running, publish heartbeat updates at least every 5 minutes.
+- Do not close operations without evidence for: `main` CI green, production health/version aligned, `npm run test:smoke:prod`, `npm run production:status`, and `sentry-cli issues list --query "is:unresolved"`.
+- If invoked from a global `~/.claude` Nightly Guardian, load the repository runbook above and let repo-specific rules override generic defaults.
+
 ## Detailed Instructions
 
 See `.github/copilot-instructions.md` for full project rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **KPI grid extension** — MRR, Daily AI Cost, Trial→Pro conversion cards with DashboardSummary integration
 - **NightMaintenance process documentation** — codified recurring overnight operations workflow (CI/main monitoring, deploy promotion, post-production smoke validation, Sentry/issue hygiene) in ADR 0163
 - **NightMaintenance agent profile** — added reusable `.github/agents/night-maintenance.agent.md` for recurring maintenance runs
+- **NightMaintenance governance routing** — AGENTS.md and CLAUDE.md now require `.github/agents/night-maintenance.agent.md` for Sentry+issue maintenance tasks; global `~/.claude` Nightly Guardian is configured to load this repo-specific runbook.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,17 @@ Before modifying: `npm run test:unit -- csp-validation`. "Caricamento..." foreve
 
 `./scripts/health-check.sh` (full triage, ~6 lines) or `npm run ci:summary` (build only). Details: `.claude/rules/ci-verification.md`.
 
+## NightMaintenance Routing (MANDATORY)
+
+- For Sentry+issue maintenance requests, use `.github/agents/night-maintenance.agent.md` as the primary execution contract.
+- Mandatory closure checks for this flow:
+  - `npm run test:smoke:prod`
+  - `npm run production:status`
+  - `curl -sS https://mirrorbuddy.org/api/health`
+  - `sentry-cli issues list --query "is:unresolved"`
+- During long CI/deploy waits, provide heartbeat updates at least every 5 minutes.
+- If a global `~/.claude` Nightly Guardian is used, it must load the MirrorBuddy runbook above and let repository-specific rules override generic multi-repo defaults.
+
 ## Thor Validation
 
 Per-task Thor (Gate 1-4, 8, 9) after each task; per-wave Thor (all 9 gates + build) after wave.


### PR DESCRIPTION
## Summary
- require NightMaintenance runbook usage in AGENTS.md and CLAUDE.md for Sentry+issue maintenance
- expand `.github/agents/night-maintenance.agent.md` with heartbeat, anti-loop guardrails, and global guardian handoff
- update CHANGELOG with governance routing note

## Test plan
- npm run test:unit -- --reporter=dot
- npm run i18n:check
