### PR TITLE
fix(deps): bump undici 6.23.0 → 6.24.1 (5 CVE security fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mirrorbuddy",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mirrorbuddy",
-      "version": "0.16.8",
+      "version": "0.16.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -26646,9 +26646,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
## Summary
Security update for undici — fixes 5 CVEs (3 HIGH, 2 Medium):
- CVE-2026-1525: HTTP Request/Response Smuggling
- CVE-2026-1527: CRLF injection via upgrade option
- CVE-2026-1528: WebSocket 64-bit length overflow (crash)
- CVE-2026-2229: WebSocket permessage-deflate unhandled exception
- CVE-2026-1526: Unbounded memory consumption in WebSocket

Replaces Dependabot PR #290 (which couldn't pass CI due to secrets unavailability for bot PRs).

Ref: #291

## Change
Only `package-lock.json` — undici 6.23.0 → 6.24.1