### PR TITLE
fix(deps): npm audit fix — flatted 3.4.2 (DoS recursion CVE)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -716,9 +716,9 @@
       }
     },
     "node_modules/@capacitor/cli": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.1.0.tgz",
-      "integrity": "sha512-JAzA/ckPgTCjZz6YumBLV2dNCFEVXAuR1oOKLD7AJ4LAI5pF5RtRZrf5FoaxvJVb0S4CouZT5cD+7NwsNJX/nw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.2.0.tgz",
+      "integrity": "sha512-1cMEk0d/I6tl1U+v/lnJR5Oylpx8ZBIHrvQxD5zK0MkjYOUyQAAGJgh97rkhGJqjAUvrGpa8H4BmyhNQN9a17A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6122,9 +6122,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/config": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.4.1.tgz",
-      "integrity": "sha512-vteSXm8N46bo3FW9MhPGVHAj+KRgrR6TWtlSk6GqToCKjTnOexXdPZyiDyEsfVW38YhqEmVl6w/6iHN8uYVJcw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.5.0.tgz",
+      "integrity": "sha512-1J/9YEX7A889xM46PYg9e8VAuSL1IUmXJW3tEhMv7XQHDWlfC9YSkIw9sTYRaq5GswGlxZ+GnnyiNsUZ9JJhSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6176,70 +6176,70 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.4.1.tgz",
-      "integrity": "sha512-BZEBdHvNJx5PzIG37EI/Zi5UUI5hGWjkYsQmKa7OIK6evAvebOTwutjS/VRI6cA6grmA52eLZR+oekGRMqkKxQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.5.0.tgz",
+      "integrity": "sha512-ondGRhzoaVpRWvFaQ5wH5zS1BIbhzbKqczKjCn6j3L0Zfe/LInjcEg8+xtB49AuZBX30qyx1ZtGoootUohz2pw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.4.1",
-        "@prisma/engines-version": "7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3",
-        "@prisma/fetch-engine": "7.4.1",
-        "@prisma/get-platform": "7.4.1"
+        "@prisma/debug": "7.5.0",
+        "@prisma/engines-version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
+        "@prisma/fetch-engine": "7.5.0",
+        "@prisma/get-platform": "7.5.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3.tgz",
-      "integrity": "sha512-fUxVd1TjOW8K4XsZ8dAm88sDW5Ry7AxWDfsYEWwScS6Fjo3caKC6hgNumUfsmsy0Il9LjDn5X0PpVXNt3iwayw==",
+      "version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e.tgz",
+      "integrity": "sha512-E+iRV/vbJLl8iGjVr6g/TEWokA+gjkV/doZkaQN1i/ULVdDwGnPJDfLUIFGS3BVwlG/m6L8T4x1x5isl8hGMxA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/debug": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.4.1.tgz",
-      "integrity": "sha512-qEtzO8oLouRv18JDQUC3G3Gnv+fGVscHZm/x1DBB/WT+kOvPDQLM2woX6IGgWnSMYYlrxjuALshT7G/blvY0bQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.5.0.tgz",
+      "integrity": "sha512-163+nffny0JoPEkDhfNco0vcuT3ymIJc9+WX7MHSQhfkeKUmKe9/wqvGk5SjppT93DtBjVwr5HPJYlXbzm6qtg==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.1.tgz",
-      "integrity": "sha512-kN4tmkQzlgm/KtE+jTNSYjsDxxe/5i6GApPI32BN9T0tlgsgSBtDJbjGBICttkAIjsh73dXf8raPKxO/2n2UUg==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
+      "integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.4.1"
+        "@prisma/debug": "7.5.0"
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.4.1.tgz",
-      "integrity": "sha512-Z9kbuxX2bvEsyeS3LZEiEnxG0lVtZbpYgaAnPj69N+A9f2De8Lta0EoFtld9zhfERVPIQWhSWUc8himky3qYdA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.5.0.tgz",
+      "integrity": "sha512-kZCl2FV54qnyrVdnII8MI6qvt7HfU6Cbiz8dZ8PXz4f4lbSw45jEB9/gEMK2SGdiNhBKyk/Wv95uthoLhGMLYA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.4.1",
-        "@prisma/engines-version": "7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3",
-        "@prisma/get-platform": "7.4.1"
+        "@prisma/debug": "7.5.0",
+        "@prisma/engines-version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
+        "@prisma/get-platform": "7.5.0"
       }
     },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.4.1.tgz",
-      "integrity": "sha512-qEtzO8oLouRv18JDQUC3G3Gnv+fGVscHZm/x1DBB/WT+kOvPDQLM2woX6IGgWnSMYYlrxjuALshT7G/blvY0bQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.5.0.tgz",
+      "integrity": "sha512-163+nffny0JoPEkDhfNco0vcuT3ymIJc9+WX7MHSQhfkeKUmKe9/wqvGk5SjppT93DtBjVwr5HPJYlXbzm6qtg==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.1.tgz",
-      "integrity": "sha512-kN4tmkQzlgm/KtE+jTNSYjsDxxe/5i6GApPI32BN9T0tlgsgSBtDJbjGBICttkAIjsh73dXf8raPKxO/2n2UUg==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
+      "integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.4.1"
+        "@prisma/debug": "7.5.0"
       }
     },
     "node_modules/@prisma/get-platform": {
@@ -6308,11 +6308,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/studio-core": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.13.1.tgz",
-      "integrity": "sha512-agdqaPEePRHcQ7CexEfkX1RvSH9uWDb6pXrZnhCRykhDFAV0/0P3d07WtfiY8hZWb7oRU4v+NkT4cGFHkQJIPg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.21.1.tgz",
+      "integrity": "sha512-bOGqG/eMQtKC0XVvcVLRmhWWzm/I+0QUWqAEhEBtetpuS3k3V4IWqKGUONkAIT223DNXJMxMtZp36b1FmcdPeg==",
       "dev": true,
       "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19 || ^22.12 || ^24.0",
+        "pnpm": "8"
+      },
       "peerDependencies": {
         "@types/react": "^18.0.0 || ^19.0.0",
         "react": "^18.0.0 || ^19.0.0",
@@ -16093,9 +16097,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -23372,17 +23376,17 @@
       "peer": true
     },
     "node_modules/prisma": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.4.1.tgz",
-      "integrity": "sha512-gDKOXwnPiMdB+uYMhMeN8jj4K7Cu3Q2wB/wUsITOoOk446HtVb8T9BZxFJ1Zop6alc89k6PMNdR2FZCpbXp/jw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.5.0.tgz",
+      "integrity": "sha512-n30qZpWehaYQzigLjmuPisyEsvOzHt7bZeRyg8gZ5DvJo9FGjD+gNaY59Ns3hlLD5/jZH5GBeftIss0jDbUoLg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "7.4.1",
+        "@prisma/config": "7.5.0",
         "@prisma/dev": "0.20.0",
-        "@prisma/engines": "7.4.1",
-        "@prisma/studio-core": "0.13.1",
+        "@prisma/engines": "7.5.0",
+        "@prisma/studio-core": "0.21.1",
         "mysql2": "3.15.3",
         "postgres": "3.4.7"
       },


### PR DESCRIPTION
## Summary
`npm audit fix` (non-breaking only). Fixes:
- ✅ **flatted** 3.4.2 — GHSA-25h7-pfq9-p65f (unbounded recursion DoS, HIGH)

### Not fixable without breaking changes:
- ⚠️ tar ≤7.5.10 — blocked by @capacitor/cli + node-gyp
- ⚠️ hono <4.12.7 — blocked by prisma
- ⚠️ effect <3.20.0 — blocked by prisma

Ref: #291

## Change
Only `package-lock.json`