### PR TITLE
chore(claude): wire hooks + skills + nested CLAUDE.md for execution discipline

### DIFF
--- a/.claude/hooks/bash-guard.sh
+++ b/.claude/hooks/bash-guard.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# PreToolUse Bash guard for MirrorBuddy.
+# Blocks token-wasteful standalone commands and unsafe git pushes.
+# Requires `jq` (already in project toolchain).
+
+set -euo pipefail
+
+input="$(cat)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""')"
+
+deny() {
+  jq -cn --arg reason "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+ask() {
+  jq -cn --arg reason "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+# Truncate heredoc body (everything after `<<` is data, not commands).
+# This avoids false positives when commit messages quote forbidden phrases.
+cmd_head="${cmd%%<<*}"
+
+# Normalize whitespace
+norm="$(printf '%s' "$cmd_head" | tr -s ' \t\n' ' ' | sed 's/^ //;s/ $//')"
+
+# 1) Token-wasteful standalone CI commands (CLAUDE.md rule)
+case "$norm" in
+  "npm run lint"|"npm run lint --"|"npm run typecheck"|"npm run typecheck --"|"npm run build"|"npm run build --")
+    deny "Use ./scripts/ci-summary.sh or npm run ci:summary instead (CLAUDE.md rule). Standalone lint/typecheck/build wastes 8k-100k tokens."
+    ;;
+  "npm run test:unit"|"npm run test:unit --")
+    deny "Standalone test:unit wastes tokens. Use: npm run test:unit -- --reporter=dot, or filter by path (e.g. npm run test:unit -- src/lib/foo)."
+    ;;
+esac
+
+# 2) gh run view --log = huge token waste
+if printf '%s' "$norm" | grep -qE 'gh[[:space:]]+run[[:space:]]+view.*--log'; then
+  deny "gh run view --log wastes tokens. Use ~/.claude/scripts/ci-check.sh (project rule: CLAUDE.md ci-verification.md)."
+fi
+
+# 3) Dangerous git push flags
+if printf '%s' "$norm" | grep -qE 'git[[:space:]]+push.*(--no-verify|-f[[:space:]]|--force)'; then
+  deny "--no-verify / --force on git push forbidden. Fix the root cause (hook failure, merge conflict) instead of bypassing."
+fi
+
+# 4) gh pr merge requires explicit user approval
+if printf '%s' "$norm" | grep -qE '^gh[[:space:]]+pr[[:space:]]+merge'; then
+  ask "Before merging: run 'gh pr checks <n>', paste output, confirm all SUCCESS, and get explicit user 'yes'. Ref: /pr skill."
+fi
+
+# Allow otherwise — emit no output (default allow)
+exit 0

--- a/.claude/hooks/bash-guard.sh
+++ b/.claude/hooks/bash-guard.sh
@@ -53,7 +53,7 @@ if printf '%s' "$norm" | grep -qE 'gh[[:space:]]+run[[:space:]]+view.*--log'; th
 fi
 
 # 3) Dangerous git push flags
-if printf '%s' "$norm" | grep -qE 'git[[:space:]]+push.*(--no-verify|-f[[:space:]]|--force)'; then
+if printf '%s' "$norm" | grep -qE 'git[[:space:]]+push.*(--no-verify|(^|[[:space:]])-f([[:space:]]|$)|--force)'; then
   deny "--no-verify / --force on git push forbidden. Fix the root cause (hook failure, merge conflict) instead of bypassing."
 fi
 

--- a/.claude/hooks/main-guard.sh
+++ b/.claude/hooks/main-guard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PreToolUse Edit|Write guard.
+# Blocks writes when current branch is `main` — forces worktree/branch discipline.
+# Honors escape hatch env MB_ALLOW_MAIN_WRITES=1 (for emergency hotfixes only).
+
+set -euo pipefail
+
+# Escape hatch
+if [ "${MB_ALLOW_MAIN_WRITES:-0}" = "1" ]; then
+  exit 0
+fi
+
+# Only guard if we're inside the MirrorBuddy repo
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$repo_root" ]; then
+  exit 0
+fi
+
+branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+
+# Extract file path from stdin
+input="$(cat)"
+fp="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')"
+
+# Carve-outs: meta/docs can be edited on main (config, ADRs, CLAUDE.md, .claude/**)
+case "$fp" in
+  */CLAUDE.md|*/.claude/*|*/docs/*|*.md|*/SETUP.md|*/CHANGELOG.md|*/.env.example|*/.gitignore)
+    exit 0
+    ;;
+esac
+
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  jq -cn --arg reason "MainGuard: writes on main branch blocked. Create a worktree first (/worktree-start) or a feature branch. Override: MB_ALLOW_MAIN_WRITES=1 (emergency only)." '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/post-edit-ts.sh
+++ b/.claude/hooks/post-edit-ts.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# PostToolUse Edit|Write notifier.
+# When a .ts/.tsx/.prisma/messages/*.json file is edited, remind Claude
+# to run `npm run ci:summary` before claiming done.
+
+set -euo pipefail
+
+input="$(cat)"
+fp="$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_response.filePath // ""')"
+
+if [ -z "$fp" ]; then
+  exit 0
+fi
+
+case "$fp" in
+  *.ts|*.tsx|*.prisma|*/messages/*/*.json)
+    jq -cn --arg note "Reminder: TypeScript/Prisma/i18n file edited ($fp). Before claiming done, run: npm run ci:summary. If i18n changed, also: npm run i18n:check." '{
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: $note
+      }
+    }'
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,41 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/bash-guard.sh",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/main-guard.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-edit-ts.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/bash-guard.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/bash-guard.sh\"",
             "timeout": 10
           }
         ]
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/main-guard.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/main-guard.sh\"",
             "timeout": 10
           }
         ]
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/post-edit-ts.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit-ts.sh\"",
             "timeout": 10
           }
         ]

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: pr
+description: Open a PR with MirrorBuddy checklist — ci:summary green, conventional commit, issue link, wait CI, require explicit user approval before merge.
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+context: inline
+user-invocable: true
+---
+
+# PR Skill — MirrorBuddy
+
+Encodes recurring PR workflow. Prevents premature merges, skipped version bumps, missing issue links.
+
+## Activation
+
+Message contains `/pr` or `/pr {title}`.
+
+## Hard Rules (NEVER skip)
+
+1. `npm run ci:summary` green before `git push`.
+2. Conventional commit subject (`feat|fix|chore|docs|refactor|test|release(scope): ...`).
+3. PR body MUST link issue: `Closes #<n>` or `Refs #<n>`.
+4. After push: run `gh pr checks <n>` — paste full output.
+5. All checks SUCCESS → ask user: **"May I merge?"** — wait explicit yes.
+6. NEVER `gh pr merge` autonomously. NEVER `--no-verify`. NEVER force-push to main.
+
+## Workflow
+
+### Phase 1 — Pre-flight
+
+```bash
+git status --short
+git branch --show-current  # must NOT be main
+npm run ci:summary         # must be green
+```
+
+If on main → abort. Create branch or worktree first (`/worktree-start`).
+
+### Phase 2 — Commit
+
+Use heredoc. Conventional format. Co-author line.
+
+```bash
+git add <specific files>
+git commit -m "$(cat <<'EOF'
+feat(scope): concise subject
+
+Why this change (not what). Reference issue.
+
+Closes #<n>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Phase 3 — Push + PR
+
+```bash
+git push -u origin <branch>
+gh pr create --title "type(scope): subject" --body "$(cat <<'EOF'
+## Summary
+- <1-3 bullets>
+
+## Test plan
+- [ ] ci:summary green
+- [ ] <feature-specific verification>
+
+Closes #<n>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Phase 4 — CI watch
+
+```bash
+gh pr checks <n>   # paste output to user
+```
+
+All green → ask: **"May I merge?"**
+Any red → fix, new commit (NEVER --amend pushed commits).
+
+### Phase 5 — Merge (ONLY after explicit user yes)
+
+```bash
+gh pr merge <n> --squash --delete-branch
+```
+
+## Forbidden
+
+- `git push --no-verify`
+- `gh pr merge` without user yes
+- `--amend` on pushed commits
+- merge with red/pending CI
+- hardcoded secrets in diff
+- `console.log` left in
+- missing issue link
+
+## Related
+
+- `/worktree-start` — create isolated worktree before coding
+- `/verify-done` — gate before claiming completion
+- `/release` — full release validation

--- a/.claude/skills/verify-done/SKILL.md
+++ b/.claude/skills/verify-done/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: verify-done
+description: Gate before claiming any task complete. Runs health-check.sh + ci:summary, pastes output, only then allows "done" claim.
+allowed-tools:
+  - Bash
+  - Read
+context: inline
+user-invocable: true
+---
+
+# Verify-Done — MirrorBuddy
+
+Anti-premature-completion gate. Run BEFORE saying "done", "completed", "finished".
+
+## Activation
+
+- Message contains `/verify-done`
+- Implicit: Claude MUST run this before claiming a task complete
+
+## Mandatory Steps
+
+### 1. Project health
+
+```bash
+./scripts/health-check.sh
+```
+
+Expect: no critical red. If red, NOT done.
+
+### 2. CI summary
+
+```bash
+npm run ci:summary
+```
+
+Expect: lint + types + build all pass.
+
+### 3. Task-specific verification
+
+Match the change type:
+
+| Change type          | Extra verification                                  |
+| -------------------- | --------------------------------------------------- |
+| UI text              | `npm run i18n:check` (all 5 locales synced)         |
+| Prisma schema        | `npx prisma generate` + migration applied           |
+| New env var          | `.env.example` + `validate-pre-deploy.ts` updated   |
+| Client component     | Dev server running, manual click-through in browser |
+| API route (mutation) | CSRF + auth middleware present                      |
+| Cookie logic         | Uses `cookie-constants.ts`, no hardcoded names      |
+| E2E test             | Imports from fixtures, not `@playwright/test`       |
+| Admin route          | `withAdmin` + `withCSRF` + `auditService.log()`     |
+
+### 4. Paste output
+
+Copy the actual tool output into the reply. No summarization, no "looks good".
+
+### 5. State explicitly
+
+> "All verification checks passed. Task <name> complete."
+
+Only after all four steps. If any step failed → task NOT done → keep working.
+
+## Forbidden
+
+- Claiming done without running health-check or ci:summary
+- "I think it works" — either prove it or keep working
+- Skipping i18n / env / CSRF checks when they apply
+- Marking TaskUpdate completed before verification run
+
+## Related
+
+- `/pr` — open PR AFTER verify-done passes
+- `/release` — full release gate

--- a/.claude/skills/worktree-start/SKILL.md
+++ b/.claude/skills/worktree-start/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: worktree-start
+description: Bootstrap isolated git worktree under ./worktrees/<task-id>. Verifies non-empty path, branch created, deps linked. Prevents working directly on main.
+allowed-tools:
+  - Read
+  - Glob
+  - Bash
+context: inline
+user-invocable: true
+---
+
+# Worktree Start — MirrorBuddy
+
+Creates isolated worktree. Enforces "never on main" rule.
+
+## Activation
+
+Message contains `/worktree-start` or `/worktree-start {task-id}`.
+
+## Hard Rules
+
+1. NEVER work directly on main branch (MainGuard blocks writes anyway).
+2. Worktree path MUST be non-empty before any write/launch.
+3. Branch name = `<type>/<task-id>-<slug>` (e.g., `fix/720-csp-nonce`).
+4. One worktree per task. Clean up after PR merge.
+
+## Workflow
+
+### Phase 1 — Validate
+
+```bash
+test "$(git branch --show-current)" = "main" && echo "on main — will create worktree" || echo "already on branch"
+git status --short  # must be clean before worktree from main
+```
+
+### Phase 2 — Create
+
+```bash
+TASK_ID="${1:-$(date +%s)}"
+SLUG="<short-descriptor>"
+BRANCH="feat/${TASK_ID}-${SLUG}"
+WT_PATH="./worktrees/${TASK_ID}"
+
+mkdir -p ./worktrees
+git worktree add -b "$BRANCH" "$WT_PATH" main
+
+# Verify non-empty
+test -d "$WT_PATH" && test -n "$(ls "$WT_PATH")" || { echo "ABORT: worktree empty"; exit 1; }
+```
+
+### Phase 3 — Bootstrap deps
+
+```bash
+cd "$WT_PATH"
+npm install --prefer-offline --no-audit
+npx prisma generate
+```
+
+### Phase 4 — Report
+
+Return to user: worktree path, branch name, next command hint.
+
+## Cleanup (after PR merge)
+
+```bash
+git worktree remove ./worktrees/<task-id>
+git branch -d <branch>   # only if merged
+```
+
+## Forbidden
+
+- working on `main` directly
+- deleting active worktrees (check with `git worktree list` first)
+- force-removing worktrees with uncommitted changes
+
+## Related
+
+- `/pr` — open PR from worktree
+- `/verify-done` — pre-completion check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,3 +54,19 @@ WCAG 2.1 AA (7 DSA profiles) | NO localStorage | Prisma only | `@/` aliases | 5 
 ## Verification
 
 `./scripts/health-check.sh` (full) or `npm run ci:summary` (build). Thor: per-task (Gates 1-4, 8, 9) + per-wave (all 9 + build). Night: `.github/agents/night-maintenance.agent.md`.
+
+## Execution Bias
+
+When user says "execute", "continue", "fai", or references a plan/MISSION.md: act within ≤3 exploratory tool calls, then start work. No drift into exploration. Skills `/pr`, `/worktree-start`, `/verify-done` encode recurring checklists — invoke them instead of re-deriving steps.
+
+## Worktree Discipline
+
+Never work directly on `main`. Use `/worktree-start` → creates `./worktrees/<id>` + branch. MainGuard hook (`.claude/hooks/main-guard.sh`) blocks writes to src on main (carve-outs: CLAUDE.md, `.claude/**`, `docs/**`, `*.md`). Emergency override: `MB_ALLOW_MAIN_WRITES=1`.
+
+## Pre-Push Checklist (hook-enforced)
+
+Bash guard (`.claude/hooks/bash-guard.sh`) blocks: standalone `npm run lint|typecheck|build|test:unit`, `gh run view --log`, `git push --no-verify|--force`. Use `npm run ci:summary` + `~/.claude/scripts/ci-check.sh`. `gh pr merge` triggers confirmation — paste `gh pr checks <n>` output + wait user "yes".
+
+## Verify-Before-Done
+
+Never claim "done" without running `/verify-done` (or equivalent: `./scripts/health-check.sh` + `npm run ci:summary`). Paste actual output. If red → not done. Applies to TaskUpdate completed status too.

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -1,0 +1,53 @@
+# E2E Tests — MirrorBuddy
+
+Playwright specs. See root + `.claude/rules/e2e-testing.md` (authoritative).
+
+## CRITICAL: Fixture import (ESLint-enforced)
+
+```ts
+// ✓ CORRECT — auto TOS mock + wall bypasses
+import { test, expect } from './fixtures/base-fixtures';
+import { test, expect } from './fixtures/a11y-fixtures'; // a11y
+import { test, expect } from './fixtures/auth-fixtures'; // trial/admin
+import { test, expect, testAllLocales } from './fixtures'; // locale
+
+// ✗ WRONG — TOS modal blocks all interactions
+import { test, expect } from '@playwright/test';
+```
+
+## Wall bypass (ADR 0059)
+
+Base fixtures auto-apply:
+
+1. `/api/tos` route mock → bypasses TosGateProvider
+2. `mirrorbuddy-consent` localStorage → bypasses CookieConsentWall
+3. `mirrorbuddy-trial-consent` cookie → bypasses TrialConsentGate
+
+Without fixtures = tests timeout.
+
+## Production safety (F-03)
+
+`e2e/global-setup.ts` checks `NODE_ENV` — E2E blocked in production. NO workarounds.
+
+## Adding a new wall
+
+1. Update `e2e/global-setup.ts` localStorage array.
+2. If component calls APIs on mount → mock those endpoints in `base-fixtures.ts`.
+3. Run E2E locally before push.
+
+## Spec structure
+
+- Filename `feature.spec.ts`. One feature per file.
+- Setup inside `test.beforeEach`; avoid global mutation.
+- Selectors: `data-testid` > role > text. Never XPath.
+- Assertions: `expect(locator).toBeVisible()` (auto-retry) over `page.locator().count()`.
+
+## Running
+
+- Headed locally: `npx playwright test --headed --ui`.
+- CI: `./scripts/ci-summary.sh --e2e` (uses fail-only output).
+- Single file: `npx playwright test e2e/foo.spec.ts`.
+
+## Flake policy
+
+Flaky specs → quarantine with `test.fixme()` + create issue. Don't disable without ticket.

--- a/messages/CLAUDE.md
+++ b/messages/CLAUDE.md
@@ -1,0 +1,53 @@
+# i18n Messages — MirrorBuddy
+
+next-intl message catalogs. See root + `.claude/rules/i18n.md` (authoritative).
+
+## Locales (5 — day-1 parity required)
+
+`it` (default) | `en` | `fr` | `de` | `es`
+
+## CRITICAL: Wrapper key (ADR 0104)
+
+EVERY JSON file MUST wrap content under single key matching filename:
+
+```json
+// messages/it/chat.json
+{
+  "chat": {
+    "title": "Chat",
+    "placeholder": "Scrivi..."
+  }
+}
+```
+
+Missing wrapper = namespace collision via `Object.assign()` → 98 ESLint warnings + 37 E2E failures (past incident).
+
+## Key rules
+
+- camelCase only (ADR 0091). ESLint `no-kebab-case-i18n-keys` enforces.
+- Interpolation: `"{count, plural, one {# item} other {# items}}"` (ICU MessageFormat).
+- No HTML tags in values. Use `<Rich>` components in React if markup needed.
+- Keys stable across releases. Rename = breaking change for external consumers.
+
+## Add new keys (workflow)
+
+```bash
+# 1. Add to messages/it/<ns>.json (Italian first — source of truth)
+# 2. Sync placeholders to all locales
+npx tsx scripts/i18n-sync-namespaces.ts --add-missing
+# 3. Translate placeholder values in en/fr/de/es
+# 4. Verify parity
+npm run i18n:check
+```
+
+Or use `/localize` skill for bulk translation.
+
+## Formal address (ADR 0064)
+
+Pre-1900 historical figures use Lei/Sie/Vous. Set `FORMAL_PROFESSORS` in `src/lib/greeting/templates/index.ts`.
+
+## Namespaces (19+)
+
+`common, auth, admin, chat, home, tools, settings, compliance, consent, education, navigation, errors, welcome, metadata, pricing, marketing, achievements, maintenance, voice, analytics, waitlist`.
+
+New namespace → add file to all 5 locales + register in `src/i18n/`.

--- a/prisma/CLAUDE.md
+++ b/prisma/CLAUDE.md
@@ -1,0 +1,41 @@
+# Prisma — MirrorBuddy
+
+PostgreSQL + pgvector. Schema split across `prisma/schema/` (ADR enables multi-file). Migrations in `prisma/migrations/`.
+
+## After ANY schema change
+
+```bash
+npx prisma generate       # regenerate client
+npx prisma migrate dev --name <slug>   # local migration
+npm run ci:summary        # types pass
+```
+
+## Hard Rules
+
+- Parameterized queries ONLY. No `$queryRaw` with string interpolation.
+- Migrations are APPEND-ONLY. Never edit applied migrations.
+- PII fields (email, name, birthdate, etc.): document in DPIA (`docs/compliance/DPIA.md`).
+- Vector columns: use `pgvector` type. Embeddings scrubbed of PII before insert.
+- Cascades explicit: declare `onDelete` / `onUpdate` — never rely on defaults.
+- Indexes: add for query paths used at scale (see `src/lib/db/query-patterns.ts`).
+- Soft-delete: `deletedAt` timestamp + scope queries. Hard-delete only via admin GDPR endpoint.
+
+## Seeding
+
+- `seed.ts` = minimal dev bootstrap.
+- `seed-tiers.ts`, `seed-model-catalog.ts` = idempotent reference data.
+- Never seed PII or real users.
+
+## Local Postgres
+
+NOT auto-started. `brew services start postgresql@17` or `./scripts/ensure-test-db.sh`. CI/prod = Supabase.
+
+## Common pitfalls
+
+- Forgetting `prisma generate` → type errors across repo.
+- Editing `schema.prisma` but not `schema/` split → drift.
+- `dev.db` (SQLite) is legacy — ignore for production schema decisions.
+
+## Migration naming
+
+`<action>-<entity>` — e.g. `add-fsrs-cards`, `index-users-email`. Conventional.

--- a/src/app/api/CLAUDE.md
+++ b/src/app/api/CLAUDE.md
@@ -1,0 +1,48 @@
+# API Routes — MirrorBuddy
+
+Route handlers under `src/app/api/`. See root `CLAUDE.md` + `.claude/rules/admin-patterns.md` for context.
+
+## Mutation Template (POST/PUT/PATCH/DELETE)
+
+```ts
+import { NextResponse } from 'next/server';
+import { pipe, withSentry, withCSRF, withAuth } from '@/lib/api/middlewares';
+
+export const POST = pipe(
+  withSentry('/api/path'),
+  withCSRF, // BEFORE auth on authenticated endpoints
+  withAuth, // or withAdmin for /api/admin/*
+)(async (ctx) => {
+  // ctx.userId (auth) / ctx.isAdmin (admin)
+  return NextResponse.json(data);
+});
+```
+
+## Hard Rules
+
+- CSRF on ALL mutating routes (POST/PUT/PATCH/DELETE). `withCSRF` BEFORE `withAuth`.
+- Admin routes: `withAdmin` + `auditService.log({ action: "VERB_ENTITY", entityType, entityId, adminId })` after mutation.
+- Cron routes: `CRON_SECRET` header check, no CSRF/auth.
+- Public routes: no CSRF required; still validate input.
+- NEVER read auth cookies directly. Use `validateAuth()` / `validateAdminAuth()` / `validateVisitorId()`.
+- Input validation at boundary. Zod schemas preferred.
+- Prisma parameterized queries only — no raw SQL with interpolation.
+- Never log PII (email, name, birthdate) to console/Sentry.
+- Error response shape: `{ error: string }`, proper HTTP status.
+
+## Standard Status Codes
+
+200 ok | 201 created | 204 no-content | 400 validation | 401 unauth | 403 forbidden | 404 missing | 409 conflict | 429 rate-limit | 500 server
+
+## Rate limiting
+
+See `src/lib/api/rate-limit.ts`. Apply on anonymous/trial endpoints.
+
+## Tier gating
+
+```ts
+import { tierService } from '@/lib/tier/tier-service';
+const hasFeature = await tierService.hasFeature(ctx.userId, 'voice');
+```
+
+## Tests: unit in `__tests__/`, E2E in project `e2e/` (see `e2e/CLAUDE.md`).

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -1,0 +1,55 @@
+# UI Components — MirrorBuddy
+
+React components. Server-first (Next 16 App Router). See root + `.claude/rules/accessibility.md`, `.claude/rules/i18n.md`.
+
+## Server vs Client
+
+- Default: server component (no `"use client"`, no hooks, no event handlers).
+- `"use client"` ONLY when: state/hooks/browser APIs/event handlers required.
+- Server fetches data, client renders interactivity.
+
+## i18n (MANDATORY — ESLint enforces)
+
+```tsx
+// Client
+import { useTranslations } from 'next-intl';
+const t = useTranslations('ns');
+
+// Server
+import { getTranslations } from 'next-intl/server';
+const t = await getTranslations('ns');
+```
+
+- NO hardcoded user-facing text (italian/english/etc.) — ESLint `no-hardcoded-italian` blocks.
+- camelCase keys only (ADR 0091).
+- Add keys IT first → `npx tsx scripts/i18n-sync-namespaces.ts --add-missing` → `npm run i18n:check`.
+- Namespace wrapper key (ADR 0104): JSON MUST wrap content under filename key.
+
+## Accessibility (WCAG 2.1 AA — 7 DSA profiles)
+
+- Contrast 4.5:1 normal / 3:1 large.
+- Visible focus indicators.
+- Full keyboard nav (Tab/Enter/Escape).
+- Respect `prefers-reduced-motion`.
+- TTS-friendly content order.
+- Test with `useAccessibilityStore` profiles.
+
+## State
+
+- `Zustand` stores under `@/lib/stores/`. NO localStorage.
+- Server state via REST + SWR/fetch in server components.
+
+## Forms / Dialogs
+
+- `<Dialog>` (NOT `window.confirm`/`alert`) for destructive ops.
+- `toast()` from sonner for feedback.
+- Zod + react-hook-form for validation.
+
+## CSP
+
+Inline scripts must use nonces (see `src/components/providers.tsx`). "Caricamento..." stuck = CSP violation.
+
+## File layout
+
+- `kebab-case.tsx` filenames, PascalCase exports.
+- Co-locate tests: `component.test.tsx` next to `component.tsx`.

--- a/src/lib/CLAUDE.md
+++ b/src/lib/CLAUDE.md
@@ -1,0 +1,42 @@
+# Lib — MirrorBuddy
+
+Shared modules under `src/lib/`. See root + `.claude/rules/` (tier, cookies, compliance).
+
+## Key subdirs
+
+| Dir                | Purpose                                                                   |
+| ------------------ | ------------------------------------------------------------------------- |
+| `ai/providers/`    | Azure OpenAI / Claude / Ollama adapters                                   |
+| `auth/`            | Session, cookies, CSRF, admin. Use `validateAuth()` — no raw cookie reads |
+| `safety/`          | Bias detector, content filter, crisis detection                           |
+| `tier/`            | Trial/Base/Pro enforcement — `tierService`                                |
+| `education/fsrs/`  | Spaced repetition                                                         |
+| `api/middlewares/` | `pipe`, `withSentry`, `withCSRF`, `withAuth`, `withAdmin`                 |
+| `stores/`          | Zustand stores (never localStorage)                                       |
+
+## Hard Rules
+
+- Prisma client: import from `@/lib/db` (NOT direct `@prisma/client`). Parameterized queries only.
+- Defensive coding: null/undefined guards on ALL external input.
+- Every `async` = error handling (try/catch or `.catch`).
+- NO PII in vector DB. Scrub before embedding.
+- Safety guardrails: run `biasDetector`/`contentFilter` on user-generated AI prompts.
+- Cookie constants: import from `auth/cookie-constants.ts`. NEVER hardcode names.
+- Types: extend `src/types/index.ts`. Avoid `any` (lint blocks).
+
+## AI Providers
+
+- Select via `ai/providers/factory.ts` (tier-aware).
+- Streaming responses use SSE helpers in `ai/streaming/`.
+- Post-stream: log token usage for observability (Grafana ADR 0047).
+
+## Tests
+
+- Vitest unit in `__tests__/` subdirs.
+- Mock Prisma with `prisma-mock` pattern. Do NOT mock for integration tests.
+
+## Performance
+
+- Memoize expensive derivations.
+- Avoid synchronous filesystem reads in request path.
+- Cache layer: `src/lib/cache.ts` — prefer Redis for cross-instance state.


### PR DESCRIPTION
## Summary

Enforce recurring MirrorBuddy discipline (from insights report friction patterns) via Claude Code hooks, skills, and nested CLAUDE.md files.

### Hooks (`.claude/hooks/*.sh`)
- **bash-guard.sh** — blocks token-wasteful standalone CI commands (`npm run lint|typecheck|build|test:unit`), dangerous git push flags (`--no-verify`, `--force`); asks on `gh pr merge`
- **main-guard.sh** — blocks src writes when on `main` branch (carve-out for `.claude/**`, `CLAUDE.md`, `docs/**`, `*.md`); override via `MB_ALLOW_MAIN_WRITES=1`
- **post-edit-ts.sh** — reminder to run `npm run ci:summary` after TS/Prisma/i18n edits

### Skills (`.claude/skills/`)
- **/pr** — PR checklist: ci green, conventional commit, issue link, wait CI, explicit user approval before merge
- **/worktree-start** — isolated worktree bootstrap with non-empty verify
- **/verify-done** — gate before claiming completion

### Nested CLAUDE.md
Contextual rules that auto-load when editing in these areas:
- `src/app/api/` — mutation template, CSRF/auth pipe order, audit pattern
- `src/components/` — server-first, i18n hooks, WCAG/DSA checklist
- `src/lib/` — Prisma/auth/safety/tier conventions
- `prisma/` — schema-change workflow, migration append-only
- `e2e/` — mandatory fixture import (ADR 0059)
- `messages/` — ADR 0104 wrapper key, add-keys workflow

### Root CLAUDE.md
New sections: Execution Bias, Worktree Discipline, Pre-Push Checklist, Verify-Before-Done.

## Test plan

- [ ] CI green (lint, types, build, tests)
- [ ] Hooks activate on next session (open `/hooks` or restart Claude Code)
- [ ] Manual: trigger `npm run lint` standalone → expect deny
- [ ] Manual: trigger edit on `src/**/*.ts` while on main → expect deny
- [ ] Manual: `gh pr merge` → expect ask

🤖 Generated with [Claude Code](https://claude.com/claude-code)