### PR TITLE
feat(monorepo): W1b pilot — extract @mirrorbuddy/types

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,8 @@ const withBundleAnalyzer = bundleAnalyzer({
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
+  // Monorepo: transpile workspace packages so Next can bundle their TS sources.
+  transpilePackages: ['@mirrorbuddy/types'],
   // Enable standalone output for Docker deployment
   // Creates .next/standalone with minimal server.js for production
   output: 'standalone',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,15 @@
       "version": "0.16.10",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "workspaces": [
+        "apps/*",
+        "packages/*"
+      ],
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
         "@capacitor/camera": "^8.0.0",
+        "@mirrorbuddy/types": "*",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.68.0",
         "@opentelemetry/resources": "^2.4.0",
@@ -2819,6 +2824,10 @@
       "dependencies": {
         "langium": "3.3.1"
       }
+    },
+    "node_modules/@mirrorbuddy/types": {
+      "resolved": "packages/types",
+      "link": true
     },
     "node_modules/@mrleebo/prisma-ast": {
       "version": "0.13.1",
@@ -28447,6 +28456,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/types": {
+      "name": "@mirrorbuddy/types",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "typescript": "^5"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "terser-webpack-plugin": "5.3.17"
   },
   "dependencies": {
+    "@mirrorbuddy/types": "*",
     "@anthropic-ai/sdk": "^0.73.0",
     "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
     "@capacitor/camera": "^8.0.0",
@@ -213,5 +214,9 @@
     "turbo": "^2.5.4",
     "typescript": "^5",
     "vitest": "^4.0.16"
-  }
+  },
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ]
 }

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,14 @@
+# @mirrorbuddy/types
+
+Shared TypeScript types for the MirrorBuddy workspace.
+
+## Status
+
+W1b pilot — currently exports user/settings types only. Additional types
+migrate in subsequent waves.
+
+## Usage
+
+```ts
+import type { Curriculum, Settings } from '@mirrorbuddy/types';
+```

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@mirrorbuddy/types",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared TypeScript types for MirrorBuddy workspace",
+  "license": "Apache-2.0",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,1 @@
+export type { Curriculum, SchoolLevel, StudentProfile, Theme, AIProvider, Settings } from './user';

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,0 +1,53 @@
+// ============================================================================
+// USER TYPES - Student Profile, Settings, Curriculum
+// ============================================================================
+
+export type Curriculum =
+  | 'liceoClassico'
+  | 'liceoScientifico'
+  | 'liceoLinguistico'
+  | 'liceoArtistico'
+  | 'liceoMusicale'
+  | 'istitutoTecnico'
+  | 'istitutoProfessionale'
+  | 'scuolaMedia'
+  | 'scuolaElementare';
+
+export type SchoolLevel = 'elementare' | 'media' | 'superiore';
+
+export interface StudentProfile {
+  name: string;
+  age: number;
+  schoolYear: number;
+  schoolLevel: SchoolLevel;
+  curriculum?: Curriculum;
+  // Accessibility
+  fontSize: 'small' | 'medium' | 'large' | 'extra-large';
+  highContrast: boolean;
+  dyslexiaFont: boolean;
+  voiceEnabled: boolean;
+  simplifiedLanguage: boolean;
+  adhdMode: boolean;
+}
+
+// === SETTINGS TYPES ===
+
+export type Theme = 'light' | 'dark' | 'system';
+
+export type AIProvider =
+  | 'openai'
+  | 'anthropic'
+  | 'azure'
+  | 'gemini'
+  | 'openrouter'
+  | 'perplexity'
+  | 'grok'
+  | 'ollama';
+
+export interface Settings {
+  theme: Theme;
+  provider: AIProvider;
+  model: string;
+  budgetLimit: number;
+  studentProfile: StudentProfile;
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": true,
+    "declaration": false,
+    "composite": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,53 +1,10 @@
-// ============================================================================
-// USER TYPES - Student Profile, Settings, Curriculum
-// ============================================================================
-
-export type Curriculum =
-  | 'liceoClassico'
-  | 'liceoScientifico'
-  | 'liceoLinguistico'
-  | 'liceoArtistico'
-  | 'liceoMusicale'
-  | 'istitutoTecnico'
-  | 'istitutoProfessionale'
-  | 'scuolaMedia'
-  | 'scuolaElementare';
-
-export type SchoolLevel = 'elementare' | 'media' | 'superiore';
-
-export interface StudentProfile {
-  name: string;
-  age: number;
-  schoolYear: number;
-  schoolLevel: SchoolLevel;
-  curriculum?: Curriculum;
-  // Accessibility
-  fontSize: 'small' | 'medium' | 'large' | 'extra-large';
-  highContrast: boolean;
-  dyslexiaFont: boolean;
-  voiceEnabled: boolean;
-  simplifiedLanguage: boolean;
-  adhdMode: boolean;
-}
-
-// === SETTINGS TYPES ===
-
-export type Theme = 'light' | 'dark' | 'system';
-
-export type AIProvider =
-  | 'openai'
-  | 'anthropic'
-  | 'azure'
-  | 'gemini'
-  | 'openrouter'
-  | 'perplexity'
-  | 'grok'
-  | 'ollama';
-
-export interface Settings {
-  theme: Theme;
-  provider: AIProvider;
-  model: string;
-  budgetLimit: number;
-  studentProfile: StudentProfile;
-}
+// Re-exports from @mirrorbuddy/types workspace package (W1b pilot).
+// Runtime-free: types only.
+export type {
+  Curriculum,
+  SchoolLevel,
+  StudentProfile,
+  Theme,
+  AIProvider,
+  Settings,
+} from '@mirrorbuddy/types';


### PR DESCRIPTION
## Summary

**Wave 1b** — first workspace package extraction. Pilot scope: user/settings types only. Proves monorepo plumbing end-to-end (pnpm + npm dual resolution, Next.js `transpilePackages`, Vercel build, CI).

## Changes

- `packages/types/` — new workspace package `@mirrorbuddy/types@0.1.0`
  - Exports: `Curriculum`, `SchoolLevel`, `StudentProfile`, `Theme`, `AIProvider`, `Settings`
  - `tsconfig.json` extends root
  - No runtime deps (pure types)
- Root `package.json`: adds `workspaces: ["apps/*", "packages/*"]` + `"@mirrorbuddy/types": "*"` dep (npm workspaces — compatible with both pnpm and CI's `npm ci`)
- `next.config.ts`: `transpilePackages: ['@mirrorbuddy/types']`
- `src/types/user.ts`: thin re-export shim → preserves all existing `@/types` and `@/types/user` import paths across the codebase

## Non-goals (deferred)

- Other type files (characters, voice, education, gamification, etc.) migrate in later waves
- Vercel Root Directory flip deferred until `apps/web/` is populated
- pnpm-only features (workspace protocol) intentionally avoided for CI compatibility

## Test plan

- [x] `ci:summary` PASS (lint + typecheck + build)
- [x] `node_modules/@mirrorbuddy/types` → `packages/types` symlink verified
- [x] `src/lib/tools/plugin/orchestrator-types.ts` still resolves `@/types/user` import
- [ ] CI: Build & Lint required ✓
- [ ] CI: PR Gate required ✓
- [ ] Vercel Preview deploys successfully

## Rollout notes

Once merged, subsequent waves append more type files to `packages/types/src/` and narrow `src/types/*.ts` shims file-by-file. No breaking-change window for the app layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)