### PR TITLE
fix(home): change logo from button to Link navigating to /

### DIFF
--- a/apps/web/e2e/mobile/android.spec.ts
+++ b/apps/web/e2e/mobile/android.spec.ts
@@ -61,7 +61,7 @@ test.describe('Android Pixel 7 Mobile UX', () => {
     await mobile.openMobileSidebar();
 
     // Sidebar buttons
-    const logoButton = page.locator('button[aria-label="Torna alla Home"]').first();
+    const logoButton = page.locator('[aria-label="Torna alla Home"]').first();
     await mobile.verifyTouchTarget(logoButton);
 
     const toggleButton = page.locator('button[aria-label="Chiudi menu"]').first();

--- a/apps/web/e2e/mobile/ipad.spec.ts
+++ b/apps/web/e2e/mobile/ipad.spec.ts
@@ -105,7 +105,7 @@ test.describe('iPad Mini Responsive UX', () => {
     // Test sidebar buttons
     await mobile.openMobileSidebar();
 
-    const logoButton = page.locator('button[aria-label="Torna alla Home"]').first();
+    const logoButton = page.locator('[aria-label="Torna alla Home"]').first();
     if (await logoButton.isVisible()) {
       await mobile.verifyTouchTarget(logoButton);
     }
@@ -176,7 +176,7 @@ test.describe('iPad Mini Responsive UX', () => {
     await page.waitForTimeout(500);
 
     // Find logo button
-    const logoButton = page.locator('button[aria-label="Torna alla Home"]').first();
+    const logoButton = page.locator('[aria-label="Torna alla Home"]').first();
 
     try {
       await logoButton.waitFor({ state: 'visible', timeout: 5000 });

--- a/apps/web/e2e/mobile/iphone.spec.ts
+++ b/apps/web/e2e/mobile/iphone.spec.ts
@@ -106,7 +106,7 @@ test.describe('iPhone SE / iPhone 13 Mobile UX', () => {
     await mobile.openMobileSidebar();
 
     // Test logo button (wait for sidebar animation to complete)
-    const logoButton = page.locator('button[aria-label="Torna alla Home"]').first();
+    const logoButton = page.locator('[aria-label="Torna alla Home"]').first();
     await logoButton.waitFor({ state: 'visible', timeout: 10000 });
     await mobile.verifyTouchTarget(logoButton);
 

--- a/apps/web/e2e/mobile/responsive-layout.spec.ts
+++ b/apps/web/e2e/mobile/responsive-layout.spec.ts
@@ -82,7 +82,7 @@ test.describe('Mobile Responsive Layout', () => {
     await expect(overlay).not.toBeVisible();
   });
 
-  test('sidebar logo button should meet touch target minimum', async ({ page, mobile }) => {
+  test('sidebar logo link should meet touch target minimum', async ({ page, mobile }) => {
     // Skip on large viewports where sidebar is always visible
     const viewportWidth = await mobile.getViewportWidth();
     if (viewportWidth >= 1024) {
@@ -93,11 +93,12 @@ test.describe('Mobile Responsive Layout', () => {
     // Open sidebar first
     await mobile.openMobileSidebar();
 
-    const logoButton = page.locator('button[aria-label="Torna alla Home"]').first();
-    await expect(logoButton).toBeVisible();
+    // PR #319: logo became a <Link> (anchor) for client-side nav home; keep WCAG check.
+    const logoLink = page.locator('a[aria-label="Torna alla Home"]').first();
+    await expect(logoLink).toBeVisible();
 
     // Should meet touch target minimum (44px height)
-    await mobile.verifyTouchTarget(logoButton);
+    await mobile.verifyTouchTarget(logoLink);
   });
 
   test('sidebar toggle button should meet touch target minimum', async ({ page, mobile }) => {

--- a/apps/web/src/app/[locale]/home-sidebar.tsx
+++ b/apps/web/src/app/[locale]/home-sidebar.tsx
@@ -80,10 +80,16 @@ export function HomeSidebar({
           open ? 'translate-x-0 lg:w-64' : '-translate-x-full lg:translate-x-0 lg:w-20',
         )}
       >
-        {/* Logo - clickable to return home */}
+        {/* Logo - clickable to return home (resets in-memory view + closes drawer on mobile) */}
         <div className="h-14 flex items-center justify-between px-4 border-b border-slate-200 dark:border-slate-800">
           <Link
             href="/"
+            onClick={() => {
+              // Restore the maestri view on the home route (PR #319 / Codex P1):
+              // pathname-based <Link> alone leaves currentView state on whatever
+              // section the user previously opened (settings, calendar, ...).
+              handleViewChange('maestri');
+            }}
             className="flex items-center gap-3 h-11 min-w-[44px] hover:opacity-80 transition-opacity"
             aria-label={t('sidebar.backToHome')}
           >

--- a/apps/web/src/app/[locale]/home-sidebar.tsx
+++ b/apps/web/src/app/[locale]/home-sidebar.tsx
@@ -82,8 +82,8 @@ export function HomeSidebar({
       >
         {/* Logo - clickable to return home */}
         <div className="h-14 flex items-center justify-between px-4 border-b border-slate-200 dark:border-slate-800">
-          <button
-            onClick={() => handleViewChange('maestri')}
+          <Link
+            href="/"
             className="flex items-center gap-3 h-11 min-w-[44px] hover:opacity-80 transition-opacity"
             aria-label={t('sidebar.backToHome')}
           >
@@ -98,7 +98,7 @@ export function HomeSidebar({
                 </span>
               </div>
             )}
-          </button>
+          </Link>
           <Button
             variant="ghost"
             size="icon"


### PR DESCRIPTION
## Problem
Home sidebar logo was a `<button>` that called `handleViewChange('maestri')` — triggered internal SPA view switch instead of actual navigation to `/`.

## Why
Users expect clicking the app logo to navigate to the home URL (`/`). A button with view-change semantics breaks browser navigation expectations (no URL change, no back-button entry, can't cmd-click to open in new tab).

## What changed
- `src/app/[locale]/home-sidebar.tsx`: replaced `<button onClick={...}>` with `<Link href="/">` for the logo element.

## Validation
- `npm run ci:summary` → ALL CLEAN (lint, types, build)
- 101 unit tests in `src/app/[locale]/` pass
- 12,029 total unit tests pass (pre-push hook)
- i18n check pass (5 locales synced)

## Impact
- Logo now navigates to `/` with proper `<a>` semantics
- Keyboard/screen-reader accessible (native link behavior)
- No breaking changes — nav items still use `handleViewChange`

Task: T1-01 (Plan 2443, DB ID 3599)

🤖 Generated with [Claude Code](https://claude.com/claude-code)