### PR TITLE
fix(ci): install pnpm in Deploy to Staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1771,6 +1771,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

Hotfix: main-branch staging deploy has been failing since #317 merged.

```
Error: spawn pnpm ENOENT
##[error]Process completed with exit code 1.
```

## Cause

`packageManager: pnpm@10.33.0` in root `package.json` (added by #317) makes Vercel CLI shell out to `pnpm` during `vercel build`. The staging-deploy GitHub runner has no pnpm binary on PATH → ENOENT.

## Fix

Add `pnpm/action-setup@v4` step before Node setup in the `🎪 Deploy to Staging` job. Pinned to `10.33.0` to match `packageManager`.

`promote-to-production.yml` untouched — it only runs `vercel promote` on prebuilt deployments.

## Test plan

- [x] pre-push hook PASS (build, i18n, unit tests, vercel env check)
- [ ] Required CI checks pass (Build & Lint + PR Gate)
- [ ] After merge: staging deploy green on main

Closes the post-merge red CI on commit `852a0f563`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)