### PR TITLE
fix(deps): sync pnpm-lock.yaml after W1b — workspace:* protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@anthropic-ai/sdk": "^0.73.0",
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
         "@capacitor/camera": "^8.0.0",
-        "@mirrorbuddy/types": "*",
+        "@mirrorbuddy/types": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.68.0",
         "@opentelemetry/resources": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "terser-webpack-plugin": "5.3.17"
   },
   "dependencies": {
-    "@mirrorbuddy/types": "*",
+    "@mirrorbuddy/types": "workspace:*",
     "@anthropic-ai/sdk": "^0.73.0",
     "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
     "@capacitor/camera": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@capacitor/camera':
         specifier: ^8.0.0
         version: 8.1.0(@capacitor/core@8.3.1)
+      '@mirrorbuddy/types':
+        specifier: workspace:*
+        version: link:packages/types
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -145,7 +148,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       recharts:
         specifier: ^3.6.0
-        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@17.0.2)(react@19.2.3)(redux@5.0.1)
       resend:
         specifier: ^6.9.1
         version: 6.12.0
@@ -324,6 +327,12 @@ importers:
       vitest:
         specifier: ^4.0.16
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/types:
+    devDependencies:
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
 packages:
 
@@ -16751,7 +16760,7 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1):
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@17.0.2)(react@19.2.3)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
       clsx: 2.1.1
@@ -16761,7 +16770,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      react-is: 16.13.1
+      react-is: 17.0.2
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3


### PR DESCRIPTION
## Summary

Second hotfix for main-branch staging deploy. #320 fixed \`spawn pnpm ENOENT\` by installing pnpm in the runner. The next error surfaced:

\`\`\`
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/package.json
* 1 dependencies were added: @mirrorbuddy/types@*
\`\`\`

## Cause

#318 (packages/types pilot) added \`"@mirrorbuddy/types": "*"\` to root \`package.json\` and regenerated \`package-lock.json\` via \`npm install\`. The pnpm lockfile was never refreshed. Vercel's \`vercel build\` uses pnpm (per \`packageManager\` field) with \`--frozen-lockfile\` by default → fails.

## Fix

1. Switch dep spec \`"@mirrorbuddy/types": "*"\` → \`"workspace:*"\`. Both npm 8+ and pnpm honor this; avoids registry 404 lookups.
2. \`pnpm install --lockfile-only\` → pnpm-lock.yaml now includes the workspace entry.
3. \`npm install --package-lock-only\` → package-lock.json also syncs.

## Verified

- \`pnpm install\` succeeds locally
- \`npm install\` also succeeds (postinstall \`prisma generate\` errors in bare worktree; not a lockfile issue)
- Both lockfiles contain \`workspace:*\` specifier

## Test plan

- [x] pnpm install succeeds locally
- [x] pre-push hooks PASS (build, i18n, unit tests, vercel env check)
- [ ] CI: Build & Lint + PR Gate required ✓
- [ ] Post-merge: main staging deploy green

Closes latent blocker for #321 (batch-1 types) and all future W1b-ext PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)