### PR TITLE
docs: monorepo migration — ADR 0164 + README + package docs

### DIFF
--- a/CONTRIBUTING-MONOREPO.md
+++ b/CONTRIBUTING-MONOREPO.md
@@ -1,0 +1,128 @@
+# Contributing to the MirrorBuddy Monorepo
+
+Developer guide for working with the pnpm workspaces + Turborepo setup.
+See `docs/adr/0164-monorepo-migration-pnpm-turborepo.md` for the design
+decision and migration waves.
+
+## Prerequisites
+
+- Node.js ≥ 20
+- pnpm ≥ 10.33.0 (pinned via the `packageManager` field in root
+  `package.json` — `corepack enable` will install the right version)
+
+## Layout
+
+```
+MirrorBuddy/
+├── apps/
+│   └── web/             (Next.js app — post-W2, currently still at root)
+├── packages/
+│   └── types/           (@mirrorbuddy/types — shared TS contracts)
+├── pnpm-workspace.yaml  (workspace glob config)
+├── turbo.json           (task pipeline)
+└── …
+```
+
+W3 adds: `packages/{db,ai-providers,safety,tools,education,i18n,ui}`.
+
+## Common commands
+
+| Command | Purpose |
+|---|---|
+| `pnpm install` | Install deps for root + every workspace |
+| `pnpm dev` | Start the dev server (Turbo runs the right targets) |
+| `pnpm build` | Production build |
+| `pnpm test:unit` | Vitest across all packages |
+| `pnpm --filter @mirrorbuddy/types <cmd>` | Run a script inside a specific workspace |
+
+## Adding a dep to a specific workspace
+
+```bash
+pnpm --filter @mirrorbuddy/types add -D typescript
+pnpm --filter mirrorbuddy add lodash  # "mirrorbuddy" is the root app
+```
+
+Do NOT run `pnpm add` at the repo root without `--filter` — it adds the
+dep to the root `package.json`, which is almost never what you want
+post-W2.
+
+## Creating a new package
+
+```bash
+mkdir packages/<name>
+cd packages/<name>
+pnpm init
+# Set name to "@mirrorbuddy/<name>" and add to turbo.json pipeline if
+# it needs custom build/lint/test targets
+```
+
+Template `package.json` (types-only package):
+
+```json
+{
+  "name": "@mirrorbuddy/<name>",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": { ".": { "types": "./src/index.ts", "default": "./src/index.ts" } },
+  "files": ["src"],
+  "scripts": { "typecheck": "tsc --noEmit" }
+}
+```
+
+For runtime packages, add a `build` script that outputs `./dist/`, and
+update `main`/`types`/`exports` accordingly.
+
+## Next.js `transpilePackages`
+
+Internal workspace packages that ship TS sources (no dist) must be
+declared in `next.config.ts`:
+
+```ts
+const nextConfig: NextConfig = {
+  transpilePackages: ['@mirrorbuddy/types', '@mirrorbuddy/i18n', /* … */],
+  …
+};
+```
+
+## CI / lockfiles
+
+During the W1 → W4 transition both `pnpm-lock.yaml` (authoritative)
+and `package-lock.json` (for legacy npm-based workflows) are committed.
+After W4 we drop `package-lock.json`.
+
+If you change `package.json` deps, regenerate both locks:
+
+```bash
+pnpm install --lockfile-only
+npm install --package-lock-only --no-audit --no-fund
+git add package.json pnpm-lock.yaml package-lock.json
+```
+
+## Reviewing cross-workspace imports
+
+Imports from `packages/X` into `packages/Y` are fine if `Y` declares
+`X` in its dependencies. Imports from `packages/*` into `apps/web` are
+fine. Imports from `apps/web` **into** `packages/*` are forbidden (it
+creates a dependency cycle; W3 adds an eslint rule to enforce).
+
+## Running a single package's tests
+
+```bash
+pnpm --filter @mirrorbuddy/types run typecheck
+pnpm --filter @mirrorbuddy/types exec vitest run
+```
+
+## Troubleshooting
+
+- **`ERR_PNPM_OUTDATED_LOCKFILE`** in CI: you added a dep but didn't
+  regenerate `pnpm-lock.yaml`. Run `pnpm install` locally and commit
+  the lock.
+- **`@types/*` version conflicts** between nested workspaces: pnpm
+  hoists differently than npm. Use an `overrides` entry in root
+  `package.json` to pin the version, or add a precise cast at the
+  interop point (see `src/lib/db.ts` for the `@types/pg` example).
+- **`spawn pnpm ENOENT`** on Vercel or a GitHub runner: pnpm isn't on
+  PATH. Add `pnpm/action-setup@v4` to the workflow (see ADR 0164 and
+  PR #320 for precedent).

--- a/README.md
+++ b/README.md
@@ -221,22 +221,25 @@ MirrorBuddy implements Microsoft's [Ethical Design Hacker](https://www.microsoft
 ## Quick Start
 
 ```bash
-# Clone and install
+# Clone and install (pnpm required; see below)
 git clone https://github.com/FightTheStroke/MirrorBuddy.git
 cd MirrorBuddy
-npm install
+pnpm install      # npm install still works during W1–W3 transition
 
 # Configure environment
 cp .env.example .env
 # Edit .env with your Azure OpenAI or Ollama credentials
 
 # Initialize database
-npx prisma generate
-npx prisma migrate dev
+pnpm prisma generate
+pnpm prisma migrate dev
 
 # Start development server
-npm run dev
+pnpm dev
 ```
+
+**Prerequisites:** Node ≥ 20, pnpm ≥ 10.33.0 (pinned via the `packageManager` field).
+Turborepo handles cross-package task orchestration; `pnpm dev` / `pnpm build` / `pnpm lint` run through Turbo automatically.
 
 Open http://localhost:3000 and start learning.
 
@@ -258,14 +261,14 @@ MirrorBuddy ships as native iOS and Android apps using Capacitor, sharing the sa
 
 ```bash
 # Install Capacitor
-npm install @capacitor/cli @capacitor/core
+pnpm add @capacitor/cli @capacitor/core
 
 # Add iOS/Android platforms
-npx cap add ios
-npx cap add android
+pnpm cap add ios
+pnpm cap add android
 
 # Build for mobile
-npm run build:mobile
+pnpm build:mobile
 
 # Open native IDE to build & deploy
 npx cap open ios   # Opens Xcode
@@ -436,6 +439,7 @@ For i18n-specific incidents:
 | Database      | Prisma + PostgreSQL + pgvector             |
 | Testing       | Playwright E2E (API-focused) + Vitest unit |
 | Observability | Grafana Cloud + Prometheus metrics         |
+| Monorepo      | pnpm workspaces + Turborepo (see ADR 0164) |
 
 ---
 

--- a/docs/adr/0164-monorepo-migration-pnpm-turborepo.md
+++ b/docs/adr/0164-monorepo-migration-pnpm-turborepo.md
@@ -1,0 +1,81 @@
+# ADR 0164: Monorepo Migration (pnpm Workspaces + Turborepo)
+
+Status: Accepted | Date: 21 Apr 2026 | Plan: incremental (W1 → W4)
+
+## Context
+
+MirrorBuddy shipped as a single-package Next.js 16 repo with `src/` and
+`package-lock.json`. Two pressures forced a structural change:
+
+1. **Shared code sprawl** — FSRS logic, safety guards, AI-provider
+   adapters, maestri data, i18n helpers, UI primitives, and type
+   contracts were all living under `src/lib/` and `src/types/`. None
+   was independently versionable, testable, or extractable for the
+   upcoming iOS/mobile split.
+2. **Build orchestration ceiling** — `npm` with a flat lockfile could
+   not express cross-package task graphs; full `next build` was the
+   only CI "big hammer", even for doc-only PRs.
+
+Precedents consulted: Vercel's `turborepo-nextjs` starter, the Next.js
+docs monorepo guide (requires `transpilePackages` for internal workspace
+libraries), and several FightTheStroke-internal OSS extractions planned
+post-migration.
+
+## Decision
+
+Adopt **pnpm workspaces** + **Turborepo** as the monorepo foundation,
+rolled out incrementally in four waves so each can land behind CI gates
+without freezing main:
+
+| Wave | Scope | PRs |
+|---|---|---|
+| W1a | `pnpm-workspace.yaml`, `turbo.json`, `pnpm-lock.yaml`, `packageManager: pnpm@10.33.0` | #317 |
+| W1b | `packages/types` pilot (`@mirrorbuddy/types`) with user/content/education/gamification/learning-path, shim-preserving `src/types/` | #318 + #321 |
+| W2a | Move `public/`, `messages/`, `e2e/` → `apps/web/` | TBD |
+| W2b | Move `prisma/`, `prisma.config.ts`, add `binaryTargets = ["native", "rhel-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]` | TBD |
+| W2c | Move `src/` + next configs + sentry configs + eslint/vitest/playwright configs, add `outputFileTracingRoot`, flip Vercel Root Directory | TBD |
+| W2d | Update `scripts/*.{ts,sh}` imports + `.github/workflows` path filters | TBD |
+| W3 | Extract `packages/{db,ai-providers,safety,tools,education,i18n,ui}` | TBD |
+| W4 | Migrate CI workflows to pnpm, drop `package-lock.json`, wire Turbo task pipeline, enable remote cache | TBD |
+
+## Consequences
+
+### Positive
+
+- Hermetic package boundaries enforce `@mirrorbuddy/*` contract
+  imports; no more deep `@/lib/…` reach-in.
+- Turbo task cache avoids full rebuilds on doc PRs.
+- pnpm strict peer-deps surfaces resolution drift (regressions caught
+  in W1b: e.g. the `pnpm-lock.yaml` drift fixed by #322).
+- Vercel `transpilePackages: ['@mirrorbuddy/types']` is the minimal
+  plumbing required; the pilot has already proved it ships cleanly.
+
+### Negative / mitigations
+
+- **CI temporarily dual-locked**: W1a commits both `pnpm-lock.yaml` and
+  `package-lock.json` so existing `npm ci`-based workflows continue.
+  The dual lock lives until W4 migrates workflows to pnpm.
+- **Nested `@types/pg` drift** (surfaced by the Prisma 7.7 upgrade in
+  #323): some workspace packages ship their own `@types/*` which TS
+  treats as distinct identities. Mitigation: prefer `as never as
+  ConstructorParameters<typeof X>[0]` casts at the narrow interop
+  point until the upstream fixes it.
+- **Branch protection friction**: PRs merged with `--admin` during
+  migration (#317–#323) bypass the "REVIEW_REQUIRED" rule. Post-W4
+  we reinstate normal review flow.
+
+## Rollback strategy
+
+Each wave is self-contained; reverting the merge commit restores the
+prior state. W1 reversal is lockfile-only (no application code moved).
+W2 is the only wave where a full reverse requires re-moving files.
+
+## Enforcement
+
+- Rule: new shared code lives under `packages/` only; `apps/web/src/`
+  is the app layer, not a shared library.
+- Check: `.claude/hooks/main-guard.sh` plus lint rule
+  `local-rules/no-cross-workspace-imports` (added in W3) blocks direct
+  `apps/web/src/…` imports from `packages/*`.
+- Ref: ADR 0065 (Vercel serverless DB pool), ADR 0075 (auth),
+  ADR 0082 (i18n namespacing), this ADR.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,14 +1,88 @@
 # @mirrorbuddy/types
 
-Shared TypeScript types for the MirrorBuddy workspace.
+Shared TypeScript types for the MirrorBuddy workspace. Runtime-free;
+imports nothing from Node, React, Next.js, Prisma, or any other runtime
+dependency.
 
-## Status
+## Scope
 
-W1b pilot — currently exports user/settings types only. Additional types
-migrate in subsequent waves.
+This package is the single source of truth for domain contract types
+that cross package boundaries. If a type is consumed by only one
+package (`apps/web`), keep it local to that package. If it's shared
+— or will be shared once W3 extraction completes — it belongs here.
+
+**Allowed**: pure TypeScript `type`, `interface`, `enum`, union, and
+constant-literal exports.
+
+**Not allowed**: runtime imports (`import { ... } from 'react'`,
+`from '@prisma/client'`, etc.). The `exports` map in `package.json`
+points directly at source TS files; a runtime import would leak into
+consumers' bundles.
+
+## Exported modules
+
+| Module | Types |
+|---|---|
+| `user` | `Curriculum`, `SchoolLevel`, `StudentProfile`, `Theme`, `AIProvider`, `Settings` |
+| `content` | `Subject`, `Maestro`, `MaestroVoice` |
+| `education` | `Question`, `Quiz`, `Flashcard`, `FlashcardDeck`, `Homework`, `CardState`, `Rating`, `QuestionType`, `QuizResult`, `HomeworkStep` |
+| `gamification` | `MasteryTier`, `SubjectMastery`, `Streak`, `Achievement`, `Progress`, `Season`, `SeasonName`, `SeasonHistory`, `Grade`, `GradeType` |
+| `learning-path` | `TopicStatus`, `TopicStepType`, `TopicDifficulty`, `TopicStep`, `LearningPathTopic`, `StepContent`, `OverviewContent`, `MindmapContent`, `FlashcardContent`, `QuizContent` |
+
+(Subsequent batches add: adaptive-difficulty, audio, conversation,
+parent, parent-dashboard, tier-types, unified-chat-view, and
+characters/greeting/voice/tier-definition/tier-subscription/
+unified-chat-config-factory once their app-layer dependencies are
+refactored out.)
 
 ## Usage
 
 ```ts
-import type { Curriculum, Settings } from '@mirrorbuddy/types';
+// Preferred: import from the package
+import type { Curriculum, Settings, Flashcard } from '@mirrorbuddy/types';
+
+// Also works during W1b transition — src/types/*.ts shims re-export
+// everything from @mirrorbuddy/types so legacy @/types paths keep
+// resolving.
+import type { Flashcard } from '@/types/education';
 ```
+
+## Adding a new type
+
+1. Decide: is it shared (cross-package) or app-local? If app-local,
+   keep it in `apps/web/src/` (or `src/` during W1b). If shared,
+   continue.
+2. Add the file under `packages/types/src/<domain>.ts`. No runtime
+   imports — only `type`, `interface`, `enum`, string-literal unions.
+3. Update `packages/types/src/index.ts` to re-export the new module
+   with `export * from './<domain>';`.
+4. If an existing file in `apps/web/src/types/<domain>.ts` already
+   exists with the same content, replace its contents with the shim
+   `export * from '@mirrorbuddy/types';` to preserve `@/types/<domain>`
+   import paths throughout the app.
+5. Run `pnpm install` (regenerates pnpm-lock.yaml) then
+   `pnpm run ci:summary` to verify lint + typecheck + build pass.
+
+## Testing
+
+Runtime-free packages don't need runtime tests. When a type needs
+structural verification, add `tsd` / `expect-type` assertions
+alongside the module (e.g. `src/education.type-tests.ts`). These are
+picked up by `tsc --noEmit` as part of the standard typecheck.
+
+## Versioning
+
+Internal package — not published to npm. Version in `package.json`
+tracks contract-breaking changes so consumers can spot them during
+code review; bump the minor on additive changes and the major on
+removals or rename-in-place. No formal changelog yet — rely on git
+history via `git log packages/types/`.
+
+## Relationship to `apps/web/src/types/`
+
+During the W1b transition the original `src/types/*.ts` files live on
+as **shims** containing only `export * from '@mirrorbuddy/types';`.
+This keeps all `@/types/<name>` import paths resolving while consumers
+gradually switch to the package import. Once every consumer uses
+`@mirrorbuddy/types` directly, the shims can be deleted in a single
+PR (planned for the W2 app-move wave).


### PR DESCRIPTION
## Summary

Documentation catch-up for the monorepo migration (#317, #318, #320, #322, #323). Records the decision formally and updates developer-facing docs so `pnpm install` isn't a surprise to new contributors.

## Files

- **\`docs/adr/0164-monorepo-migration-pnpm-turborepo.md\`** — new ADR. Context, decision, W1–W4 rollout plan, consequences (dual-lockfile trade-off, nested \`@types/pg\` issue, review-required bypass), rollback strategy.
- **\`README.md\`** — Quick Start switches \`npm install\` → \`pnpm install\`. Mobile Apps section follows suit. Tech Stack table adds \"Monorepo\" row linking to ADR 0164. Prerequisites block mentions Node ≥ 20, pnpm ≥ 10.33.0.
- **\`packages/types/README.md\`** — expanded from 15-line stub to 88-line reference: scope rules (runtime-free), exported modules table, usage examples, adding-a-type workflow, versioning policy, and the shim relationship to \`src/types/\`.
- **\`CONTRIBUTING-MONOREPO.md\`** — new top-level guide. Layout diagram, common commands, per-workspace \`pnpm --filter\` syntax, creating a new package, Next.js \`transpilePackages\` rules, lockfile discipline during W1–W4 dual-lock phase, cross-workspace import rules, troubleshooting \`ERR_PNPM_OUTDATED_LOCKFILE\` / \`@types\` drift / \`spawn pnpm ENOENT\`.

## Not in this PR

- \`.claude/rules/*.md\` and nested \`CLAUDE.md\` files still reference \`src/…\` paths. Per the docs-plan agent's recommendation, those updates happen post-W2 when \`apps/web/src/\` becomes real and those paths are actually wrong.
- \`docs/claude/operations.md\` has 2 path refs to \`src/lib/observability/\` and \`src/app/api/cron/\` — also post-W2.

## Test plan

- [x] Markdown renders correctly (GitHub preview)
- [x] No code changes; ci:summary should trivially pass
- [ ] CI: Build & Lint + PR Gate required ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)