### PR TITLE
fix(docker): copy packages/ before npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@ WORKDIR /app
 RUN apk add --no-cache libc6-compat openssl
 
 # Copy package files and Prisma config
-COPY package.json package-lock.json ./
+# Monorepo: copy workspace config + packages/ so npm ci can resolve
+# workspace:* deps (added in W1b migration). Excluding prisma-lock.yaml
+# because we use package-lock.json in Docker until W4 migration completes.
+COPY package.json package-lock.json pnpm-workspace.yaml ./
+COPY packages ./packages/
 COPY prisma.config.ts ./
 COPY prisma ./prisma/
 


### PR DESCRIPTION
## Summary

Third hotfix for main-branch staging deploy. #320 fixed \`spawn pnpm ENOENT\` in the staging-deploy job. #322 synced pnpm-lock.yaml. This PR fixes the Docker Build job which surfaced next:

\`\`\`
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
ERROR: process "/bin/sh -c npm ci" did not complete successfully: exit code: 1
\`\`\`

## Cause

#322 switched \`@mirrorbuddy/types\` from \`"*"\` → \`"workspace:*"\` in the root \`package.json\`. The Docker \`deps\` stage runs \`npm ci\` but only copies \`package.json\` + \`package-lock.json\` — **not** the \`packages/\` dir or \`pnpm-workspace.yaml\`. With no workspace context, npm 10 treats \`workspace:*\` as an unknown URL scheme and errors.

## Fix

Add \`packages/\` and \`pnpm-workspace.yaml\` to the COPY step before \`npm ci\`. npm honors the \`workspaces\` field in root \`package.json\` and resolves \`@mirrorbuddy/types\` as a local symlink.

Node 20 Alpine base image already ships npm 10+ (workspace protocol support added in npm 8).

## Test plan

- [x] pre-push hooks PASS
- [ ] CI: Build & Lint + PR Gate required ✓
- [ ] CI: Docker Build job green
- [ ] Post-merge: main staging deploy green

## Follow-up

Dockerfile still uses \`npm ci\` — W4 workflow migration will switch to \`pnpm install --frozen-lockfile\` across the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)