### PR TITLE
fix(docker): enable pnpm in builder stage (unblocks staging deploy + voice fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ RUN npx prisma generate
 FROM node:20-alpine AS builder
 WORKDIR /app
 
+# Enable pnpm in builder stage too (corepack activation doesn't carry across
+# FROM boundaries in multi-stage Dockerfile)
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .


### PR DESCRIPTION
Dockerfile stage 2 fails with `pnpm: not found` — corepack enable in stage 1 doesn't carry across FROM boundaries. Docker Build failing on main since #331. Staging skipped → #336 voice 429 fix not deployed to prod. This hotfix restores the pipeline.