### PR TITLE
fix(deps): declare nanoid as direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "markmap-view": "^0.18.12",
     "mathjs": "^15.1.0",
     "mermaid": "^11.14.0",
+    "nanoid": "^5.0.0",
     "next": "^16.2.1",
     "next-intl": "^4.7.0",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       mermaid:
         specifier: ^11.14.0
         version: 11.14.0
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.9
       next:
         specifier: ^16.2.1
         version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -6684,6 +6687,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   napi-build-utils@2.0.0:
@@ -15857,6 +15865,8 @@ snapshots:
       lru.min: 1.1.4
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.9: {}
 
   napi-build-utils@2.0.0: {}
 


### PR DESCRIPTION
Docker Build on main fails with Turbopack 'Can't resolve nanoid'. 5 files import nanoid but it was only transitive — works under npm but fails under pnpm+node-linker=hoisted strict resolution. One-line fix: add nanoid ^5.0.0 to dependencies. ci:summary PASS.