### PR TITLE
fix(deps): declare @types/pg

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^20",
+    "@types/pg": "^8.15.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/uuid": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.39
+      '@types/pg':
+        specifier: ^8.15.0
+        version: 8.20.0
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -12113,7 +12116,7 @@ snapshots:
 
   '@types/pg-pool@2.0.7':
     dependencies:
-      '@types/pg': 8.15.6
+      '@types/pg': 8.20.0
 
   '@types/pg@8.15.6':
     dependencies:


### PR DESCRIPTION
Docker Build fails with 'Could not find declaration file for pg'. Add @types/pg to devDeps.