### PR TITLE
feat(monorepo): W3 extract @mirrorbuddy/tier (reversed-shim)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,7 @@ const nextConfig: NextConfig = {
     '@mirrorbuddy/education',
     '@mirrorbuddy/i18n',
     '@mirrorbuddy/utils',
+    '@mirrorbuddy/tier',
   ],
   // Enable standalone output for Docker deployment
   // Creates .next/standalone with minimal server.js for production

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "@mirrorbuddy/greeting": "workspace:*",
     "@mirrorbuddy/i18n": "workspace:*",
     "@mirrorbuddy/logger": "workspace:*",
+    "@mirrorbuddy/tier": "workspace:*",
     "@mirrorbuddy/types": "workspace:*",
     "@mirrorbuddy/utils": "workspace:*",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/tier/package.json
+++ b/packages/tier/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@mirrorbuddy/tier",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Tier/subscription service for MirrorBuddy (reversed-shim — canonical impl in src/lib/tier)",
+  "license": "Apache-2.0",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "types": "./src/server.ts",
+      "default": "./src/server.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mirrorbuddy/types": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/tier/src/index.ts
+++ b/packages/tier/src/index.ts
@@ -1,0 +1,6 @@
+// @mirrorbuddy/tier — reversed-shim entry.
+// Canonical implementation lives at src/lib/tier during W3 migration (see
+// CONTRIBUTING-MONOREPO.md §Test-arch). Tests mocking @/lib/tier paths
+// propagate transparently to consumers of @mirrorbuddy/tier because both
+// resolve to the same module identity at src/lib/tier.
+export * from '../../../src/lib/tier';

--- a/packages/tier/src/server.ts
+++ b/packages/tier/src/server.ts
@@ -1,0 +1,3 @@
+// @mirrorbuddy/tier/server — reversed-shim entry for server-only exports.
+// See ./index.ts for rationale.
+export * from '../../../src/lib/tier/server';

--- a/packages/tier/tsconfig.json
+++ b/packages/tier/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": true,
+    "declaration": false,
+    "composite": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/tier/tsconfig.json
+++ b/packages/tier/tsconfig.json
@@ -1,12 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist",
     "noEmit": true,
     "declaration": false,
     "composite": false
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../../src/lib/tier/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@mirrorbuddy/logger':
         specifier: workspace:*
         version: link:packages/logger
+      '@mirrorbuddy/tier':
+        specifier: workspace:*
+        version: link:packages/tier
       '@mirrorbuddy/types':
         specifier: workspace:*
         version: link:packages/types
@@ -437,6 +440,16 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.0.0
         version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2(esbuild@0.27.7))
+    devDependencies:
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+  packages/tier:
+    dependencies:
+      '@mirrorbuddy/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       typescript:
         specifier: ^5


### PR DESCRIPTION
## Summary

Closes #358. Adds the `@mirrorbuddy/tier` workspace entry using the **reversed-shim pattern** introduced in #365, with zero source-file moves.

## Approach

The previous partial-extraction attempt moved `tier-service` et al. into `packages/tier/src/` and kept `video-vision-{guard,usage-service}` at the app layer because their tests mocked `../tier-service` — a relative path that stopped intercepting the package-internal `./tier-service` after the move.

This PR takes the opposite approach: **nothing moves**. Canonical impl stays at `src/lib/tier/`. `packages/tier/src/{index,server}.ts` just re-export via relative path (`../../../src/lib/tier[/server]`). Result:

- Tests mocking `@/lib/db`, `@/lib/logger`, `../tier-service`, etc. keep working because the canonical modules are exactly where the tests expect them to be.
- Any future cross-package consumer that imports `@mirrorbuddy/tier` reaches the same module identity as the tests — mocks propagate transparently.
- Zero test migration churn.

## Wiring

- `packages/tier/package.json` — workspace package, exports `.` and `./server`
- `packages/tier/tsconfig.json` — extends root tsconfig
- `next.config.ts` — `transpilePackages += '@mirrorbuddy/tier'`
- root `package.json` — `@mirrorbuddy/tier: workspace:*`
- `pnpm-lock.yaml` — regenerated

## Verification

- [x] `npm run ci:summary` → ALL CLEAN (lint ✅, typecheck ✅, build ✅, unsafe-queries ✅)
- [x] `npm run i18n:check` → PASS (7046 keys × 5 locales)
- [x] `npm run test:unit -- src/lib/tier` → **137/137** ✅
- [x] `npm run test:unit` (full) → **798/802 files pass, 12029/12044 tests** — identical to pre-change baseline

## Notes

Documents the reversed-shim policy already landed in #366 / `CONTRIBUTING-MONOREPO.md` §Test-arch. Same approach will be used for the remaining W3 extractions (#356, #357, #361, #359, #360 shadcn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)