### PR TITLE
feat(monorepo): W3 extract @mirrorbuddy/safety (reversed-shim)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,7 @@ const nextConfig: NextConfig = {
     '@mirrorbuddy/i18n',
     '@mirrorbuddy/utils',
     '@mirrorbuddy/tier',
+    '@mirrorbuddy/safety',
   ],
   // Enable standalone output for Docker deployment
   // Creates .next/standalone with minimal server.js for production

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "@mirrorbuddy/greeting": "workspace:*",
     "@mirrorbuddy/i18n": "workspace:*",
     "@mirrorbuddy/logger": "workspace:*",
+    "@mirrorbuddy/safety": "workspace:*",
     "@mirrorbuddy/tier": "workspace:*",
     "@mirrorbuddy/types": "workspace:*",
     "@mirrorbuddy/utils": "workspace:*",

--- a/packages/safety/package.json
+++ b/packages/safety/package.json
@@ -23,6 +23,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@mirrorbuddy/db": "workspace:*",
+    "@mirrorbuddy/greeting": "workspace:*",
+    "@mirrorbuddy/logger": "workspace:*",
     "@mirrorbuddy/types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/safety/package.json
+++ b/packages/safety/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@mirrorbuddy/safety",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Child-safety guardrails for MirrorBuddy (reversed-shim — canonical impl in src/lib/safety)",
+  "license": "Apache-2.0",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "types": "./src/server.ts",
+      "default": "./src/server.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mirrorbuddy/types": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/safety/src/index.ts
+++ b/packages/safety/src/index.ts
@@ -1,0 +1,4 @@
+// @mirrorbuddy/safety — reversed-shim entry.
+// Canonical implementation lives at src/lib/safety during W3 migration
+// (see CONTRIBUTING-MONOREPO.md §Test-arch).
+export * from '../../../src/lib/safety';

--- a/packages/safety/src/server.ts
+++ b/packages/safety/src/server.ts
@@ -1,0 +1,3 @@
+// @mirrorbuddy/safety/server — server-only reversed-shim entry.
+// See ./index.ts for rationale.
+export * from '../../../src/lib/safety/server';

--- a/packages/safety/tsconfig.json
+++ b/packages/safety/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "composite": false
+  },
+  "include": ["src/**/*", "../../src/lib/safety/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@mirrorbuddy/logger':
         specifier: workspace:*
         version: link:packages/logger
+      '@mirrorbuddy/safety':
+        specifier: workspace:*
+        version: link:packages/safety
       '@mirrorbuddy/tier':
         specifier: workspace:*
         version: link:packages/tier
@@ -440,6 +443,16 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.0.0
         version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2(esbuild@0.27.7))
+    devDependencies:
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+  packages/safety:
+    dependencies:
+      '@mirrorbuddy/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       typescript:
         specifier: ^5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,6 +450,15 @@ importers:
 
   packages/safety:
     dependencies:
+      '@mirrorbuddy/db':
+        specifier: workspace:*
+        version: link:../db
+      '@mirrorbuddy/greeting':
+        specifier: workspace:*
+        version: link:../greeting
+      '@mirrorbuddy/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@mirrorbuddy/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Summary

Closes #356. Adds the `@mirrorbuddy/safety` workspace entry using the reversed-shim pattern established in #367.

## Approach

Nothing moves. `src/lib/safety/` remains canonical. `packages/safety/src/{index,server}.ts` re-export via relative path. The 5 safety test files that mock `@/lib/logger` keep working unchanged because safety code still imports through the logger shim, which the tests intercept. No pre-existing mock surfaces change module identity.

## Wiring

- `packages/safety/package.json` — workspace package, exports `.` and `./server`
- `packages/safety/tsconfig.json` — extends root; includes `src/**/*` and `../../src/lib/safety/**/*` so isolated `pnpm --filter … typecheck` works
- `next.config.ts` — `transpilePackages += '@mirrorbuddy/safety'`
- root `package.json` — `@mirrorbuddy/safety: workspace:*`
- `pnpm-lock.yaml` — regenerated

## Verification

- [x] `pnpm --filter @mirrorbuddy/safety typecheck` → exits 0
- [x] `npm run ci:summary` → ALL CLEAN
- [x] full unit suite: 798/802 files, 12029/12044 tests — identical to baseline
- [x] 88 safety tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)