### PR TITLE
feat(monorepo): W3 extract @mirrorbuddy/ai-providers (reversed-shim)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,7 @@ const nextConfig: NextConfig = {
     '@mirrorbuddy/utils',
     '@mirrorbuddy/tier',
     '@mirrorbuddy/safety',
+    '@mirrorbuddy/ai-providers',
   ],
   // Enable standalone output for Docker deployment
   // Creates .next/standalone with minimal server.js for production

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@anthropic-ai/sdk": "^0.73.0",
     "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
     "@capacitor/camera": "^8.0.0",
+    "@mirrorbuddy/ai-providers": "workspace:*",
     "@mirrorbuddy/db": "workspace:*",
     "@mirrorbuddy/education": "workspace:*",
     "@mirrorbuddy/greeting": "workspace:*",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@mirrorbuddy/ai-providers",
+  "version": "0.1.0",
+  "private": true,
+  "description": "AI provider adapters (Azure OpenAI, Ollama, Claude) for MirrorBuddy (reversed-shim — canonical impl in src/lib/ai/providers)",
+  "license": "Apache-2.0",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mirrorbuddy/logger": "workspace:*",
+    "@mirrorbuddy/types": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/ai-providers/src/index.ts
+++ b/packages/ai-providers/src/index.ts
@@ -1,0 +1,4 @@
+// @mirrorbuddy/ai-providers — reversed-shim entry.
+// Canonical implementation lives at src/lib/ai/providers during W3 migration
+// (see CONTRIBUTING-MONOREPO.md §Test-arch).
+export * from '../../../src/lib/ai/providers';

--- a/packages/ai-providers/tsconfig.json
+++ b/packages/ai-providers/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "composite": false
+  },
+  "include": ["src/**/*", "../../src/lib/ai/providers/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@capacitor/camera':
         specifier: ^8.0.0
         version: 8.1.0(@capacitor/core@8.3.1)
+      '@mirrorbuddy/ai-providers':
+        specifier: workspace:*
+        version: link:packages/ai-providers
       '@mirrorbuddy/db':
         specifier: workspace:*
         version: link:packages/db
@@ -384,6 +387,19 @@ importers:
       vitest:
         specifier: ^4.0.16
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/ai-providers:
+    dependencies:
+      '@mirrorbuddy/logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@mirrorbuddy/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
   packages/db:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #357. Adds `@mirrorbuddy/ai-providers` workspace entry using the reversed-shim pattern.

## Approach

Canonical impl stays at `src/lib/ai/providers/`. Package re-exports via relative path. Transitive deps (`@mirrorbuddy/logger`, `@mirrorbuddy/types`) declared upfront to keep isolated typecheck self-contained (lesson from #369).

## Consumer audit

Per issue #357 pre-requisite: `grep -rn azureChatCompletion\|aiRouter\|azureCircuitBreaker\|resetOllamaCircuitBreaker src/` — all usages resolve through `@/lib/ai/server` (the orchestration layer) and `./providers` barrel. No pre-existing consumer bugs surfaced.

## Wiring

- `packages/ai-providers/package.json` — workspace pkg with logger + types deps
- `packages/ai-providers/tsconfig.json` — include covers `src/lib/ai/providers/**/*`
- `next.config.ts` — `transpilePackages += '@mirrorbuddy/ai-providers'`
- root `package.json` — `@mirrorbuddy/ai-providers: workspace:*`

## Verification

- [x] `pnpm --filter @mirrorbuddy/ai-providers typecheck` → 0
- [x] `npm run ci:summary` → ALL CLEAN
- [x] full unit suite: 798/802 files, 12029/12044 tests — identical to baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)