### PR TITLE
feat(monorepo): W3 extract @mirrorbuddy/maestri (reversed-shim)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,7 @@ const nextConfig: NextConfig = {
     '@mirrorbuddy/tier',
     '@mirrorbuddy/safety',
     '@mirrorbuddy/ai-providers',
+    '@mirrorbuddy/maestri',
   ],
   // Enable standalone output for Docker deployment
   // Creates .next/standalone with minimal server.js for production

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@mirrorbuddy/greeting": "workspace:*",
     "@mirrorbuddy/i18n": "workspace:*",
     "@mirrorbuddy/logger": "workspace:*",
+    "@mirrorbuddy/maestri": "workspace:*",
     "@mirrorbuddy/safety": "workspace:*",
     "@mirrorbuddy/tier": "workspace:*",
     "@mirrorbuddy/types": "workspace:*",

--- a/packages/maestri/package.json
+++ b/packages/maestri/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@mirrorbuddy/maestri",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Character data (Maestri, Coach, Buddy, Amici) for MirrorBuddy (reversed-shim — canonical impl in src/data/maestri)",
+  "license": "Apache-2.0",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mirrorbuddy/greeting": "workspace:*",
+    "@mirrorbuddy/types": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/maestri/src/index.ts
+++ b/packages/maestri/src/index.ts
@@ -1,0 +1,4 @@
+// @mirrorbuddy/maestri — reversed-shim entry.
+// Canonical implementation lives at src/data/maestri during W3 migration
+// (see CONTRIBUTING-MONOREPO.md §Test-arch).
+export * from '../../../src/data/maestri';

--- a/packages/maestri/tsconfig.json
+++ b/packages/maestri/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "composite": false
+  },
+  "include": ["src/**/*", "../../src/data/maestri/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@mirrorbuddy/logger':
         specifier: workspace:*
         version: link:packages/logger
+      '@mirrorbuddy/maestri':
+        specifier: workspace:*
+        version: link:packages/maestri
       '@mirrorbuddy/safety':
         specifier: workspace:*
         version: link:packages/safety
@@ -459,6 +462,19 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.0.0
         version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2(esbuild@0.27.7))
+    devDependencies:
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+  packages/maestri:
+    dependencies:
+      '@mirrorbuddy/greeting':
+        specifier: workspace:*
+        version: link:../greeting
+      '@mirrorbuddy/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       typescript:
         specifier: ^5


### PR DESCRIPTION
## Summary

Closes #361. Adds `@mirrorbuddy/maestri` workspace entry using the reversed-shim pattern.

Canonical impl stays at `src/data/maestri/` (29 character files + `prompts/`, `mini-kb/`, `safety-guidelines*`). Package re-exports via relative path.

## Wiring

- `packages/maestri/package.json` — deps: `@mirrorbuddy/greeting`, `@mirrorbuddy/types`
- `packages/maestri/tsconfig.json` — include covers `src/data/maestri/**/*`
- `next.config.ts` — `transpilePackages += '@mirrorbuddy/maestri'`
- root `package.json` — `@mirrorbuddy/maestri: workspace:*`

## Verification

- [x] `pnpm --filter @mirrorbuddy/maestri typecheck` → 0
- [x] `npm run ci:summary` → ALL CLEAN
- [x] full unit suite: 798/802 files, 12029/12044 tests — baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)