### PR TITLE
feat(monorepo): W3 extract @mirrorbuddy/ui (PR1: shadcn primitives)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,7 @@ const nextConfig: NextConfig = {
     '@mirrorbuddy/safety',
     '@mirrorbuddy/ai-providers',
     '@mirrorbuddy/maestri',
+    '@mirrorbuddy/ui',
   ],
   // Enable standalone output for Docker deployment
   // Creates .next/standalone with minimal server.js for production

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@mirrorbuddy/safety": "workspace:*",
     "@mirrorbuddy/tier": "workspace:*",
     "@mirrorbuddy/types": "workspace:*",
+    "@mirrorbuddy/ui": "workspace:*",
     "@mirrorbuddy/utils": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.73.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@mirrorbuddy/ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "shadcn/ui primitives for MirrorBuddy (reversed-shim — canonical impl in src/components/ui)",
+  "license": "Apache-2.0",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,5 @@
+// @mirrorbuddy/ui — reversed-shim entry for shadcn UI primitives.
+// Canonical implementation lives at src/components/ui during W3 migration
+// (see CONTRIBUTING-MONOREPO.md §Test-arch). The barrel at
+// src/components/ui/index.ts aggregates per-component named exports.
+export * from '../../../src/components/ui';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "composite": false
+  },
+  "include": ["src/**/*", "../../src/components/ui/**/*"],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "../../src/components/ui/__tests__/**",
+    "../../src/components/ui/**/*.test.ts",
+    "../../src/components/ui/**/*.test.tsx"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@mirrorbuddy/types':
         specifier: workspace:*
         version: link:packages/types
+      '@mirrorbuddy/ui':
+        specifier: workspace:*
+        version: link:packages/ui
       '@mirrorbuddy/utils':
         specifier: workspace:*
         version: link:packages/utils
@@ -510,6 +513,12 @@ importers:
         version: 5.9.3
 
   packages/types:
+    devDependencies:
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+  packages/ui:
     devDependencies:
       typescript:
         specifier: ^5

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,29 @@
+// Barrel for shadcn UI primitives. Aggregates named exports from all
+// components in this directory so workspace consumers (e.g. @mirrorbuddy/ui)
+// can re-export the full set with a single statement. Per-file imports
+// (`@/components/ui/button`) keep working unchanged.
+export * from './badge';
+export * from './button';
+export * from './card';
+export * from './checkbox';
+export * from './dialog';
+export * from './dropdown-menu';
+export * from './input';
+export * from './maintenance-banner';
+export * from './monitored-image';
+export * from './page-header';
+export * from './portal';
+export * from './progress';
+export * from './select';
+export * from './skeleton';
+export * from './slider';
+export * from './spinner';
+export * from './staging-banner';
+export * from './status-badge';
+export * from './table';
+export * from './tabs';
+export * from './textarea';
+export * from './toast';
+export * from './tooltip';
+export * from './touch-target';
+export * from './user-menu-dropdown';


### PR DESCRIPTION
## Summary

Part of #360 — split into 2 PRs per request: this PR ships the shadcn UI primitives package; accessibility follows in PR2.

Adds `@mirrorbuddy/ui` workspace entry using the reversed-shim pattern. Canonical impl stays at `src/components/ui/`. To keep the package barrel a single statement, this PR also adds a barrel at `src/components/ui/index.ts` aggregating the 25 component files. Existing per-file imports (`@/components/ui/button`) keep working unchanged.

## Wiring

- `src/components/ui/index.ts` (NEW) — barrel
- `packages/ui/package.json` — workspace pkg, no runtime deps (UI primitives are self-contained Tailwind+Radix)
- `packages/ui/tsconfig.json` — includes `src/components/ui/**/*`; excludes test files (jest-dom matchers require vitest setup not loaded under isolated tsc)
- `next.config.ts` — `transpilePackages += '@mirrorbuddy/ui'`
- root `package.json` — `@mirrorbuddy/ui: workspace:*`

## Verification

- [x] `pnpm --filter @mirrorbuddy/ui typecheck` → 0
- [x] `npm run ci:summary` → ALL CLEAN
- [x] full unit suite: 798/802 files, 12029/12044 tests — baseline

## Follow-up

PR2 will add `@mirrorbuddy/accessibility` for `src/lib/accessibility`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)