### PR TITLE
feat(monorepo): W3 extract @mirrorbuddy/accessibility (PR2 of #360)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,7 @@ const nextConfig: NextConfig = {
     '@mirrorbuddy/ai-providers',
     '@mirrorbuddy/maestri',
     '@mirrorbuddy/ui',
+    '@mirrorbuddy/accessibility',
   ],
   // Enable standalone output for Docker deployment
   // Creates .next/standalone with minimal server.js for production

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@anthropic-ai/sdk": "^0.73.0",
     "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
     "@capacitor/camera": "^8.0.0",
+    "@mirrorbuddy/accessibility": "workspace:*",
     "@mirrorbuddy/ai-providers": "workspace:*",
     "@mirrorbuddy/db": "workspace:*",
     "@mirrorbuddy/education": "workspace:*",

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@mirrorbuddy/accessibility",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Accessibility store + helpers (DSA profiles, ADHD session) for MirrorBuddy (reversed-shim — canonical impl in src/lib/accessibility)",
+  "license": "Apache-2.0",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mirrorbuddy/types": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/accessibility/src/index.ts
+++ b/packages/accessibility/src/index.ts
@@ -1,0 +1,4 @@
+// @mirrorbuddy/accessibility — reversed-shim entry.
+// Canonical implementation lives at src/lib/accessibility during W3 migration
+// (see CONTRIBUTING-MONOREPO.md §Test-arch).
+export * from '../../../src/lib/accessibility';

--- a/packages/accessibility/tsconfig.json
+++ b/packages/accessibility/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "composite": false
+  },
+  "include": ["src/**/*", "../../src/lib/accessibility/**/*"],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "../../src/lib/accessibility/__tests__/**",
+    "../../src/lib/accessibility/**/*.test.ts",
+    "../../src/lib/accessibility/**/*.test.tsx"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@capacitor/camera':
         specifier: ^8.0.0
         version: 8.1.0(@capacitor/core@8.3.1)
+      '@mirrorbuddy/accessibility':
+        specifier: workspace:*
+        version: link:packages/accessibility
       '@mirrorbuddy/ai-providers':
         specifier: workspace:*
         version: link:packages/ai-providers
@@ -393,6 +396,16 @@ importers:
       vitest:
         specifier: ^4.0.16
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/accessibility:
+    dependencies:
+      '@mirrorbuddy/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
   packages/ai-providers:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #360 (PR1 was #374 shadcn ui). Adds `@mirrorbuddy/accessibility` workspace entry using the reversed-shim pattern.

Canonical impl stays at `src/lib/accessibility/` (7 DSA profiles store, ADHD session helpers, a11y telemetry, browser detection).

## Wiring

- `packages/accessibility/package.json` — single dep `@mirrorbuddy/types`
- `packages/accessibility/tsconfig.json` — includes `src/lib/accessibility/**/*`; excludes test files
- `next.config.ts` — `transpilePackages += '@mirrorbuddy/accessibility'`
- root `package.json` — `@mirrorbuddy/accessibility: workspace:*`

## Verification

- [x] `pnpm --filter @mirrorbuddy/accessibility typecheck` → 0
- [x] `npm run ci:summary` → ALL CLEAN
- [x] full unit suite: 798/802 files, 12029/12044 tests — baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)