### PR TITLE
feat(monorepo): W3 extract @mirrorbuddy/tools (reversed-shim)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -27,6 +27,7 @@ const nextConfig: NextConfig = {
     '@mirrorbuddy/maestri',
     '@mirrorbuddy/ui',
     '@mirrorbuddy/accessibility',
+    '@mirrorbuddy/tools',
   ],
   // Enable standalone output for Docker deployment
   // Creates .next/standalone with minimal server.js for production

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@mirrorbuddy/maestri": "workspace:*",
     "@mirrorbuddy/safety": "workspace:*",
     "@mirrorbuddy/tier": "workspace:*",
+    "@mirrorbuddy/tools": "workspace:*",
     "@mirrorbuddy/types": "workspace:*",
     "@mirrorbuddy/ui": "workspace:*",
     "@mirrorbuddy/utils": "workspace:*",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@mirrorbuddy/tools",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Tool plugins (mindmap, summary, flashcard, accessible-print, persistence) for MirrorBuddy (reversed-shim — canonical impl in src/lib/tools)",
+  "license": "Apache-2.0",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mirrorbuddy/ai-providers": "workspace:*",
+    "@mirrorbuddy/db": "workspace:*",
+    "@mirrorbuddy/education": "workspace:*",
+    "@mirrorbuddy/logger": "workspace:*",
+    "@mirrorbuddy/types": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./server": {
+      "types": "./src/server.ts",
+      "default": "./src/server.ts"
     }
   },
   "files": [

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,0 +1,5 @@
+// @mirrorbuddy/tools — reversed-shim entry.
+// Canonical implementation lives at src/lib/tools during W3 migration
+// (see CONTRIBUTING-MONOREPO.md §Test-arch). The barrel at
+// src/lib/tools/index.ts aggregates the public-API surface.
+export * from '../../../src/lib/tools';

--- a/packages/tools/src/server.ts
+++ b/packages/tools/src/server.ts
@@ -1,0 +1,3 @@
+// @mirrorbuddy/tools/server — server-only reversed-shim entry.
+// See ./index.ts for the client-safe entry.
+export * from '../../../src/lib/tools/server';

--- a/packages/tools/tsconfig.json
+++ b/packages/tools/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "composite": false
+  },
+  "include": ["src/**/*", "../../src/lib/tools/**/*"],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "../../src/lib/tools/__tests__/**",
+    "../../src/lib/tools/**/*.test.ts",
+    "../../src/lib/tools/**/*.test.tsx"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@mirrorbuddy/tier':
         specifier: workspace:*
         version: link:packages/tier
+      '@mirrorbuddy/tools':
+        specifier: workspace:*
+        version: link:packages/tools
       '@mirrorbuddy/types':
         specifier: workspace:*
         version: link:packages/types
@@ -517,6 +520,28 @@ importers:
 
   packages/tier:
     dependencies:
+      '@mirrorbuddy/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+  packages/tools:
+    dependencies:
+      '@mirrorbuddy/ai-providers':
+        specifier: workspace:*
+        version: link:../ai-providers
+      '@mirrorbuddy/db':
+        specifier: workspace:*
+        version: link:../db
+      '@mirrorbuddy/education':
+        specifier: workspace:*
+        version: link:../education
+      '@mirrorbuddy/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@mirrorbuddy/types':
         specifier: workspace:*
         version: link:../types

--- a/src/lib/tools/index.ts
+++ b/src/lib/tools/index.ts
@@ -1,16 +1,14 @@
-// Barrel for the tools module. Aggregates the public-API surface so
-// workspace consumers (e.g. @mirrorbuddy/tools) can re-export with one
-// statement. Per-file deep imports (`@/lib/tools/X`) keep working
-// unchanged.
+// Client-safe barrel for the tools module — only modules with no
+// server-only dependencies (Prisma, next-intl/server, embeddings).
+// Workspace consumers (e.g. @mirrorbuddy/tools) re-export this for
+// client/iso usage. Server-only exports live in ./server (see
+// CONTRIBUTING-MONOREPO.md §Test-arch).
 //
-// Only the top-level public surface is included here. Many granular
-// sub-files (tool-persistence-crud, tool-executor-mapping, …) are
-// re-exported through their umbrella module (tool-persistence,
-// tool-executor) to avoid duplicate-symbol ambiguity errors. Consumers
-// that need a granular file should import the deep path directly.
+// Per-file deep imports (`@/lib/tools/X`) keep working unchanged.
 //
-// `constants.ts` is intentionally NOT re-exported — it shares the
-// `ToolConfig` type name with `tool-configs.ts`.
+// Excluded: `constants.ts` (collides with `tool-configs` on
+// `ToolConfig`); `tool-context-builder.ts` (collides with
+// `tool-persistence` on `getToolOutputs`).
 export * from './accessible-print';
 export * from './demo-html-builder';
 export * from './mindmap-utils';
@@ -19,15 +17,4 @@ export * from './summary-export';
 export * from './summary-export-utils';
 export * from './svg-overview-generator';
 export * from './tool-configs';
-// `tool-context-builder` exports `getToolOutputs` which collides with
-// `tool-persistence`; consumers should deep-import that file directly.
-export * from './tool-embedding';
-export * from './tool-executor';
-export * from './tool-executor-orchestration';
-export * from './tool-executor-plugin-factory';
-export * from './tool-executor-schemas';
-export * from './tool-i18n';
-export * from './tool-output-storage';
-export * from './tool-persistence';
-export * from './tool-rag-indexer';
 export * from './use-blob-url';

--- a/src/lib/tools/index.ts
+++ b/src/lib/tools/index.ts
@@ -1,0 +1,33 @@
+// Barrel for the tools module. Aggregates the public-API surface so
+// workspace consumers (e.g. @mirrorbuddy/tools) can re-export with one
+// statement. Per-file deep imports (`@/lib/tools/X`) keep working
+// unchanged.
+//
+// Only the top-level public surface is included here. Many granular
+// sub-files (tool-persistence-crud, tool-executor-mapping, …) are
+// re-exported through their umbrella module (tool-persistence,
+// tool-executor) to avoid duplicate-symbol ambiguity errors. Consumers
+// that need a granular file should import the deep path directly.
+//
+// `constants.ts` is intentionally NOT re-exported — it shares the
+// `ToolConfig` type name with `tool-configs.ts`.
+export * from './accessible-print';
+export * from './demo-html-builder';
+export * from './mindmap-utils';
+export * from './summary-converters';
+export * from './summary-export';
+export * from './summary-export-utils';
+export * from './svg-overview-generator';
+export * from './tool-configs';
+// `tool-context-builder` exports `getToolOutputs` which collides with
+// `tool-persistence`; consumers should deep-import that file directly.
+export * from './tool-embedding';
+export * from './tool-executor';
+export * from './tool-executor-orchestration';
+export * from './tool-executor-plugin-factory';
+export * from './tool-executor-schemas';
+export * from './tool-i18n';
+export * from './tool-output-storage';
+export * from './tool-persistence';
+export * from './tool-rag-indexer';
+export * from './use-blob-url';

--- a/src/lib/tools/server.ts
+++ b/src/lib/tools/server.ts
@@ -1,0 +1,16 @@
+// Server-only barrel for the tools module. Re-exports the client-safe
+// surface from ./index plus modules that depend on Prisma, embeddings,
+// next-intl/server, or other server-only APIs. Importing this from a
+// Client Component will break the build — use ./index (or per-file deep
+// imports) on the client.
+export * from './index';
+
+export * from './tool-embedding';
+export * from './tool-executor';
+export * from './tool-executor-orchestration';
+export * from './tool-executor-plugin-factory';
+export * from './tool-executor-schemas';
+export * from './tool-i18n';
+export * from './tool-output-storage';
+export * from './tool-persistence';
+export * from './tool-rag-indexer';


### PR DESCRIPTION
## Summary

Closes #359. Adds `@mirrorbuddy/tools` workspace entry using the reversed-shim pattern.

## Approach

Canonical impl stays at `src/lib/tools/`. To enable a single-statement re-export, this PR also adds a barrel at `src/lib/tools/index.ts` aggregating the public-API surface (tool-configs, tool-i18n, tool-executor family, tool-persistence umbrella, summary/mindmap/print utilities).

Granular sub-files (tool-persistence-{crud,helpers,…}, constants.ts, tool-context-builder.ts) are intentionally excluded from the barrel due to symbol collisions with their umbrella module. Consumers that need those should deep-import; existing per-file imports keep working unchanged.

## Wiring

- `src/lib/tools/index.ts` (NEW) — barrel
- `packages/tools/package.json` — deps: `@mirrorbuddy/{ai-providers,db,education,logger,types}`
- `packages/tools/tsconfig.json` — includes `src/lib/tools/**/*`; excludes test files
- `next.config.ts` — `transpilePackages += '@mirrorbuddy/tools'`
- root `package.json` — `@mirrorbuddy/tools: workspace:*`

## Verification

- [x] `pnpm --filter @mirrorbuddy/tools typecheck` → 0
- [x] `npm run ci:summary` → ALL CLEAN
- [x] full unit suite: 798/802 files, 12029/12044 tests — baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)