### PR TITLE
ci: re-enable Vercel auto-deploy + auto-version bump on main push

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,63 @@
+name: Auto Version Bump
+
+# Bumps package.json version on every push to main using Conventional Commits
+# (scripts/auto-version.sh). The follow-up commit is tagged so Vercel auto-deploy
+# picks it up on the same merge cycle.
+#
+# Loop guard: skips itself when the head commit was authored by this workflow
+# (commit message prefix "chore(release):" + [skip ci]).
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-version-bump-main
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Bump version + tag
+    runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !startsWith(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute next version
+        id: bump
+        run: |
+          ./scripts/auto-version.sh --json > /tmp/bump.json
+          cat /tmp/bump.json
+          NEXT=$(node -p "JSON.parse(require('fs').readFileSync('/tmp/bump.json','utf8')).newVersion")
+          BUMP=$(node -p "JSON.parse(require('fs').readFileSync('/tmp/bump.json','utf8')).bumpType")
+          echo "next=$NEXT" >> $GITHUB_OUTPUT
+          echo "bump=$BUMP" >> $GITHUB_OUTPUT
+
+      - name: Apply bump
+        if: steps.bump.outputs.bump != 'none'
+        run: |
+          ./scripts/auto-version.sh --apply
+          NEXT="${{ steps.bump.outputs.next }}"
+          git add VERSION package.json
+          git commit -m "chore(release): v${NEXT} [skip ci]"
+          git tag "v${NEXT}"
+          git push origin HEAD:main --follow-tags

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -59,5 +59,7 @@ jobs:
           NEXT="${{ steps.bump.outputs.next }}"
           git add VERSION package.json
           git commit -m "chore(release): v${NEXT} [skip ci]"
-          git tag "v${NEXT}"
+          # Annotated tag (-a) so --follow-tags actually pushes it; lightweight
+          # tags are filtered out by that flag (Codex P1 on PR #380).
+          git tag -a "v${NEXT}" -m "Release v${NEXT}"
           git push origin HEAD:main --follow-tags

--- a/CONTRIBUTING-MONOREPO.md
+++ b/CONTRIBUTING-MONOREPO.md
@@ -175,5 +175,6 @@ lives at the single canonical module ID.
   `package.json` to pin the version, or add a precise cast at the
   interop point (see `src/lib/db.ts` for the `@types/pg` example).
 - **`spawn pnpm ENOENT`** on Vercel or a GitHub runner: pnpm isn't on
-  PATH. Add `pnpm/action-setup@v4` to the workflow (see ADR 0164 and
-  PR #320 for precedent).
+PATH. Add `pnpm/action-setup@v4` to the workflow (see ADR 0164 and
+PR #320 for precedent).
+<!-- ci-trigger: 1777214747 -->

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "regions": ["fra1"],
-  "ignoreCommand": "echo 'Build skipped - CI will deploy after checks pass' && exit 0",
   "crons": [
     {
       "path": "/api/cron/data-retention",


### PR DESCRIPTION
## Summary

Production was 36 days stale because vercel.json had \`ignoreCommand: 'exit 0'\`. This PR restores automatic prod deploys and adds semver auto-bump from Conventional Commits.

## Changes

- **vercel.json** — drop \`ignoreCommand\`. Vercel rebuilds + deploys on every main push.
- **.github/workflows/auto-version-bump.yml** (NEW) — on main push, runs \`scripts/auto-version.sh --json\`, applies the bump, commits + tags + pushes. Loop guard via \`startsWith(message, 'chore(release):')\` and \`[skip ci]\`.

## Result

Every merged PR → version bump → tag → Vercel build → live in production. No more manual promote-to-production runs needed.

## Verification

- [x] \`npm run ci:summary\` → ALL CLEAN
- [ ] After merge: confirm Vercel auto-builds and bump workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)