### PR TITLE
fix(sentry): silence Failed-to-save-material noise (MIRRORBUDDY-1P/1R)

### DIFF
--- a/apps/web/src/lib/hooks/use-saved-materials/utils/api.ts
+++ b/apps/web/src/lib/hooks/use-saved-materials/utils/api.ts
@@ -8,13 +8,31 @@ import type { ToolType } from '@/types/tools';
 import type { SavedMaterial } from '../types';
 import { csrfFetch } from '@/lib/auth';
 
-export async function fetchMaterials(
-  toolType: ToolType,
-  userId: string
-): Promise<SavedMaterial[]> {
+function isTransientNetworkError(error: unknown): boolean {
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return true;
+  }
+  if (error instanceof Error) {
+    return error.name === 'AbortError' || error.name === 'TimeoutError';
+  }
+  return false;
+}
+
+function toError(error: unknown, fallbackMessage: string): Error {
+  if (error instanceof Error) return error;
+  if (error === undefined || error === null) return new Error(fallbackMessage);
+  if (typeof error === 'string') return new Error(`${fallbackMessage}: ${error}`);
+  try {
+    return new Error(`${fallbackMessage}: ${JSON.stringify(error).slice(0, 500)}`);
+  } catch {
+    return new Error(`${fallbackMessage}: ${String(error)}`);
+  }
+}
+
+export async function fetchMaterials(toolType: ToolType, userId: string): Promise<SavedMaterial[]> {
   try {
     const response = await fetch(
-      `/api/materials?userId=${userId}&toolType=${toolType}&status=active`
+      `/api/materials?userId=${userId}&toolType=${toolType}&status=active`,
     );
     if (!response.ok) {
       throw new Error(`API error: ${response.status}`);
@@ -36,7 +54,7 @@ export async function saveMaterialToAPI(
     subject?: string;
     maestroId?: string;
     preview?: string;
-  }
+  },
 ): Promise<SavedMaterial | null> {
   try {
     const toolId = crypto.randomUUID();
@@ -57,7 +75,19 @@ export async function saveMaterialToAPI(
     const data = await response.json();
     return data.material;
   } catch (error) {
-    logger.error('Failed to save material', { toolType, title }, error);
+    if (isTransientNetworkError(error)) {
+      logger.debug('Save material aborted (transient network)', {
+        toolType,
+        title,
+        errorName: error instanceof Error ? error.name : typeof error,
+      });
+      return null;
+    }
+    logger.error(
+      'Failed to save material',
+      { toolType, title },
+      toError(error, 'Failed to save material'),
+    );
     return null;
   }
 }
@@ -77,7 +107,7 @@ export async function deleteMaterialFromAPI(toolId: string): Promise<boolean> {
 export async function updateMaterialInAPI(
   toolId: string,
   content: Record<string, unknown>,
-  title?: string
+  title?: string,
 ): Promise<boolean> {
   try {
     const response = await csrfFetch('/api/materials', {
@@ -94,7 +124,7 @@ export async function updateMaterialInAPI(
 export function generateContentHash(
   toolType: string,
   title: string,
-  content: Record<string, unknown>
+  content: Record<string, unknown>,
 ): string {
   const str = `${toolType}-${title}-${JSON.stringify(content)}`;
   let hash = 0;
@@ -112,7 +142,7 @@ export async function saveMaterialToAPIWithId(
   toolType: ToolType,
   title: string,
   content: Record<string, unknown>,
-  options?: { subject?: string; maestroId?: string; preview?: string }
+  options?: { subject?: string; maestroId?: string; preview?: string },
 ): Promise<SavedMaterial | null> {
   try {
     const requestBody = {
@@ -138,7 +168,7 @@ export async function saveMaterialToAPIWithId(
         const text = await response.text().catch(() => '');
         errorData = { message: text || `HTTP ${response.status}` };
       }
-      
+
       const errorMessage = `API error: ${response.status} - ${JSON.stringify(errorData)}`;
       logger.error('Failed to save material - API error', {
         errorDetails: errorMessage,
@@ -162,24 +192,34 @@ export async function saveMaterialToAPIWithId(
       });
       return null;
     }
-    
+
     return data.material;
   } catch (error) {
-    const errorMessage = error instanceof Error 
-      ? error.message 
-      : typeof error === 'string' 
-        ? error 
-        : String(error);
-    
-    logger.error('Failed to save material', {
-      errorDetails: errorMessage || 'Unknown error',
-      toolType: toolType || 'unknown',
-      title: title || 'untitled',
-      userId: userId || 'unknown',
-      toolId: toolId || 'unknown',
-      errorType: error instanceof Error ? error.constructor.name : typeof error,
-    });
+    if (isTransientNetworkError(error)) {
+      logger.debug('Save material aborted (transient network)', {
+        toolType,
+        title,
+        toolId,
+        errorName: error instanceof Error ? error.name : typeof error,
+      });
+      return null;
+    }
+
+    const errorMessage =
+      error instanceof Error ? error.message : typeof error === 'string' ? error : String(error);
+
+    logger.error(
+      'Failed to save material',
+      {
+        errorDetails: errorMessage || 'Unknown error',
+        toolType: toolType || 'unknown',
+        title: title || 'untitled',
+        userId: userId || 'unknown',
+        toolId: toolId || 'unknown',
+        errorType: error instanceof Error ? error.constructor.name : typeof error,
+      },
+      toError(error, 'Failed to save material'),
+    );
     return null;
   }
 }
-

--- a/apps/web/src/lib/hooks/use-saved-materials/utils/api.ts
+++ b/apps/web/src/lib/hooks/use-saved-materials/utils/api.ts
@@ -164,23 +164,16 @@ export async function saveMaterialToAPIWithId(
       try {
         errorData = await response.json();
       } catch {
-        // If response is not JSON, try to get text
         const text = await response.text().catch(() => '');
         errorData = { message: text || `HTTP ${response.status}` };
       }
 
-      const errorMessage = `API error: ${response.status} - ${JSON.stringify(errorData)}`;
-      logger.error('Failed to save material - API error', {
-        errorDetails: errorMessage,
-        status: response.status,
-        statusText: response.statusText,
-        toolType,
-        title,
-        userId,
-        toolId,
-        errorData,
-      });
-      throw new Error(errorMessage);
+      const apiError = new Error(
+        `API error: ${response.status} - ${JSON.stringify(errorData)}`,
+      ) as Error & { status?: number; errorData?: Record<string, unknown> };
+      apiError.status = response.status;
+      apiError.errorData = errorData;
+      throw apiError;
     }
 
     const data = await response.json();
@@ -205,6 +198,17 @@ export async function saveMaterialToAPIWithId(
       return null;
     }
 
+    const status = (error as { status?: number } | null)?.status;
+    if (status === 401 || status === 403) {
+      logger.warn('Save material denied (auth)', {
+        status,
+        toolType,
+        title,
+        toolId,
+      });
+      return null;
+    }
+
     const errorMessage =
       error instanceof Error ? error.message : typeof error === 'string' ? error : String(error);
 
@@ -212,6 +216,7 @@ export async function saveMaterialToAPIWithId(
       'Failed to save material',
       {
         errorDetails: errorMessage || 'Unknown error',
+        status,
         toolType: toolType || 'unknown',
         title: title || 'untitled',
         userId: userId || 'unknown',

--- a/packages/logger/src/client.ts
+++ b/packages/logger/src/client.ts
@@ -59,7 +59,24 @@ function sanitizeContext(context?: ClientLogContext): ClientLogContext | undefin
  * Send error to Sentry
  */
 function captureError(message: string, context?: ClientLogContext, error?: unknown): void {
-  const errorToCapture = error instanceof Error ? error : new Error(message);
+  let errorToCapture: Error;
+  if (error instanceof Error) {
+    errorToCapture = error;
+  } else if (error === undefined || error === null) {
+    errorToCapture = new Error(message);
+  } else {
+    let serialized: string;
+    if (typeof error === 'string') {
+      serialized = error;
+    } else {
+      try {
+        serialized = JSON.stringify(error).slice(0, 500);
+      } catch {
+        serialized = String(error);
+      }
+    }
+    errorToCapture = new Error(`${message}: ${serialized}`);
+  }
   const sanitizedContext = sanitizeContext(context);
 
   if (isProduction) {


### PR DESCRIPTION
## Summary

Two production Sentry issues (`MIRRORBUDDY-1P`, `MIRRORBUDDY-1R`) firing as `Error: Failed to save material[ - API error]` with a useless 2-frame stack (minified `Y → c`) — the stack came from the client logger itself, not the call site.

**Root cause** — `packages/logger/src/client.ts` fabricated `new Error(message)` whenever the caller didn't pass an `Error` as the third arg. `saveMaterialToAPIWithId` was the offender:
- Outer catch logged with no `error` arg (1P)
- Inner `logger.error('Failed to save material - API error', ...)` fired before the `throw`, also with no `error` arg (1R) — duplicating the noise

**Fix** (2 commits):

1. `5d1a3b5` — Pass the original error through to the logger in both save helpers. Skip Sentry capture for transient cases (`AbortError`/offline) — expected on mobile when the user navigates mid-save. Improve the client-logger fallback so synthetic Errors include the stringified original.
2. `334a810` — Drop the redundant inner log in `saveMaterialToAPIWithId`; attach `status` + `errorData` onto the thrown Error so the outer catch surfaces real context. Skip Sentry for 401/403 (auth-gated tools like `?tool=pdf` for trial users), log as `warn` so they're still in observability.

After this, save failures hitting Sentry will have:
- The actual call-site stack
- The real Error message (`API error: 4xx - {...}`) instead of the literal "Failed to save material"
- `status` in the context
- No noise from auth-gated tools or page-unload aborts

## Test plan

- [x] `npm run ci:summary` — lint WARN (185 pre-existing), typecheck PASS, build PASS, unsafe-queries PASS
- [x] `npm run test:unit` — 11939 passed, 15 skipped, 0 failed
- [x] Pre-push hook — Prisma fresh + production build PASS (240s + 173s)
- [ ] Verify in Vercel preview that `/it/maestri/erodoto?tool=demo` and `?tool=pdf` save flows still work end-to-end
- [ ] After merge: monitor Sentry to confirm `MIRRORBUDDY-1P/1R` stop reoccurring under the same fingerprint

https://claude.ai/code/session_01KtTR2GArtvAiE76UXU6JAB