### PR TITLE
fix(voice): cancel in-flight response on maestro switch to prevent voice overlap

### DIFF
--- a/apps/web/src/lib/hooks/voice-session/actions.ts
+++ b/apps/web/src/lib/hooks/voice-session/actions.ts
@@ -76,42 +76,52 @@ export function useSendText(
 }
 
 /**
+ * Cancel the active assistant response and flush any locally buffered audio.
+ *
+ * Pure helper (not a hook) so callers like character switching can run the
+ * same teardown without depending on the React `useCallback` returned by
+ * `useCancelResponse`.
+ */
+export function performCancelResponse(
+  refs: ActionRefs,
+  setSpeaking: (value: boolean) => void,
+): void {
+  if (refs.hasActiveResponseRef.current) {
+    logger.debug('[VoiceSession] Cancelling active response');
+
+    if (refs.webrtcDataChannelRef.current?.readyState === 'open') {
+      refs.webrtcDataChannelRef.current.send(JSON.stringify({ type: 'response.cancel' }));
+      logger.debug('[VoiceSession] Sent response.cancel via WebRTC data channel');
+    }
+
+    refs.hasActiveResponseRef.current = false;
+  }
+
+  if (refs.webrtcAudioElementRef.current) {
+    refs.webrtcAudioElementRef.current.pause();
+    logger.debug('[VoiceSession] WebRTC audio element paused');
+  }
+
+  refs.audioQueueRef.current.clear();
+  refs.isPlayingRef.current = false;
+  refs.isBufferingRef.current = true;
+  refs.scheduledSourcesRef.current.forEach((source) => {
+    try {
+      source.stop();
+    } catch {
+      /* already stopped */
+    }
+  });
+  refs.scheduledSourcesRef.current.clear();
+  setSpeaking(false);
+}
+
+/**
  * Cancel current AI response and clear audio queue
  */
 export function useCancelResponse(refs: ActionRefs, setSpeaking: (value: boolean) => void) {
   return useCallback(() => {
-    // Only send response.cancel if Azure actually has an active response
-    if (refs.hasActiveResponseRef.current) {
-      logger.debug('[VoiceSession] Cancelling active response');
-
-      if (refs.webrtcDataChannelRef.current?.readyState === 'open') {
-        refs.webrtcDataChannelRef.current.send(JSON.stringify({ type: 'response.cancel' }));
-        logger.debug('[VoiceSession] Sent response.cancel via WebRTC data channel');
-      }
-
-      // eslint-disable-next-line react-hooks/immutability -- Intentional ref mutation
-      refs.hasActiveResponseRef.current = false;
-    }
-
-    // Pause WebRTC audio element if present
-    if (refs.webrtcAudioElementRef.current) {
-      refs.webrtcAudioElementRef.current.pause();
-      logger.debug('[VoiceSession] WebRTC audio element paused');
-    }
-
-    // Always clear local audio queue and stop scheduled sources
-    refs.audioQueueRef.current.clear();
-    refs.isPlayingRef.current = false;
-    refs.isBufferingRef.current = true;
-    refs.scheduledSourcesRef.current.forEach((source) => {
-      try {
-        source.stop();
-      } catch {
-        /* already stopped */
-      }
-    });
-    refs.scheduledSourcesRef.current.clear();
-    setSpeaking(false);
+    performCancelResponse(refs, setSpeaking);
   }, [refs, setSpeaking]);
 }
 

--- a/apps/web/src/lib/hooks/voice-session/switch-character.test.ts
+++ b/apps/web/src/lib/hooks/voice-session/switch-character.test.ts
@@ -71,14 +71,21 @@ describe('useSwitchCharacter hook', () => {
 
     const deps = {
       webrtcDataChannelRef: { current: null },
+      webrtcAudioElementRef: { current: null },
+      audioQueueRef: { current: { clear: vi.fn() } },
+      isPlayingRef: { current: false },
+      isBufferingRef: { current: false },
+      scheduledSourcesRef: { current: new Set() },
+      hasActiveResponseRef: { current: false },
       maestroRef: { current: null },
       greetingSentRef: { current: false },
       sessionReadyRef: { current: false },
       sendSessionConfigRef: { current: null },
       switchCharacterStore: vi.fn(),
+      setSpeaking: vi.fn(),
     };
 
-    const switchFn = useSwitchCharacter(deps);
+    const switchFn = useSwitchCharacter(deps as never);
     const result = switchFn({
       id: 'test',
       name: 'Test',

--- a/apps/web/src/lib/hooks/voice-session/switch-character.ts
+++ b/apps/web/src/lib/hooks/voice-session/switch-character.ts
@@ -9,14 +9,15 @@
 import { useCallback } from 'react';
 import { clientLogger as logger } from '@/lib/logger/client';
 import type { Maestro } from '@/types';
+import { performCancelResponse, type ActionRefs } from './actions';
 
-interface SwitchCharacterDeps {
-  webrtcDataChannelRef: React.MutableRefObject<RTCDataChannel | null>;
+interface SwitchCharacterDeps extends ActionRefs {
   maestroRef: React.MutableRefObject<Maestro | null>;
   greetingSentRef: React.MutableRefObject<boolean>;
   sessionReadyRef: React.MutableRefObject<boolean>;
   sendSessionConfigRef: React.MutableRefObject<(() => void) | null>;
   switchCharacterStore: (maestro: Maestro) => void;
+  setSpeaking: (value: boolean) => void;
 }
 
 /**
@@ -39,17 +40,19 @@ export function useSwitchCharacter(deps: SwitchCharacterDeps) {
         to: maestro.id,
       });
 
-      // Update refs for the new character
+      // Cancel any in-flight response from the previous maestro and flush
+      // buffered audio. Without this, Azure keeps streaming the old voice's
+      // audio frames into the same WebRTC remote track while the new
+      // session.update provokes a second response, and the two voices overlap.
+      performCancelResponse(deps, deps.setSpeaking);
+
       // eslint-disable-next-line react-hooks/immutability -- Intentional ref mutation for character switch
       deps.maestroRef.current = maestro;
       deps.greetingSentRef.current = false;
       deps.sessionReadyRef.current = false;
 
-      // Update store (clears transcript/tools, keeps connection)
       deps.switchCharacterStore(maestro);
 
-      // Re-send session config via existing data channel
-      // This triggers useSendSessionConfig which builds new instructions
       if (deps.sendSessionConfigRef.current) {
         deps.sendSessionConfigRef.current();
       }

--- a/apps/web/src/lib/hooks/voice-session/use-voice-session.ts
+++ b/apps/web/src/lib/hooks/voice-session/use-voice-session.ts
@@ -191,11 +191,18 @@ export function useVoiceSession(options: UseVoiceSessionOptions = {}) {
   const disconnect = useDisconnect(connectionRefs, store.reset, setConnectionState);
   const switchCharacter = useSwitchCharacter({
     webrtcDataChannelRef: refs.webrtcDataChannelRef,
+    webrtcAudioElementRef: refs.webrtcAudioElementRef,
+    audioQueueRef: refs.audioQueueRef,
+    isPlayingRef: refs.isPlayingRef,
+    isBufferingRef: refs.isBufferingRef,
+    scheduledSourcesRef: refs.scheduledSourcesRef,
+    hasActiveResponseRef: refs.hasActiveResponseRef,
     maestroRef: refs.maestroRef,
     greetingSentRef: refs.greetingSentRef,
     sessionReadyRef: refs.sessionReadyRef,
     sendSessionConfigRef: refs.sendSessionConfigRef,
     switchCharacterStore: store.switchCharacter,
+    setSpeaking: store.setSpeaking,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Production bug: while a student talked with a maestro over voice, sometimes a second voice (different maestro or duplicate of the same one) started speaking on top — voices overlapped.

**Root cause** — `useSwitchCharacter` (`apps/web/src/lib/hooks/voice-session/switch-character.ts`) only sent `session.update` with the new character config. It did **not** cancel any in-flight response from the previous maestro nor flush the local audio pipeline. Azure kept streaming the previous response's audio frames into the same WebRTC remote track while the new `session.update` provoked a fresh response with a different voice — both played simultaneously.

The teardown logic was already implemented inside `useCancelResponse` (`actions.ts`) — barge-in, safety intervention and `disconnect()` all use it — but `useSwitchCharacter` was missing the call.

## Fix

- Extract `performCancelResponse(refs, setSpeaking)` from `useCancelResponse` as a non-hook helper so non-React callers can reuse it.
- Call it from `useSwitchCharacter` *before* re-sending session config:
  - `response.cancel` over the data channel (only if `hasActiveResponseRef`)
  - Pause `webrtcAudioElementRef`
  - Clear `audioQueueRef`
  - Stop & clear scheduled `AudioBufferSourceNode`s
  - Reset `hasActiveResponseRef`, `isPlayingRef`, `isBufferingRef`
  - `setSpeaking(false)`
- Extend `SwitchCharacterDeps` with `ActionRefs` + `setSpeaking`; wire through in `use-voice-session.ts`.
- Bump test deps in `switch-character.test.ts` for the extended type.

After this, switching maestro mid-response cleanly stops the old voice before the new one starts.

## Test plan

- [x] `npm run ci:summary` — lint WARN (185 pre-existing, no new), typecheck PASS, build PASS, unsafe-queries PASS
- [x] `npm run test:unit -- voice-session` — 38 files / 354 tests PASS
- [x] `npm run test:unit` — 11939 passed, 15 skipped, 0 failed
- [ ] Manual: in Vercel preview, start voice session with maestro A, while maestro A is mid-response click maestro B — verify only maestro B speaks
- [ ] Manual: switch back rapidly A → B → A — no audio overlap on either transition

https://claude.ai/code/session_01KtTR2GArtvAiE76UXU6JAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtTR2GArtvAiE76UXU6JAB)_