### PR TITLE
fix(version): align apps/web/package.json to 0.16.11

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrorbuddy/web",
-  "version": "0.0.1",
+  "version": "0.16.11",
   "private": true,
   "description": "MirrorBuddy Next.js web app (W2 #362). Workspace deps + scripts inherit from repo root via pnpm workspace; this manifest exists so Vercel rootDirectory='apps/web' can find a package.json.",
   "scripts": {


### PR DESCRIPTION
Fixes /api/version reporting 0.0.1 on production. Vercel root=apps/web, so getAppVersion() falls back to apps/web/package.json when the VERSION file isn't found at process.cwd().

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>