### PR TITLE
fix(ci): use pnpm audit in weekly security workflow

### DIFF
--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run npm audit
+      - name: Run pnpm audit
         id: audit
         run: |
-          npm audit --audit-level=high > audit-report.txt 2>&1 || echo "AUDIT_FAILED=true" >> "$GITHUB_OUTPUT"
+          pnpm audit --audit-level=high > audit-report.txt 2>&1 || echo "AUDIT_FAILED=true" >> "$GITHUB_OUTPUT"
 
       - name: Create issue on failure
         if: steps.audit.outputs.AUDIT_FAILED == 'true'
@@ -48,11 +48,11 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Security: npm audit found high-severity vulnerabilities`,
+              title: `Security: pnpm audit found high-severity vulnerabilities`,
               body: [
                 '## Weekly Security Audit Failed',
                 '',
-                '`npm audit --audit-level=high` found vulnerabilities:',
+                '`pnpm audit --audit-level=high` found vulnerabilities:',
                 '',
                 '```',
                 truncated,
@@ -60,7 +60,7 @@ jobs:
                 '',
                 '**Action required**: Review and update affected packages.',
                 '',
-                'Run locally: `npm audit` for full report.',
+                'Run locally: `pnpm audit` for full report.',
               ].join('\n'),
               labels: ['security', 'dependencies'],
             });


### PR DESCRIPTION
Project uses pnpm; `npm audit` fails with ENOLOCK because there is no package-lock.json. Switches the weekly audit to `pnpm audit` so it actually runs against the lockfile.

Closes #388
Closes #389

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>