### PR TITLE
fix(sentry): pass real error on WelcomePage existing-data fetch

### DIFF
--- a/apps/web/src/app/[locale]/welcome/hooks/use-existing-user-data.ts
+++ b/apps/web/src/app/[locale]/welcome/hooks/use-existing-user-data.ts
@@ -1,18 +1,35 @@
-import { useState, useEffect } from "react";
-import { logger } from "@/lib/logger";
-import { useOnboardingStore } from "@/lib/stores/onboarding-store";
-import type { ExistingUserData } from "../types";
+import { useState, useEffect } from 'react';
+import { logger } from '@/lib/logger';
+import { useOnboardingStore } from '@/lib/stores/onboarding-store';
+import type { ExistingUserData } from '../types';
+
+function isTransientFetchError(error: unknown): boolean {
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return true;
+  }
+  if (error instanceof Error) {
+    return error.name === 'AbortError' || error.name === 'TimeoutError';
+  }
+  return false;
+}
 
 export function useExistingUserData() {
-  const [existingUserData, setExistingUserData] =
-    useState<ExistingUserData | null>(null);
+  const [existingUserData, setExistingUserData] = useState<ExistingUserData | null>(null);
   const [hasCheckedExistingData, setHasCheckedExistingData] = useState(false);
   const { updateData } = useOnboardingStore();
 
   useEffect(() => {
     async function fetchExistingData() {
       try {
-        const response = await fetch("/api/onboarding");
+        const response = await fetch('/api/onboarding');
+        if (!response.ok) {
+          if (response.status === 401 || response.status === 403) {
+            // Anonymous visitor — expected, no Sentry noise
+            setHasCheckedExistingData(true);
+            return;
+          }
+          throw new Error(`/api/onboarding ${response.status}`);
+        }
         const data = await response.json();
 
         if (data.hasExistingData && data.data) {
@@ -24,9 +41,17 @@ export function useExistingUserData() {
 
         setHasCheckedExistingData(true);
       } catch (error) {
-        logger.error("[WelcomePage] Failed to fetch existing data", {
-          error: String(error),
-        });
+        if (isTransientFetchError(error)) {
+          logger.debug('[WelcomePage] Existing-data fetch aborted (transient)', {
+            errorName: error instanceof Error ? error.name : typeof error,
+          });
+        } else {
+          logger.error(
+            '[WelcomePage] Failed to fetch existing data',
+            { component: 'WelcomePage' },
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        }
         setHasCheckedExistingData(true);
       }
     }

--- a/apps/web/src/app/welcome/hooks/use-existing-user-data.ts
+++ b/apps/web/src/app/welcome/hooks/use-existing-user-data.ts
@@ -3,6 +3,16 @@ import { logger } from '@/lib/logger';
 import { useOnboardingStore } from '@/lib/stores/onboarding-store';
 import type { ExistingUserData } from '../types';
 
+function isTransientFetchError(error: unknown): boolean {
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return true;
+  }
+  if (error instanceof Error) {
+    return error.name === 'AbortError' || error.name === 'TimeoutError';
+  }
+  return false;
+}
+
 export function useExistingUserData() {
   const [existingUserData, setExistingUserData] = useState<ExistingUserData | null>(null);
   const [hasCheckedExistingData, setHasCheckedExistingData] = useState(false);
@@ -12,6 +22,13 @@ export function useExistingUserData() {
     async function fetchExistingData() {
       try {
         const response = await fetch('/api/onboarding');
+        if (!response.ok) {
+          if (response.status === 401 || response.status === 403) {
+            setHasCheckedExistingData(true);
+            return;
+          }
+          throw new Error(`/api/onboarding ${response.status}`);
+        }
         const data = await response.json();
 
         if (data.hasExistingData && data.data) {
@@ -23,7 +40,17 @@ export function useExistingUserData() {
 
         setHasCheckedExistingData(true);
       } catch (error) {
-        logger.error('[WelcomePage] Failed to fetch existing data', { error: String(error) });
+        if (isTransientFetchError(error)) {
+          logger.debug('[WelcomePage] Existing-data fetch aborted (transient)', {
+            errorName: error instanceof Error ? error.name : typeof error,
+          });
+        } else {
+          logger.error(
+            '[WelcomePage] Failed to fetch existing data',
+            { component: 'WelcomePage' },
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        }
         setHasCheckedExistingData(true);
       }
     }
@@ -35,4 +62,3 @@ export function useExistingUserData() {
     hasCheckedExistingData,
   };
 }
-


### PR DESCRIPTION
## Summary

Production Sentry: `Error: [WelcomePage] Failed to fetch existing data` (May 24 2026, transaction `/:locale/welcome`, Android Chrome Mobile) — **same root cause as MIRRORBUDDY-1P/1R**.

`useExistingUserData` called `logger.error('[WelcomePage] Failed to fetch existing data', { error: String(error) })` without passing the original Error as the third arg. The client logger then fabricated `new Error(message)` with a 2-frame stack from the logger itself. Anonymous mobile visitors hitting `/welcome` with a flaky connection generated noise with no actionable context (stack shows only `at Y → at Object.error → at None`).

## Fix

- Pass the real Error as third arg to `logger.error` so Sentry shows the actual stack and inner message.
- Detect `AbortError` / `TimeoutError` / `navigator.onLine === false` and downgrade to `logger.debug` — page-unload aborts on mobile aren't actionable.
- Check `response.ok` before `.json()` — fetch only rejects on network failure, not on HTTP 4xx/5xx. Throw with status in the message so context flows to the outer catch.
- Swallow `401` / `403` quietly: anonymous visitors are the *expected* audience of the welcome flow, no Sentry noise.
- Applied to both `apps/web/src/app/[locale]/welcome/hooks/use-existing-user-data.ts` (i18n route, where the current Sentry hit) and the non-localized `apps/web/src/app/welcome/hooks/use-existing-user-data.ts` (legacy route, same bug pattern).

## Test plan

- [x] `npm run ci:summary` — lint WARN (185 baseline, no new), typecheck PASS, build PASS, unsafe-queries PASS
- [x] Pre-push hook — Prisma fresh + production build PASS
- [ ] Manual smoke after deploy: visit `/en/welcome` while signed out; verify no Sentry noise on 401 from `/api/onboarding`
- [ ] After merge: monitor Sentry to confirm the `[WelcomePage] Failed to fetch existing data` fingerprint stops reoccurring under fabricated-error form

## Follow-up (out of scope here)

This is the third Sentry noise issue under the same pattern (1P, 1R, this one). I'll open a follow-up ESLint rule or codemod that flags `logger.error(msg, ctx)` calls inside `catch` blocks where the `error` binding isn't forwarded as the third arg.

https://claude.ai/code/session_01KtTR2GArtvAiE76UXU6JAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtTR2GArtvAiE76UXU6JAB)_