### PR TITLE
fix(welcome): sync legacy hook with locale version

### DIFF
--- a/apps/web/src/app/welcome/hooks/use-existing-user-data.ts
+++ b/apps/web/src/app/welcome/hooks/use-existing-user-data.ts
@@ -39,6 +39,7 @@ export function useExistingUserData() {
         const response = await fetch('/api/onboarding');
         if (!response.ok) {
           if (response.status === 401 || response.status === 403) {
+            // Anonymous visitor — expected, no Sentry noise
             setHasCheckedExistingData(true);
             return;
           }


### PR DESCRIPTION
Sync the legacy `/welcome` hook with the `[locale]/welcome` version.

Adds the missing explanatory comment for 401/403 handling. Both copies
are now identical, resolving the tech debt noted in mirrorbuddy-todo.

Co-Authored-By: Oz <oz-agent@warp.dev>