### PR TITLE
fix(ci): locate sentry client config in monorepo apps/web/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules/
 /.pnp
 .pnp.*
 .yarn/*
@@ -13,12 +13,12 @@
 # testing
 /coverage
 /reports
-/test-results/
-/playwright-report/
+test-results/
+playwright-report/
 /playwright/.cache/
 
 # next.js
-/.next/
+.next/
 /out/
 
 # production

--- a/scripts/validate-pre-deploy.ts
+++ b/scripts/validate-pre-deploy.ts
@@ -239,9 +239,14 @@ function validateOptionalEnvVars(): void {
 }
 
 function validateSentryClientFallback(): void {
-  const clientConfigPath = path.join(process.cwd(), 'sentry.client.config.ts');
-  if (!fs.existsSync(clientConfigPath)) {
-    addResult('Sentry', 'Client Config', 'FAIL', 'sentry.client.config.ts not found', true);
+  const candidates = [
+    path.join(process.cwd(), 'sentry.client.config.ts'),
+    path.join(process.cwd(), 'apps', 'web', 'sentry.client.config.ts'),
+    path.join(process.cwd(), 'apps', 'web', 'instrumentation-client.ts'),
+  ];
+  const clientConfigPath = candidates.find((p) => fs.existsSync(p));
+  if (!clientConfigPath) {
+    addResult('Sentry', 'Client Config', 'FAIL', 'sentry client config not found', true);
     return;
   }
 


### PR DESCRIPTION
## Summary
- allow pre-deploy validation to find Sentry client config in the monorepo web app
- accept the current Next 16 instrumentation-client fallback location
- ignore nested generated artifacts from Next/Playwright and workspace node_modules churn

## Validation
- pnpm install --frozen-lockfile
- npm run ci:summary:full — PASS (lint warnings only)
- npm run test:unit -- --reporter=dot — PASS summary: 11947 passed, 15 skipped
- npm run i18n:check — PASS
- npx playwright install
- npm run test:smoke:prod — current production failure: /api/embeddings returns 200 for unauthenticated POST; not introduced by this branch and should be rechecked after main deploy

## Notes
- No version bump: CI/test hygiene only; no runtime product change.
