### PR TITLE
fix(deps): override basic-ftp audit advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "@opentelemetry/otlp-transformer": {
       "protobufjs": "8.0.2"
     },
-    "eslint-plugin-react-hooks": "7.0.1"
+    "eslint-plugin-react-hooks": "7.0.1",
+    "basic-ftp": "5.3.1"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.73.0",
@@ -257,7 +258,8 @@
       "protobufjs": "7.5.6",
       "fast-uri": "3.1.2",
       "@opentelemetry/otlp-transformer>protobufjs": "8.0.2",
-      "eslint-plugin-react-hooks": "7.0.1"
+      "eslint-plugin-react-hooks": "7.0.1",
+      "basic-ftp": "5.3.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   fast-uri: 3.1.2
   '@opentelemetry/otlp-transformer>protobufjs': 8.0.2
   eslint-plugin-react-hooks: 7.0.1
+  basic-ftp: 5.3.1
 
 importers:
 
@@ -4419,8 +4420,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
   bcp-47-match@2.0.3:
@@ -13112,7 +13113,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.20: {}
 
-  basic-ftp@5.3.0: {}
+  basic-ftp@5.3.1: {}
 
   bcp-47-match@2.0.3: {}
 
@@ -14661,7 +14662,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- override transitive basic-ftp to patched 5.3.1 for GHSA-rpmf-866q-6p89
- refresh pnpm lockfile so @lhci/cli/proxy-agent resolves the patched version

Closes #420.

## Validation
- pnpm audit --audit-level=high — PASS (remaining findings are low/moderate only)
- npm run ci:summary:full — PASS (lint warnings only)
- npm run test:unit -- --reporter=dot — PASS (11947 passed, 15 skipped)
- npm run i18n:check — PASS
