### PR TITLE
fix(api): retire public embeddings endpoint

### DIFF
--- a/apps/web/src/app/api/embeddings/route.ts
+++ b/apps/web/src/app/api/embeddings/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+const RETIRED_ENDPOINT = { error: 'Endpoint not found' };
+
+function retiredEmbeddingEndpointResponse() {
+  return NextResponse.json(RETIRED_ENDPOINT, { status: 404 });
+}
+
+export const GET = retiredEmbeddingEndpointResponse;
+export const POST = retiredEmbeddingEndpointResponse;
+export const PUT = retiredEmbeddingEndpointResponse;
+export const PATCH = retiredEmbeddingEndpointResponse;
+export const DELETE = retiredEmbeddingEndpointResponse;
+export const OPTIONS = retiredEmbeddingEndpointResponse;


### PR DESCRIPTION
## Summary
- add an explicit retired /api/embeddings route that returns 404 for all methods
- restores the production smoke expectation that unauthenticated embeddings requests do not succeed or render an HTML page

## Validation
- npm run ci:summary:full — PASS (lint warnings only)
- npm run test:unit -- --reporter=dot — PASS (11947 passed, 15 skipped)
- npm run i18n:check — PASS
