### PR TITLE
feat(parental-gate): child-resistant gate for the adult area (#432)

### DIFF
--- a/apps/web/e2e/parental-gate.spec.ts
+++ b/apps/web/e2e/parental-gate.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Parental gate (#432)
+ *
+ * The adult area ("Per i grandi": Settings, Parent area, Calendar) must be
+ * gated behind a child-resistant challenge:
+ * - a math challenge when no parent PIN is configured (covers trial users), and
+ * - a PIN prompt once a parent PIN has been set.
+ */
+
+import { test, expect } from './fixtures/base-fixtures';
+import type { Page } from '@playwright/test';
+
+// Land on the authenticated home, bypassing welcome/onboarding.
+async function mockHome(page: Page): Promise<void> {
+  await page.route('/api/onboarding', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        onboardingState: {
+          hasCompletedOnboarding: true,
+          onboardingCompletedAt: new Date().toISOString(),
+          currentStep: 'ready',
+          isReplayMode: false,
+        },
+        hasExistingData: true,
+        data: { name: 'Test', age: 12, schoolLevel: 'media', learningDifferences: [] },
+      }),
+    }),
+  );
+  await page.route('/api/user/settings', (route) =>
+    route.request().method() === 'GET'
+      ? route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            studentProfile: { preferredCoach: 'melissa', preferredBuddy: 'mario' },
+          }),
+        })
+      : route.fulfill({ status: 200, body: '{}' }),
+  );
+  await page.route('/api/tos', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ accepted: true, version: '1.0' }),
+    }),
+  );
+  await page.route('/api/progress', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        xp: 0,
+        level: 1,
+        streak: 0,
+        totalStudyMinutes: 0,
+        sessionsThisWeek: 0,
+        questionsAsked: 0,
+      }),
+    }),
+  );
+}
+
+const UNLOCK = /sblocca|unlock/i;
+
+test.describe('Parental gate (#432)', () => {
+  test('math challenge gates the adult Settings area', async ({ page }) => {
+    await mockHome(page);
+    await page.route('/api/user/parental-pin', (route) =>
+      route.request().method() === 'GET'
+        ? route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ isSet: false }),
+          })
+        : route.fulfill({ status: 200, body: '{}' }),
+    );
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.getByTestId('home-nav-settings').click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    const labelText = await page.locator('label[for="parental-math"]').innerText();
+    const match = labelText.match(/(\d+)\s*\+\s*(\d+)/);
+    expect(match).not.toBeNull();
+    const sum = Number(match![1]) + Number(match![2]);
+
+    // Wrong answer keeps the gate closed.
+    await page.locator('#parental-math').fill(String(sum + 1));
+    await dialog.getByRole('button', { name: UNLOCK }).click();
+    await expect(dialog).toBeVisible();
+
+    // Correct answer unlocks and dismisses the gate.
+    await page.locator('#parental-math').fill(String(sum));
+    await dialog.getByRole('button', { name: UNLOCK }).click();
+    await expect(page.getByRole('dialog')).toBeHidden();
+  });
+
+  test('cancelling the gate keeps the child on the safe area', async ({ page }) => {
+    await mockHome(page);
+    await page.route('/api/user/parental-pin', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ isSet: false }),
+      }),
+    );
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.getByTestId('home-nav-settings').click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: /annulla|cancel/i }).click();
+    await expect(page.getByRole('dialog')).toBeHidden();
+  });
+
+  test('PIN challenge gates the adult area when a PIN is configured', async ({ page }) => {
+    await mockHome(page);
+    await page.route('/api/session', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ csrfToken: 'test-token' }),
+      }),
+    );
+    await page.route('/api/user/parental-pin', (route) =>
+      route.request().method() === 'GET'
+        ? route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ isSet: true }),
+          })
+        : route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ valid: true }),
+          }),
+    );
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.getByTestId('home-nav-settings').click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await page.locator('#parental-pin').fill('1234');
+    await dialog.getByRole('button', { name: UNLOCK }).click();
+    await expect(page.getByRole('dialog')).toBeHidden();
+  });
+});

--- a/apps/web/messages/de/home.json
+++ b/apps/web/messages/de/home.json
@@ -55,6 +55,27 @@
     "streak1": "Streak",
     "streak": "Streak",
     "mb": "+% MB",
-    "sim": "(SIM)"
+    "sim": "(SIM)",
+    "parentalGate": {
+      "title": "Bereich für Erwachsene",
+      "description": "Dieser Bereich ist für Erwachsene.",
+      "mathPrompt": "Um fortzufahren: Wie viel ist {a} + {b}?",
+      "mathPlaceholder": "Deine Antwort",
+      "pinPrompt": "Eltern-PIN eingeben",
+      "pinPlaceholder": "PIN",
+      "unlock": "Entsperren",
+      "cancel": "Abbrechen",
+      "wrongAnswer": "Falsche Antwort. Versuche es erneut.",
+      "wrongPin": "Falsche PIN. Versuche es erneut.",
+      "setPinCta": "Mit einer PIN schützen",
+      "setPinHint": "4 bis 6 Ziffern.",
+      "newPin": "Neue PIN",
+      "confirmPin": "PIN bestätigen",
+      "save": "Speichern",
+      "pinMismatch": "Die beiden PINs stimmen nicht überein.",
+      "pinInvalid": "Die PIN muss 4 bis 6 Ziffern haben.",
+      "pinSaved": "PIN erfolgreich gesetzt.",
+      "loading": "Einen Moment…"
+    }
   }
 }

--- a/apps/web/messages/en/home.json
+++ b/apps/web/messages/en/home.json
@@ -55,6 +55,27 @@
     "streak1": "Streak",
     "streak": "Streak",
     "mb": "+% MB",
-    "sim": "(SIM)"
+    "sim": "(SIM)",
+    "parentalGate": {
+      "title": "Grown-ups only",
+      "description": "This area is for grown-ups.",
+      "mathPrompt": "To continue, what is {a} + {b}?",
+      "mathPlaceholder": "Your answer",
+      "pinPrompt": "Enter the parent PIN",
+      "pinPlaceholder": "PIN",
+      "unlock": "Unlock",
+      "cancel": "Cancel",
+      "wrongAnswer": "Wrong answer. Try again.",
+      "wrongPin": "Wrong PIN. Try again.",
+      "setPinCta": "Protect with a PIN",
+      "setPinHint": "4 to 6 digits.",
+      "newPin": "New PIN",
+      "confirmPin": "Confirm PIN",
+      "save": "Save",
+      "pinMismatch": "The two PINs don’t match.",
+      "pinInvalid": "The PIN must be 4 to 6 digits.",
+      "pinSaved": "PIN set successfully.",
+      "loading": "One moment…"
+    }
   }
 }

--- a/apps/web/messages/es/home.json
+++ b/apps/web/messages/es/home.json
@@ -55,6 +55,27 @@
     "streak1": "Streak",
     "streak": "Streak",
     "mb": "+% MB",
-    "sim": "(SIM)"
+    "sim": "(SIM)",
+    "parentalGate": {
+      "title": "Zona para adultos",
+      "description": "Esta zona es para personas adultas.",
+      "mathPrompt": "Para continuar, ¿cuánto es {a} + {b}?",
+      "mathPlaceholder": "Tu respuesta",
+      "pinPrompt": "Introduce el PIN de los padres",
+      "pinPlaceholder": "PIN",
+      "unlock": "Desbloquear",
+      "cancel": "Cancelar",
+      "wrongAnswer": "Respuesta incorrecta. Inténtalo de nuevo.",
+      "wrongPin": "PIN incorrecto. Inténtalo de nuevo.",
+      "setPinCta": "Proteger con un PIN",
+      "setPinHint": "De 4 a 6 dígitos.",
+      "newPin": "Nuevo PIN",
+      "confirmPin": "Confirma el PIN",
+      "save": "Guardar",
+      "pinMismatch": "Los dos PIN no coinciden.",
+      "pinInvalid": "El PIN debe tener de 4 a 6 dígitos.",
+      "pinSaved": "PIN configurado correctamente.",
+      "loading": "Un momento…"
+    }
   }
 }

--- a/apps/web/messages/fr/home.json
+++ b/apps/web/messages/fr/home.json
@@ -55,6 +55,27 @@
     "streak1": "Streak",
     "streak": "Streak",
     "mb": "+% MB",
-    "sim": "(SIM)"
+    "sim": "(SIM)",
+    "parentalGate": {
+      "title": "Espace réservé aux adultes",
+      "description": "Cette partie est réservée aux adultes.",
+      "mathPrompt": "Pour continuer, combien font {a} + {b} ?",
+      "mathPlaceholder": "Votre réponse",
+      "pinPrompt": "Saisissez le code PIN parent",
+      "pinPlaceholder": "PIN",
+      "unlock": "Déverrouiller",
+      "cancel": "Annuler",
+      "wrongAnswer": "Réponse incorrecte. Réessayez.",
+      "wrongPin": "Code PIN incorrect. Réessayez.",
+      "setPinCta": "Protéger avec un code PIN",
+      "setPinHint": "De 4 à 6 chiffres.",
+      "newPin": "Nouveau PIN",
+      "confirmPin": "Confirmez le PIN",
+      "save": "Enregistrer",
+      "pinMismatch": "Les deux codes PIN ne correspondent pas.",
+      "pinInvalid": "Le code PIN doit comporter de 4 à 6 chiffres.",
+      "pinSaved": "Code PIN enregistré.",
+      "loading": "Un instant…"
+    }
   }
 }

--- a/apps/web/messages/it/home.json
+++ b/apps/web/messages/it/home.json
@@ -55,6 +55,27 @@
     "streak1": "Streak",
     "streak": "Streak",
     "mb": "+% MB",
-    "sim": "(SIM)"
+    "sim": "(SIM)",
+    "parentalGate": {
+      "title": "Area per i grandi",
+      "description": "Questa parte è riservata agli adulti.",
+      "mathPrompt": "Per continuare, quanto fa {a} + {b}?",
+      "mathPlaceholder": "La tua risposta",
+      "pinPrompt": "Inserisci il PIN dei genitori",
+      "pinPlaceholder": "PIN",
+      "unlock": "Sblocca",
+      "cancel": "Annulla",
+      "wrongAnswer": "Risposta non corretta. Riprova.",
+      "wrongPin": "PIN non corretto. Riprova.",
+      "setPinCta": "Proteggi con un PIN",
+      "setPinHint": "Da 4 a 6 cifre.",
+      "newPin": "Nuovo PIN",
+      "confirmPin": "Conferma il PIN",
+      "save": "Salva",
+      "pinMismatch": "I due PIN non coincidono.",
+      "pinInvalid": "Il PIN deve avere da 4 a 6 cifre.",
+      "pinSaved": "PIN impostato correttamente.",
+      "loading": "Un attimo…"
+    }
   }
 }

--- a/apps/web/prisma/migrations/20260617000000_add_parental_pin/migration.sql
+++ b/apps/web/prisma/migrations/20260617000000_add_parental_pin/migration.sql
@@ -1,0 +1,4 @@
+-- Parental gate PIN (Issue #432)
+-- Stores a bcrypt hash of the parent PIN used to gate the adult ("Per i grandi")
+-- area. Nullable: existing rows keep no PIN and fall back to the math challenge.
+ALTER TABLE "Settings" ADD COLUMN "parentalPinHash" TEXT;

--- a/apps/web/prisma/schema/user.prisma
+++ b/apps/web/prisma/schema/user.prisma
@@ -167,6 +167,9 @@ model Settings {
   // Parent Dashboard (Issue #64)
   parentDashboardLastViewed DateTime?
 
+  // Parental gate PIN (Issue #432) — bcrypt hash; never returned to the client
+  parentalPinHash String?
+
   // Azure Cost Configuration
   azureCostConfig String? // JSON: {token_cost, audio_cost, etc.}
 

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -31,6 +31,8 @@ import { LazyProgressView } from '@/components/progress';
 import { TrialHomeBanner, TrialUsageDashboard } from '@/components/trial';
 import { HomeHeader } from './home-header';
 import { HomeSidebar } from './home-sidebar';
+import { ParentalGateDialog } from '@/components/parental-gate';
+import { useParentalGateStore } from '@/lib/stores/parental-gate-store';
 import { COACH_INFO, BUDDY_INFO } from './home-constants';
 import type { View, MaestroSessionMode } from './types';
 import {
@@ -42,6 +44,10 @@ import {
 } from './home-lazy';
 
 const MB_PER_LEVEL = 1000;
+
+// Adult-only surfaces ("Per i grandi") gated behind the parental gate (#432).
+// The default child landing ('maestri') is intentionally NOT gated.
+const ADULT_VIEWS: View[] = ['genitori', 'settings', 'calendar'];
 
 export default function Home() {
   const router = useRouter();
@@ -65,6 +71,8 @@ export default function Home() {
   const [maestroSessionMode, setMaestroSessionMode] = useState<MaestroSessionMode>('voice');
   const [maestroSessionKey, setMaestroSessionKey] = useState(0);
   const [requestedToolType, setRequestedToolType] = useState<ToolType | undefined>(undefined);
+  const [gatePendingView, setGatePendingView] = useState<View | null>(null);
+  const isAdultUnlocked = useParentalGateStore((s) => s.isUnlocked);
 
   useEffect(() => {
     const handleResize = () => {
@@ -125,6 +133,15 @@ export default function Home() {
       }
     }
     setCurrentView(newView);
+  };
+
+  // Gate adult surfaces ("Per i grandi") behind the parental gate (#432).
+  const requestViewChange = async (newView: View) => {
+    if (ADULT_VIEWS.includes(newView) && !isAdultUnlocked) {
+      setGatePendingView(newView);
+      return;
+    }
+    await handleViewChange(newView);
   };
 
   const handleToolRequest = (toolType: ToolType, maestro: Maestro) => {
@@ -250,12 +267,12 @@ export default function Home() {
             open={sidebarOpen}
             onToggle={() => setSidebarOpen(!sidebarOpen)}
             currentView={currentView}
-            onViewChange={handleViewChange}
+            onViewChange={requestViewChange}
             navItems={navItems}
             hasNewInsights={hasNewInsights}
             onParentAccess={() => {
               markAsViewed();
-              handleViewChange('genitori');
+              void requestViewChange('genitori');
             }}
             trialStatus={trialStatus}
           />
@@ -313,6 +330,17 @@ export default function Home() {
           )}
         </div>
       )}
+
+      <ParentalGateDialog
+        key={gatePendingView ?? 'closed'}
+        open={gatePendingView !== null}
+        onUnlock={() => {
+          const target = gatePendingView;
+          setGatePendingView(null);
+          if (target) void handleViewChange(target);
+        }}
+        onCancel={() => setGatePendingView(null)}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/api/user/parental-pin/route.ts
+++ b/apps/web/src/app/api/user/parental-pin/route.ts
@@ -1,0 +1,73 @@
+// ============================================================================
+// API ROUTE: Parental gate PIN (Issue #432)
+// GET    -> { isSet: boolean }            (status; never returns the hash)
+// PUT    -> set/replace the parent PIN    (CSRF + auth)
+// POST   -> verify a submitted PIN        (CSRF + auth + rate limit)
+// ============================================================================
+
+import { NextResponse } from 'next/server';
+import { pipe, withSentry, withCSRF, withAuth, withRateLimit } from '@/lib/api/middlewares';
+import { getRequestId } from '@/lib/tracing';
+import { safeReadJson } from '@/lib/api/safe-json';
+import {
+  getParentalPinStatus,
+  setParentalPin,
+  verifyParentalPin,
+  isValidPinFormat,
+} from '@/lib/parental-gate/pin-service';
+
+export const revalidate = 0;
+
+export const GET = pipe(
+  withSentry('/api/user/parental-pin'),
+  withAuth,
+)(async (ctx) => {
+  const userId = ctx.userId!;
+  const status = await getParentalPinStatus(userId);
+  const response = NextResponse.json(status);
+  response.headers.set('X-Request-ID', getRequestId(ctx.req));
+  return response;
+});
+
+export const PUT = pipe(
+  withSentry('/api/user/parental-pin'),
+  withCSRF,
+  withAuth,
+)(async (ctx) => {
+  const userId = ctx.userId!;
+  const body = (await safeReadJson(ctx.req)) as { pin?: unknown } | null;
+  const pin = body?.pin;
+
+  if (!isValidPinFormat(pin)) {
+    const response = NextResponse.json({ error: 'PIN must be 4 to 6 digits' }, { status: 400 });
+    response.headers.set('X-Request-ID', getRequestId(ctx.req));
+    return response;
+  }
+
+  await setParentalPin(userId, pin);
+  const response = NextResponse.json({ isSet: true });
+  response.headers.set('X-Request-ID', getRequestId(ctx.req));
+  return response;
+});
+
+export const POST = pipe(
+  withSentry('/api/user/parental-pin'),
+  withCSRF,
+  withAuth,
+  withRateLimit({ maxRequests: 10, windowMs: 60_000 }),
+)(async (ctx) => {
+  const userId = ctx.userId!;
+  const body = (await safeReadJson(ctx.req)) as { pin?: unknown } | null;
+  const pin = body?.pin;
+
+  if (!isValidPinFormat(pin)) {
+    const response = NextResponse.json({ valid: false }, { status: 400 });
+    response.headers.set('X-Request-ID', getRequestId(ctx.req));
+    return response;
+  }
+
+  const valid = await verifyParentalPin(userId, pin);
+  const response = NextResponse.json({ valid });
+  response.headers.set('X-Request-ID', getRequestId(ctx.req));
+  return response;
+});

--- a/apps/web/src/components/parental-gate/index.ts
+++ b/apps/web/src/components/parental-gate/index.ts
@@ -1,0 +1,1 @@
+export { ParentalGateDialog } from './parental-gate-dialog';

--- a/apps/web/src/components/parental-gate/parental-gate-dialog.tsx
+++ b/apps/web/src/components/parental-gate/parental-gate-dialog.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+// ============================================================================
+// PARENTAL GATE DIALOG (Issue #432)
+// Child-resistant gate shown before adult areas ("Per i grandi").
+// - When a parent PIN is configured: requires the PIN.
+// - Otherwise: a simple math challenge (zero-setup, covers trial users) plus
+//   an optional "protect with a PIN" affordance.
+// Accessibility: built on the Radix <Dialog> (focus trap, aria-modal, Esc).
+// ============================================================================
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ShieldCheck } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useParentalGateStore } from '@/lib/stores/parental-gate-store';
+
+interface ParentalGateDialogProps {
+  open: boolean;
+  onUnlock: () => void;
+  onCancel: () => void;
+}
+
+// Non-security UI challenge: a young child should not solve it, but it does not
+// need cryptographic randomness.
+function makeChallenge(): { a: number; b: number } {
+  return { a: 2 + Math.floor(Math.random() * 8), b: 2 + Math.floor(Math.random() * 8) };
+}
+
+export function ParentalGateDialog({ open, onUnlock, onCancel }: ParentalGateDialogProps) {
+  const t = useTranslations('home.parentalGate');
+  const { isPinSet, isLoading, fetchStatus, verifyPin, setPin, unlock } = useParentalGateStore();
+
+  const [challenge, setChallenge] = useState(makeChallenge);
+  const [answer, setAnswer] = useState('');
+  const [pin, setPinInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const [showSetup, setShowSetup] = useState(false);
+  const [newPin, setNewPin] = useState('');
+  const [confirmPin, setConfirmPin] = useState('');
+  const [setupMessage, setSetupMessage] = useState<string | null>(null);
+
+  // The parent remounts this dialog (via `key`) each time it opens, so local
+  // state always starts fresh; here we only (re)load the server PIN status.
+  useEffect(() => {
+    if (open) void fetchStatus();
+  }, [open, fetchStatus]);
+
+  const handleMathSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (Number(answer) === challenge.a + challenge.b) {
+      unlock();
+      onUnlock();
+    } else {
+      setError(t('wrongAnswer'));
+      setChallenge(makeChallenge());
+      setAnswer('');
+    }
+  };
+
+  const handlePinSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const ok = await verifyPin(pin);
+    if (ok) {
+      onUnlock();
+    } else {
+      setError(t('wrongPin'));
+      setPinInput('');
+    }
+  };
+
+  const handleSetupSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!/^\d{4,6}$/.test(newPin)) {
+      setSetupMessage(t('pinInvalid'));
+      return;
+    }
+    if (newPin !== confirmPin) {
+      setSetupMessage(t('pinMismatch'));
+      return;
+    }
+    const ok = await setPin(newPin);
+    setSetupMessage(ok ? t('pinSaved') : t('wrongPin'));
+    if (ok) setShowSetup(false);
+  };
+
+  const onOpenChange = (next: boolean) => {
+    if (!next) onCancel();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-indigo-500" aria-hidden="true" />
+            {t('title')}
+          </DialogTitle>
+          <DialogDescription>{t('description')}</DialogDescription>
+        </DialogHeader>
+
+        {isPinSet === null || isLoading ? (
+          <p className="py-4 text-sm text-slate-600 dark:text-slate-400">{t('loading')}</p>
+        ) : isPinSet ? (
+          <form onSubmit={handlePinSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="parental-pin" className="text-sm font-medium">
+                {t('pinPrompt')}
+              </label>
+              <Input
+                id="parental-pin"
+                type="password"
+                inputMode="numeric"
+                autoComplete="off"
+                value={pin}
+                onChange={(e) => setPinInput(e.target.value)}
+                placeholder={t('pinPlaceholder')}
+                aria-describedby={error ? 'parental-gate-error' : undefined}
+                autoFocus
+              />
+            </div>
+            {error && (
+              <p id="parental-gate-error" role="alert" className="text-sm text-red-600">
+                {error}
+              </p>
+            )}
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={onCancel}>
+                {t('cancel')}
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {t('unlock')}
+              </Button>
+            </DialogFooter>
+          </form>
+        ) : showSetup ? (
+          <form onSubmit={handleSetupSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="parental-new-pin" className="text-sm font-medium">
+                {t('newPin')}
+              </label>
+              <Input
+                id="parental-new-pin"
+                type="password"
+                inputMode="numeric"
+                autoComplete="off"
+                value={newPin}
+                onChange={(e) => setNewPin(e.target.value)}
+                placeholder={t('pinPlaceholder')}
+                autoFocus
+              />
+              <p className="mt-1 text-xs text-slate-500">{t('setPinHint')}</p>
+            </div>
+            <div>
+              <label htmlFor="parental-confirm-pin" className="text-sm font-medium">
+                {t('confirmPin')}
+              </label>
+              <Input
+                id="parental-confirm-pin"
+                type="password"
+                inputMode="numeric"
+                autoComplete="off"
+                value={confirmPin}
+                onChange={(e) => setConfirmPin(e.target.value)}
+                placeholder={t('pinPlaceholder')}
+              />
+            </div>
+            {setupMessage && (
+              <p role="alert" className="text-sm text-slate-700 dark:text-slate-300">
+                {setupMessage}
+              </p>
+            )}
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={() => setShowSetup(false)}>
+                {t('cancel')}
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {t('save')}
+              </Button>
+            </DialogFooter>
+          </form>
+        ) : (
+          <form onSubmit={handleMathSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="parental-math" className="text-sm font-medium">
+                {t('mathPrompt', { a: challenge.a, b: challenge.b })}
+              </label>
+              <Input
+                id="parental-math"
+                type="number"
+                inputMode="numeric"
+                value={answer}
+                onChange={(e) => setAnswer(e.target.value)}
+                placeholder={t('mathPlaceholder')}
+                aria-describedby={error ? 'parental-gate-error' : undefined}
+                autoFocus
+              />
+            </div>
+            {error && (
+              <p id="parental-gate-error" role="alert" className="text-sm text-red-600">
+                {error}
+              </p>
+            )}
+            <button
+              type="button"
+              onClick={() => setShowSetup(true)}
+              className="text-sm text-indigo-600 underline dark:text-indigo-400"
+            >
+              {t('setPinCta')}
+            </button>
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={onCancel}>
+                {t('cancel')}
+              </Button>
+              <Button type="submit">{t('unlock')}</Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/parental-gate/__tests__/pin-service.test.ts
+++ b/apps/web/src/lib/parental-gate/__tests__/pin-service.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as bcrypt from 'bcrypt';
+
+vi.mock('@/lib/db', async () => {
+  const { createMockPrisma } = await import('@/test/mocks/prisma');
+  return { prisma: createMockPrisma() };
+});
+
+import { prisma } from '@/lib/db';
+import {
+  isValidPinFormat,
+  getParentalPinStatus,
+  setParentalPin,
+  verifyParentalPin,
+} from '../pin-service';
+
+describe('parental-gate pin-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isValidPinFormat', () => {
+    it('accepts 4 to 6 digit strings', () => {
+      expect(isValidPinFormat('1234')).toBe(true);
+      expect(isValidPinFormat('123456')).toBe(true);
+    });
+
+    it('rejects wrong length, non-digits and non-strings', () => {
+      expect(isValidPinFormat('123')).toBe(false);
+      expect(isValidPinFormat('1234567')).toBe(false);
+      expect(isValidPinFormat('12a4')).toBe(false);
+      expect(isValidPinFormat(1234)).toBe(false);
+      expect(isValidPinFormat(undefined)).toBe(false);
+    });
+  });
+
+  describe('getParentalPinStatus', () => {
+    it('returns isSet:true when a hash exists', async () => {
+      vi.mocked(prisma.settings.findUnique).mockResolvedValue({ parentalPinHash: 'x' } as never);
+      expect(await getParentalPinStatus('u1')).toEqual({ isSet: true });
+    });
+
+    it('returns isSet:false when no hash', async () => {
+      vi.mocked(prisma.settings.findUnique).mockResolvedValue({ parentalPinHash: null } as never);
+      expect(await getParentalPinStatus('u1')).toEqual({ isSet: false });
+    });
+
+    it('returns isSet:false for an empty userId without querying', async () => {
+      expect(await getParentalPinStatus('')).toEqual({ isSet: false });
+      expect(prisma.settings.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('fails closed on a database error', async () => {
+      vi.mocked(prisma.settings.findUnique).mockRejectedValue(new Error('db') as never);
+      expect(await getParentalPinStatus('u1')).toEqual({ isSet: false });
+    });
+  });
+
+  describe('setParentalPin', () => {
+    it('hashes the PIN and upserts a bcrypt hash', async () => {
+      vi.mocked(prisma.settings.upsert).mockResolvedValue({} as never);
+      await setParentalPin('u1', '1234');
+
+      expect(prisma.settings.upsert).toHaveBeenCalledTimes(1);
+      const arg = vi.mocked(prisma.settings.upsert).mock.calls[0]![0] as {
+        where: { userId: string };
+        create: { parentalPinHash: string };
+        update: { parentalPinHash: string };
+      };
+      expect(arg.where).toEqual({ userId: 'u1' });
+      expect(arg.create.parentalPinHash).toMatch(/^\$2[aby]\$/);
+      expect(await bcrypt.compare('1234', arg.create.parentalPinHash)).toBe(true);
+    });
+
+    it('throws on an invalid PIN and never writes', async () => {
+      await expect(setParentalPin('u1', '12')).rejects.toThrow('Invalid PIN format');
+      expect(prisma.settings.upsert).not.toHaveBeenCalled();
+    });
+
+    it('throws on a missing userId', async () => {
+      await expect(setParentalPin('', '1234')).rejects.toThrow('Missing userId');
+    });
+  });
+
+  describe('verifyParentalPin', () => {
+    it('returns true when the PIN matches the stored hash', async () => {
+      const hash = await bcrypt.hash('1234', 10);
+      vi.mocked(prisma.settings.findUnique).mockResolvedValue({
+        parentalPinHash: hash,
+      } as never);
+      expect(await verifyParentalPin('u1', '1234')).toBe(true);
+    });
+
+    it('returns false when the PIN does not match', async () => {
+      const hash = await bcrypt.hash('0000', 10);
+      vi.mocked(prisma.settings.findUnique).mockResolvedValue({
+        parentalPinHash: hash,
+      } as never);
+      expect(await verifyParentalPin('u1', '1234')).toBe(false);
+    });
+
+    it('returns false when no PIN is configured', async () => {
+      vi.mocked(prisma.settings.findUnique).mockResolvedValue({ parentalPinHash: null } as never);
+      expect(await verifyParentalPin('u1', '1234')).toBe(false);
+    });
+
+    it('returns false for an invalid format without querying', async () => {
+      expect(await verifyParentalPin('u1', 'abc')).toBe(false);
+      expect(prisma.settings.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('fails closed on a database error', async () => {
+      vi.mocked(prisma.settings.findUnique).mockRejectedValue(new Error('db') as never);
+      expect(await verifyParentalPin('u1', '1234')).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/lib/parental-gate/pin-service.ts
+++ b/apps/web/src/lib/parental-gate/pin-service.ts
@@ -1,0 +1,75 @@
+// ============================================================================
+// PARENTAL GATE — PIN service (Issue #432)
+// Stores a bcrypt hash of the parent PIN in Settings.parentalPinHash.
+// The hash is NEVER returned to the client; only set/verify/status are exposed.
+// ============================================================================
+
+import { prisma } from '@/lib/db';
+import { hashPassword, verifyPassword } from '@/lib/auth/password';
+import { logger } from '@/lib/logger';
+
+const log = logger.child({ module: 'parental-gate/pin-service' });
+
+// 4 to 6 digits — child-resistant, easy for a parent to remember.
+const PIN_REGEX = /^\d{4,6}$/;
+
+/**
+ * Validate the PIN format (4-6 numeric digits).
+ */
+export function isValidPinFormat(pin: unknown): pin is string {
+  return typeof pin === 'string' && PIN_REGEX.test(pin);
+}
+
+/**
+ * Whether a parental PIN has been configured for the given user.
+ * Returns false (fail-closed to "no PIN", math fallback applies) on any error.
+ */
+export async function getParentalPinStatus(userId: string): Promise<{ isSet: boolean }> {
+  if (!userId) return { isSet: false };
+  try {
+    const settings = await prisma.settings.findUnique({
+      where: { userId },
+      select: { parentalPinHash: true },
+    });
+    return { isSet: Boolean(settings?.parentalPinHash) };
+  } catch (error) {
+    log.error('Failed to read parental PIN status', { error: String(error) });
+    return { isSet: false };
+  }
+}
+
+/**
+ * Set (or replace) the parental PIN for the given user.
+ * Throws on missing userId or invalid PIN format.
+ */
+export async function setParentalPin(userId: string, pin: string): Promise<void> {
+  if (!userId) throw new Error('Missing userId');
+  if (!isValidPinFormat(pin)) throw new Error('Invalid PIN format');
+
+  const parentalPinHash = await hashPassword(pin);
+  await prisma.settings.upsert({
+    where: { userId },
+    update: { parentalPinHash },
+    create: { userId, parentalPinHash },
+  });
+  log.info('Parental PIN set');
+}
+
+/**
+ * Verify a submitted PIN against the stored hash.
+ * Returns false on any error, invalid format, or when no PIN is configured.
+ */
+export async function verifyParentalPin(userId: string, pin: string): Promise<boolean> {
+  if (!userId || !isValidPinFormat(pin)) return false;
+  try {
+    const settings = await prisma.settings.findUnique({
+      where: { userId },
+      select: { parentalPinHash: true },
+    });
+    if (!settings?.parentalPinHash) return false;
+    return await verifyPassword(pin, settings.parentalPinHash);
+  } catch (error) {
+    log.error('Failed to verify parental PIN', { error: String(error) });
+    return false;
+  }
+}

--- a/apps/web/src/lib/stores/__tests__/parental-gate-store.test.ts
+++ b/apps/web/src/lib/stores/__tests__/parental-gate-store.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const csrfFetchMock = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  csrfFetch: (...args: unknown[]) => csrfFetchMock(...args),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  },
+}));
+
+import { useParentalGateStore } from '../parental-gate-store';
+
+function resetStore() {
+  useParentalGateStore.setState({ isUnlocked: false, isPinSet: null, isLoading: false });
+}
+
+describe('useParentalGateStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it('fetchStatus sets isPinSet=true on a 200 response', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ isSet: true }) });
+    await useParentalGateStore.getState().fetchStatus();
+    expect(useParentalGateStore.getState().isPinSet).toBe(true);
+  });
+
+  it('fetchStatus falls back to isPinSet=false for unauthenticated/trial users', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    await useParentalGateStore.getState().fetchStatus();
+    expect(useParentalGateStore.getState().isPinSet).toBe(false);
+  });
+
+  it('verifyPin unlocks the gate when the PIN is valid', async () => {
+    csrfFetchMock.mockResolvedValue({ ok: true, json: async () => ({ valid: true }) });
+    const ok = await useParentalGateStore.getState().verifyPin('1234');
+    expect(ok).toBe(true);
+    expect(useParentalGateStore.getState().isUnlocked).toBe(true);
+  });
+
+  it('verifyPin does not unlock the gate when the PIN is invalid', async () => {
+    csrfFetchMock.mockResolvedValue({ ok: true, json: async () => ({ valid: false }) });
+    const ok = await useParentalGateStore.getState().verifyPin('0000');
+    expect(ok).toBe(false);
+    expect(useParentalGateStore.getState().isUnlocked).toBe(false);
+  });
+
+  it('setPin marks isPinSet on success', async () => {
+    csrfFetchMock.mockResolvedValue({ ok: true, json: async () => ({ isSet: true }) });
+    const ok = await useParentalGateStore.getState().setPin('1234');
+    expect(ok).toBe(true);
+    expect(useParentalGateStore.getState().isPinSet).toBe(true);
+  });
+
+  it('verifyPin returns false and clears loading on a network error', async () => {
+    csrfFetchMock.mockRejectedValue(new Error('net'));
+    const ok = await useParentalGateStore.getState().verifyPin('1234');
+    expect(ok).toBe(false);
+    expect(useParentalGateStore.getState().isLoading).toBe(false);
+  });
+
+  it('lock and unlock toggle the session state', () => {
+    useParentalGateStore.getState().unlock();
+    expect(useParentalGateStore.getState().isUnlocked).toBe(true);
+    useParentalGateStore.getState().lock();
+    expect(useParentalGateStore.getState().isUnlocked).toBe(false);
+  });
+});

--- a/apps/web/src/lib/stores/parental-gate-store.ts
+++ b/apps/web/src/lib/stores/parental-gate-store.ts
@@ -1,0 +1,90 @@
+// ============================================================================
+// PARENTAL GATE STORE (Issue #432)
+// Ephemeral, in-memory only (NO persistence) — the unlock lasts for the
+// current session/tab and resets on reload, as expected for a child-resistant
+// gate. The PIN itself lives server-side (hashed); see pin-service.ts.
+// ============================================================================
+
+import { create } from 'zustand';
+import { csrfFetch } from '@/lib/auth';
+import { logger } from '@/lib/logger';
+
+const log = logger.child({ module: 'stores/parental-gate' });
+
+interface ParentalGateState {
+  /** True once the adult area has been unlocked for this session. */
+  isUnlocked: boolean;
+  /** Whether a server-side PIN exists; null until the status is fetched. */
+  isPinSet: boolean | null;
+  /** True while a network request is in flight. */
+  isLoading: boolean;
+
+  fetchStatus: () => Promise<void>;
+  verifyPin: (pin: string) => Promise<boolean>;
+  setPin: (pin: string) => Promise<boolean>;
+  unlock: () => void;
+  lock: () => void;
+}
+
+export const useParentalGateStore = create<ParentalGateState>((set) => ({
+  isUnlocked: false,
+  isPinSet: null,
+  isLoading: false,
+
+  fetchStatus: async () => {
+    set({ isLoading: true });
+    try {
+      const res = await fetch('/api/user/parental-pin');
+      if (!res.ok) {
+        // Unauthenticated / trial users: no PIN — math fallback applies.
+        set({ isPinSet: false, isLoading: false });
+        return;
+      }
+      const data = (await res.json()) as { isSet?: boolean };
+      set({ isPinSet: Boolean(data?.isSet), isLoading: false });
+    } catch (error) {
+      log.error('Failed to fetch parental PIN status', { error: String(error) });
+      set({ isPinSet: false, isLoading: false });
+    }
+  },
+
+  verifyPin: async (pin: string) => {
+    set({ isLoading: true });
+    try {
+      const res = await csrfFetch('/api/user/parental-pin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pin }),
+      });
+      const data = (await res.json()) as { valid?: boolean };
+      const valid = res.ok && Boolean(data?.valid);
+      set({ isUnlocked: valid, isLoading: false });
+      return valid;
+    } catch (error) {
+      log.error('Failed to verify parental PIN', { error: String(error) });
+      set({ isLoading: false });
+      return false;
+    }
+  },
+
+  setPin: async (pin: string) => {
+    set({ isLoading: true });
+    try {
+      const res = await csrfFetch('/api/user/parental-pin', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pin }),
+      });
+      const ok = res.ok;
+      set((state) => ({ isPinSet: ok ? true : state.isPinSet, isLoading: false }));
+      return ok;
+    } catch (error) {
+      log.error('Failed to set parental PIN', { error: String(error) });
+      set({ isLoading: false });
+      return false;
+    }
+  },
+
+  unlock: () => set({ isUnlocked: true }),
+  lock: () => set({ isUnlocked: false }),
+}));


### PR DESCRIPTION
## Summary

Implements a **child-resistant parental gate** in front of the adult "Per i grandi" surfaces — **Settings**, **Parent area** (`genitori`) and **Calendar** — so a child can no longer wander into account/config screens from the intention-based home (#430).

Two modes, automatically selected:
- **Math challenge** when no parent PIN is configured — zero-setup, works for trial/unauthenticated users, with an inline *"protect with a PIN"* affordance.
- **PIN prompt** once a parent PIN has been set — the PIN is stored as a **bcrypt hash** in `Settings.parentalPinHash` and is never returned to the client.

### Scope decision
The default child landing (`maestri`, the professor grid) is **intentionally NOT gated** — gating it would block the core learning flow on first load. The legal/COPPA work for `/invite/request` remains tracked separately in **#431**.

## Changes
| Area | File |
|---|---|
| DB | `prisma/schema/user.prisma` + migration `20260617000000_add_parental_pin` |
| Service | `lib/parental-gate/pin-service.ts` (format validation, status, set, verify via bcrypt) |
| API | `api/user/parental-pin/route.ts` — GET status, PUT set (CSRF+auth), POST verify (CSRF+auth+rate-limit) |
| State | `lib/stores/parental-gate-store.ts` — ephemeral in-memory unlock (NO localStorage, GDPR) |
| UI | `components/parental-gate/parental-gate-dialog.tsx` — accessible Radix Dialog (focus trap, aria-modal, Esc) |
| Wiring | `app/[locale]/page.tsx` — gates adult-view navigation; dialog remounts per open via `key` |
| i18n | `parentalGate` keys in all 5 locales (it/en/fr/de/es) |

## Accessibility (WCAG 2.1 AA)
Radix Dialog provides focus trap + `aria-modal`; labelled inputs; `role="alert"` error live regions; full keyboard nav (Tab/Enter/Esc).

## Tests
- **21 unit** tests (pin-service with real bcrypt + store)
- **E2E** `e2e/parental-gate.spec.ts` — math gate (wrong then correct), cancel, PIN flow

## Verification
- `npm run typecheck` → clean
- `npm run lint` (new files, `--max-warnings 0`) → clean
- `npm run test:unit` → **11968 passed**, 15 skipped, 0 failed
- `npm run build` → green
- `npm run i18n:check` → PASS (5/5 locales)

Closes #432