### PR TITLE
fix(test): correct repo-root resolution in vercel-env-sync test

### DIFF
--- a/apps/web/src/lib/__tests__/vercel-env-sync.test.ts
+++ b/apps/web/src/lib/__tests__/vercel-env-sync.test.ts
@@ -12,7 +12,8 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 
-const ROOT = resolve(__dirname, '../../..');
+// __dirname is apps/web/src/lib/__tests__ — repo root is 5 levels up.
+const ROOT = resolve(__dirname, '../../../../..');
 const HAS_ENV_FILE = existsSync(resolve(ROOT, '.env'));
 
 /** Variables that are dev/test/iOS-only and should NOT be on Vercel */


### PR DESCRIPTION
## Summary
- \`vercel-env-sync.test.ts\` computed ROOT as 3 levels up from \`apps/web/src/lib/__tests__\` (landing on \`apps/web/\`), but the scripts it validates (\`pre-push-vercel.sh\`, \`validate-pre-deploy.ts\`, \`fix-vercel-env-vars.sh\`) live at the actual repo root — 5 levels up.
- Discovered while unrelated work (T0.1/T0.3) was blocked by this pre-existing, reproducible-on-clean-main test failure.

## Test plan
- [x] All 4 tests in the file pass locally with \`.env\` present (they skip gracefully without it)
- [x] Local pre-push pipeline green (build, i18n, unit tests, Vercel checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhQVTk4CazPswSPN1HSEaZ