### PR TITLE
fix(safety): close T1.13 review gaps #467/#468, partial #469

### DIFF
--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -5,7 +5,7 @@
  * FEATURE: Function calling for tool execution (Issue #39)
  */
 
-import { NextResponse } from 'next/server';
+import { NextResponse, after } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import {
   chatCompletion,
@@ -312,35 +312,49 @@ export const POST = pipe(
         // also returns 'redirect' for jailbreak, which must not trigger crisis
         // escalation or parent notification (review finding #458 F1).
         if (filterResult.category === 'crisis') {
-          try {
-            void logSafetyEvent('crisis_detected', 'critical', {
-              userId: userId || undefined,
-              sessionId: conversationId,
-              category: 'crisis',
-              contentSnippet: lastUserMessage.content.slice(0, 50),
-            });
-            void recordComplianceCrisisDetected('crisis_detected', {
-              sessionId: conversationId,
-              maestroId,
-            });
-            void escalateCrisisDetected(userId || 'anonymous', conversationId, {
-              contentSnippet: lastUserMessage.content.slice(0, 50),
-              maestroId,
-            });
-            // Notify parent/guardian of crisis
-            if (userId) {
-              const locale = detectLocaleFromNextRequest(request);
-              void notifyParentOfCrisis({
-                userId,
+          // issue #468/D-61: crisis logging/escalation/notification must not
+          // be bare fire-and-forget `void` calls — on serverless the function
+          // can freeze right after the response is sent, silently dropping
+          // exactly the safety-critical writes this block exists for.
+          // `after()` keeps them alive past the response.
+          const runCrisisSideEffects = () =>
+            Promise.all([
+              logSafetyEvent('crisis_detected', 'critical', {
+                userId: userId || undefined,
+                sessionId: conversationId,
                 category: 'crisis',
-                severity: 'critical',
+                contentSnippet: lastUserMessage.content.slice(0, 50),
+              }),
+              recordComplianceCrisisDetected('crisis_detected', {
+                sessionId: conversationId,
                 maestroId,
-                timestamp: new Date(),
-                locale,
-              });
-            }
+              }),
+              escalateCrisisDetected(userId || 'anonymous', conversationId, {
+                contentSnippet: lastUserMessage.content.slice(0, 50),
+                maestroId,
+              }),
+              // Notify parent/guardian of crisis
+              userId
+                ? notifyParentOfCrisis({
+                    userId,
+                    category: 'crisis',
+                    severity: 'critical',
+                    maestroId,
+                    timestamp: new Date(),
+                    locale: detectLocaleFromNextRequest(request),
+                  })
+                : Promise.resolve(),
+            ]);
+          try {
+            after(() =>
+              runCrisisSideEffects().catch(() => {
+                // Crisis logging must never crash the main flow
+              }),
+            );
           } catch {
-            // Crisis logging must never crash the main flow
+            // after() throws outside a request-scoped execution context
+            // (e.g. a test run) — fall back to fire-and-forget.
+            void runCrisisSideEffects().catch(() => {});
           }
         }
 

--- a/apps/web/src/app/api/chat/stream/__tests__/stream-safety.integration.test.ts
+++ b/apps/web/src/app/api/chat/stream/__tests__/stream-safety.integration.test.ts
@@ -47,12 +47,19 @@ vi.mock('@/lib/safety/server', () => ({
   recordContentFiltered: vi.fn(),
 }));
 
-// Keep the real safety module but let tests control checkSTEMSafety
+// Keep the real safety module but let tests control checkSTEMSafety/detectBias
 vi.mock('@/lib/safety', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/safety')>();
   return {
     ...actual,
     checkSTEMSafety: vi.fn(() => ({ blocked: false })),
+    detectBias: vi.fn(() => ({
+      hasBias: false,
+      safeForEducation: true,
+      riskScore: 0,
+      analyzedLength: 0,
+      detections: [],
+    })),
   };
 });
 
@@ -68,9 +75,7 @@ vi.mock('../helpers', () => {
   }
   return {
     getUserIdWithCoppaCheck: vi.fn().mockResolvedValue({ allowed: true, userId: 'user-123' }),
-    loadUserSettings: vi
-      .fn()
-      .mockResolvedValue({ settings: null, providerPreference: undefined }),
+    loadUserSettings: vi.fn().mockResolvedValue({ settings: null, providerPreference: undefined }),
     enhancePromptWithContext: vi.fn().mockResolvedValue('system prompt'),
     checkInputSafety: vi.fn().mockReturnValue(null),
     updateBudget: vi.fn(),
@@ -112,7 +117,7 @@ vi.mock('@/lib/api/middlewares', () => ({
 
 import { POST } from '../route';
 import * as helpers from '../helpers';
-import { checkSTEMSafety } from '@/lib/safety';
+import { checkSTEMSafety, detectBias } from '@/lib/safety';
 import { recordContentFiltered } from '@/lib/safety/server';
 import { azureStreamingCompletion } from '@/lib/ai/server';
 
@@ -201,8 +206,9 @@ describe('POST /api/chat/stream safety wiring', () => {
     // Delegate to the REAL STEM filter: 'come fare la T<ZWSP>NT' must be
     // normalized to 'come fare la TNT' first, otherwise the blocklist regex
     // does not match and the dangerous query reaches the model.
-    const { checkSTEMSafety: realCheckSTEMSafety } =
-      await vi.importActual<typeof import('@/lib/safety/stem-safety')>('@/lib/safety/stem-safety');
+    const { checkSTEMSafety: realCheckSTEMSafety } = await vi.importActual<
+      typeof import('@/lib/safety/stem-safety')
+    >('@/lib/safety/stem-safety');
     vi.mocked(checkSTEMSafety).mockImplementationOnce(realCheckSTEMSafety);
 
     const response = await POST(
@@ -244,6 +250,73 @@ describe('POST /api/chat/stream safety wiring', () => {
     expect(body).toContain('[DONE]');
     expect(vi.mocked(checkSTEMSafety)).toHaveBeenCalledWith('spiegami la fotosintesi', 'curie');
     expect(vi.mocked(azureStreamingCompletion)).toHaveBeenCalled();
+    expect(vi.mocked(recordContentFiltered)).not.toHaveBeenCalled();
+  });
+
+  it('T1.4 (issue #467): runs bias detection on the full streamed output and appends a corrective message', async () => {
+    vi.mocked(checkSTEMSafety).mockReturnValueOnce({ blocked: false });
+    vi.mocked(detectBias).mockReturnValueOnce({
+      hasBias: true,
+      safeForEducation: false,
+      riskScore: 0.9,
+      analyzedLength: 4,
+      detections: [
+        {
+          detected: true,
+          category: 'gender',
+          severity: 'high',
+          match: 'ciao',
+          reason: 'test fixture',
+          suggestion: 'n/a',
+        },
+      ],
+    });
+
+    const response = await POST(
+      makeRequest({
+        messages: [{ role: 'user', content: 'raccontami una storia' }],
+        systemPrompt: 'You are MirrorBuddy',
+        maestroId: 'curie',
+        conversationId: 'conv-bias',
+      }),
+    );
+
+    const body = await readSSE(response);
+    // The already-streamed content is still present (can't be un-sent)...
+    expect(body).toContain('ciao');
+    // ...but a corrective message follows, flagged so the client can react
+    expect(body).toContain('"biasCorrection":true');
+    expect(body).toContain('"category":"bias"');
+    expect(body).toContain('[DONE]');
+
+    expect(vi.mocked(detectBias)).toHaveBeenCalledWith('ciao');
+    expect(vi.mocked(recordContentFiltered)).toHaveBeenCalledWith(
+      'bias',
+      expect.objectContaining({ maestroId: 'curie', actionTaken: 'flagged_post_stream' }),
+    );
+  });
+
+  it('T1.4 (issue #467): does not append a correction or audit when output is unbiased', async () => {
+    vi.mocked(checkSTEMSafety).mockReturnValueOnce({ blocked: false });
+    vi.mocked(detectBias).mockReturnValueOnce({
+      hasBias: false,
+      safeForEducation: true,
+      riskScore: 0,
+      analyzedLength: 0,
+      detections: [],
+    });
+
+    const response = await POST(
+      makeRequest({
+        messages: [{ role: 'user', content: 'spiegami la fotosintesi' }],
+        systemPrompt: 'You are MirrorBuddy',
+        maestroId: 'curie',
+        conversationId: 'conv-nobias',
+      }),
+    );
+
+    const body = await readSSE(response);
+    expect(body).not.toContain('biasCorrection');
     expect(vi.mocked(recordContentFiltered)).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/chat/stream/helpers.ts
+++ b/apps/web/src/app/api/chat/stream/helpers.ts
@@ -3,6 +3,7 @@
  * Business logic for streaming endpoint
  */
 
+import { after } from 'next/server';
 import { prisma } from '@/lib/db';
 import { logger } from '@/lib/logger';
 import { validateAuth } from '@/lib/auth/server';
@@ -194,34 +195,47 @@ export function checkInputSafety(
     // also returns 'redirect' for jailbreak, which must not trigger crisis
     // escalation or parent notification (review finding #458 F1).
     if (filterResult.category === 'crisis' && context) {
-      try {
-        void logSafetyEvent('crisis_detected', 'critical', {
-          userId: context.userId || undefined,
-          sessionId: context.conversationId,
-          category: 'crisis',
-          contentSnippet: content.slice(0, 50),
-        });
-        void recordComplianceCrisisDetected('crisis_detected', {
-          sessionId: context.conversationId,
-          maestroId: context.maestroId,
-        });
-        void escalateCrisisDetected(context.userId || 'anonymous', context.conversationId || '', {
-          contentSnippet: content.slice(0, 50),
-          maestroId: context.maestroId,
-        });
-        // Notify parent/guardian of crisis
-        if (context.userId) {
-          void notifyParentOfCrisis({
-            userId: context.userId,
+      // issue #468/D-61: keep crisis logging/escalation/notification alive
+      // past the response via after() instead of bare `void` fire-and-forget,
+      // which risked losing them on a serverless freeze right after respond.
+      const runCrisisSideEffects = () =>
+        Promise.all([
+          logSafetyEvent('crisis_detected', 'critical', {
+            userId: context.userId || undefined,
+            sessionId: context.conversationId,
             category: 'crisis',
-            severity: 'critical',
+            contentSnippet: content.slice(0, 50),
+          }),
+          recordComplianceCrisisDetected('crisis_detected', {
+            sessionId: context.conversationId,
             maestroId: context.maestroId,
-            timestamp: new Date(),
-            locale: context.locale || 'it',
-          });
-        }
+          }),
+          escalateCrisisDetected(context.userId || 'anonymous', context.conversationId || '', {
+            contentSnippet: content.slice(0, 50),
+            maestroId: context.maestroId,
+          }),
+          // Notify parent/guardian of crisis
+          context.userId
+            ? notifyParentOfCrisis({
+                userId: context.userId,
+                category: 'crisis',
+                severity: 'critical',
+                maestroId: context.maestroId,
+                timestamp: new Date(),
+                locale: context.locale || 'it',
+              })
+            : Promise.resolve(),
+        ]);
+      try {
+        after(() =>
+          runCrisisSideEffects().catch(() => {
+            // Crisis logging must never crash main flow
+          }),
+        );
       } catch {
-        // Crisis logging must never crash main flow
+        // after() throws outside a request-scoped execution context
+        // (e.g. a test run) — fall back to fire-and-forget.
+        void runCrisisSideEffects().catch(() => {});
       }
     }
     return {

--- a/apps/web/src/app/api/chat/stream/route.ts
+++ b/apps/web/src/app/api/chat/stream/route.ts
@@ -22,7 +22,13 @@ import {
   RATE_LIMITS,
   rateLimitResponse,
 } from '@/lib/rate-limit';
-import { StreamingSanitizer, checkSTEMSafety, normalizeUnicode } from '@/lib/safety';
+import {
+  StreamingSanitizer,
+  checkSTEMSafety,
+  normalizeUnicode,
+  detectBias,
+  SAFE_RESPONSES,
+} from '@/lib/safety';
 import { recordContentFiltered } from '@/lib/safety/server';
 import { detectLocaleFromNextRequest } from '@/lib/i18n/locale-detection';
 import { pipe, withSentry, withCSRF } from '@/lib/api/middlewares';
@@ -244,6 +250,11 @@ export const POST = pipe(
       async start(controller) {
         let totalTokens = 0;
         let budgetExceededMidStream = false;
+        // T1.4 (streaming): the full response text is accumulated so bias
+        // detection can run once the stream completes. Streaming means
+        // already-sent tokens cannot be un-sent — see the post-hoc audit +
+        // corrective-message compromise documented below (issue #467).
+        let fullResponseText = '';
 
         try {
           const generator = azureStreamingCompletion(
@@ -272,6 +283,7 @@ export const POST = pipe(
 
               const sanitized = sanitizer.processChunk(chunk.content);
               if (sanitized) {
+                fullResponseText += sanitized;
                 controller.enqueue(
                   encoder.encode(`data: ${JSON.stringify({ content: sanitized })}\n\n`),
                 );
@@ -296,8 +308,42 @@ export const POST = pipe(
           if (!budgetExceededMidStream) {
             const remaining = sanitizer.flush();
             if (remaining) {
+              fullResponseText += remaining;
               controller.enqueue(
                 encoder.encode(`data: ${JSON.stringify({ content: remaining })}\n\n`),
+              );
+            }
+          }
+
+          // T1.4 (streaming): bias detection on the full accumulated output.
+          // Unlike the non-streaming route, tokens already reached the client
+          // by the time this runs — full prevention would require buffering
+          // the entire response and losing the point of streaming. Instead:
+          // audit for compliance visibility (closes issue #467) and append a
+          // corrective message the student/parent will see, same shape as the
+          // existing content_filter mid-stream event.
+          if (!budgetExceededMidStream && fullResponseText) {
+            const biasResult = detectBias(fullResponseText);
+            if (biasResult.hasBias && !biasResult.safeForEducation) {
+              log.warn('Bias detected in streamed AI response (post-hoc)', {
+                clientId,
+                maestroId,
+                riskScore: biasResult.riskScore,
+                categories: biasResult.detections.map((d) => d.category),
+              });
+              recordContentFiltered('bias', {
+                userId,
+                maestroId,
+                actionTaken: 'flagged_post_stream',
+              });
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({
+                    content: `\n\n${SAFE_RESPONSES.jailbreak}`,
+                    biasCorrection: true,
+                    category: 'bias',
+                  })}\n\n`,
+                ),
               );
             }
           }

--- a/apps/web/src/lib/hooks/voice-session/__tests__/event-handlers-safety.test.ts
+++ b/apps/web/src/lib/hooks/voice-session/__tests__/event-handlers-safety.test.ts
@@ -72,8 +72,30 @@ describe('Event Handlers - safety intervention wiring', () => {
           safetyResult: blockedUserResult,
           dataChannel: ctx.dataChannel,
           setWarningState: ctx.deps.setSafetyWarning,
+          pauseAudio: expect.any(Function),
         }),
       );
+    });
+
+    it('issue #469: pauseAudio fallback tears down local/remote audio regardless of channel state', async () => {
+      const { checkUserTranscript } = await import('../transcript-safety');
+      vi.mocked(checkUserTranscript).mockReturnValue(blockedUserResult);
+      const { triggerSafetyIntervention } = await import('../safety-intervention');
+      ctx.dataChannel.readyState = 'closed';
+
+      const { result } = renderHook(() => useHandleServerEvent(ctx.deps));
+      result.current({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: 'flagged user input',
+      });
+
+      const call = vi.mocked(triggerSafetyIntervention).mock.calls[0][0];
+      call.pauseAudio?.();
+
+      expect(ctx.audioElement.pause).toHaveBeenCalled();
+      expect(ctx.source.stop).toHaveBeenCalled();
+      expect(ctx.deps.scheduledSourcesRef.current.size).toBe(0);
+      expect(ctx.deps.setSpeaking).toHaveBeenCalledWith(false);
     });
 
     it('should still surface the user own words in the transcript', async () => {

--- a/apps/web/src/lib/hooks/voice-session/__tests__/safety-intervention.test.ts
+++ b/apps/web/src/lib/hooks/voice-session/__tests__/safety-intervention.test.ts
@@ -262,6 +262,101 @@ describe('triggerSafetyIntervention', () => {
       ).not.toThrow();
     });
 
+    it('issue #469: still surfaces UI warning + audit log when channel is closed', async () => {
+      const { clientLogger } = await import('@/lib/logger/client');
+      mockDataChannel.readyState = 'closed';
+
+      const safetyResult: TranscriptSafetyResult = {
+        severity: 'critical',
+        flaggedPatterns: ['crisis'],
+        actionTaken: 'escalate',
+        checkDurationMs: 5,
+      };
+
+      triggerSafetyIntervention({
+        sessionId: 'test-session-closed-channel',
+        safetyResult,
+        dataChannel: mockDataChannel as unknown as RTCDataChannel,
+        setWarningState: mockSetWarningState,
+      });
+
+      expect(mockSetWarningState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          active: true,
+          severity: 'critical',
+          flaggedPatterns: ['crisis'],
+        }),
+      );
+      expect(clientLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[SafetyIntervention]'),
+        expect.objectContaining({ eventId: 'VCE-004', channelUnavailable: true }),
+      );
+    });
+
+    it('issue #469: calls pauseAudio fallback when channel is closed', () => {
+      mockDataChannel.readyState = 'closed';
+      const pauseAudio = vi.fn();
+
+      const safetyResult: TranscriptSafetyResult = {
+        severity: 'high',
+        flaggedPatterns: ['explicit'],
+        actionTaken: 'block',
+        checkDurationMs: 5,
+      };
+
+      triggerSafetyIntervention({
+        sessionId: 'test-session-pause-closed',
+        safetyResult,
+        dataChannel: mockDataChannel as unknown as RTCDataChannel,
+        setWarningState: mockSetWarningState,
+        pauseAudio,
+      });
+
+      expect(pauseAudio).toHaveBeenCalledTimes(1);
+    });
+
+    it('issue #469: calls pauseAudio fallback even when channel is open', () => {
+      const pauseAudio = vi.fn();
+
+      const safetyResult: TranscriptSafetyResult = {
+        severity: 'high',
+        flaggedPatterns: ['explicit'],
+        actionTaken: 'block',
+        checkDurationMs: 5,
+      };
+
+      triggerSafetyIntervention({
+        sessionId: 'test-session-pause-open',
+        safetyResult,
+        dataChannel: mockDataChannel as unknown as RTCDataChannel,
+        setWarningState: mockSetWarningState,
+        pauseAudio,
+      });
+
+      expect(pauseAudio).toHaveBeenCalledTimes(1);
+    });
+
+    it('issue #469: does not call pauseAudio when action is allow', () => {
+      const pauseAudio = vi.fn();
+
+      const safetyResult: TranscriptSafetyResult = {
+        severity: 'none',
+        flaggedPatterns: [],
+        actionTaken: 'allow',
+        checkDurationMs: 2,
+      };
+
+      triggerSafetyIntervention({
+        sessionId: 'test-session-pause-allow',
+        safetyResult,
+        dataChannel: mockDataChannel as unknown as RTCDataChannel,
+        setWarningState: mockSetWarningState,
+        pauseAudio,
+      });
+
+      expect(pauseAudio).not.toHaveBeenCalled();
+    });
+
     it('should only intervene for non-allow actions', () => {
       const safetyResult: TranscriptSafetyResult = {
         severity: 'none',

--- a/apps/web/src/lib/hooks/voice-session/event-handlers.ts
+++ b/apps/web/src/lib/hooks/voice-session/event-handlers.ts
@@ -47,6 +47,29 @@ export interface EventHandlerDeps extends Omit<ToolHandlerParams, 'event'> {
 }
 
 /**
+ * Stop any playing/queued assistant audio immediately, regardless of
+ * data-channel state. Used as the `pauseAudio` fallback for
+ * triggerSafetyIntervention (issue #469): when the channel is closed,
+ * response.cancel can't reach the model, but local/remote audio already in
+ * flight must still stop.
+ */
+function pauseVoiceAudio(deps: EventHandlerDeps): void {
+  deps.webrtcAudioElementRef.current?.pause();
+  deps.audioQueueRef.current.clear();
+  deps.isPlayingRef.current = false;
+  deps.isBufferingRef.current = true;
+  deps.scheduledSourcesRef.current.forEach((source) => {
+    try {
+      source.stop();
+    } catch {
+      /* already stopped */
+    }
+  });
+  deps.scheduledSourcesRef.current.clear();
+  deps.setSpeaking(false);
+}
+
+/**
  * Main server event handler for Azure Realtime API events (WebRTC)
  */
 export function useHandleServerEvent(deps: EventHandlerDeps) {
@@ -197,6 +220,7 @@ export function useHandleServerEvent(deps: EventHandlerDeps) {
                 safetyResult,
                 dataChannel: deps.webrtcDataChannelRef.current,
                 setWarningState: deps.setSafetyWarning,
+                pauseAudio: () => pauseVoiceAudio(deps),
               });
             }
 

--- a/apps/web/src/lib/hooks/voice-session/safety-intervention.ts
+++ b/apps/web/src/lib/hooks/voice-session/safety-intervention.ts
@@ -41,6 +41,14 @@ export interface SafetyInterventionParams {
   dataChannel: RTCDataChannel | null;
   /** Callback to update UI warning state */
   setWarningState: (state: SafetyWarningState) => void;
+  /**
+   * Optional local/remote audio teardown, invoked unconditionally whenever an
+   * intervention fires — including when the data channel is closed. Mirrors
+   * the unconditional pause used on the assistant-reject path (issue #469):
+   * response.cancel can only reach the model over an open channel, but the
+   * audio already playing/queued locally must stop regardless.
+   */
+  pauseAudio?: () => void;
 }
 
 /**
@@ -112,7 +120,7 @@ function getRedirectMessage(flaggedPatterns: string[]): string {
  * }
  */
 export function triggerSafetyIntervention(params: SafetyInterventionParams): void {
-  const { sessionId, safetyResult, dataChannel, setWarningState } = params;
+  const { sessionId, safetyResult, dataChannel, setWarningState, pauseAudio } = params;
 
   // Check feature flag - if disabled, no intervention
   const flagResult = isFeatureEnabled('voice_transcript_safety');
@@ -127,11 +135,36 @@ export function triggerSafetyIntervention(params: SafetyInterventionParams): voi
     return;
   }
 
-  // Validate data channel
+  // Stop any playing/queued audio unconditionally, regardless of data-channel
+  // state — response.cancel below can only reach the model over an open
+  // channel, but audio already in flight locally must stop either way
+  // (issue #469).
+  pauseAudio?.();
+
+  // Validate data channel. response.cancel/response.create require an open
+  // channel to reach the model, but the intervention must still surface to
+  // the UI/audit trail even when it can't — a silent no-op here would leave
+  // a flagged conversation with no warning and no compliance record.
   if (!dataChannel || dataChannel.readyState !== 'open') {
-    logger.warn('[SafetyIntervention] Data channel not available, cannot send intervention', {
+    const interventionReason = getInterventionReason(safetyResult.flaggedPatterns);
+    const redirectMessage = getRedirectMessage(safetyResult.flaggedPatterns);
+    logger.warn('[SafetyIntervention] Data channel unavailable, applying audio-only fallback', {
+      component: 'voice-safety-intervention',
+      eventId: 'VCE-004',
+      eventName: 'Safety Intervention Activated',
       sessionId,
+      interventionReason,
+      flaggedPatterns: safetyResult.flaggedPatterns,
+      detectedSeverity: safetyResult.severity,
+      channelUnavailable: true,
       readyState: dataChannel?.readyState || 'null',
+      timestamp: Date.now(),
+    });
+    setWarningState({
+      active: true,
+      severity: safetyResult.severity,
+      flaggedPatterns: safetyResult.flaggedPatterns,
+      message: redirectMessage,
     });
     return;
   }

--- a/apps/web/src/lib/safety/audit/__tests__/compliance-audit.test.ts
+++ b/apps/web/src/lib/safety/audit/__tests__/compliance-audit.test.ts
@@ -3,7 +3,13 @@
  * Tests F-07 - Safety events logging per audit compliance (L.132 Art.4)
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { afterMock } = vi.hoisted(() => ({
+  afterMock: vi.fn((cb: () => unknown) => cb()),
+}));
+vi.mock('next/server', () => ({ after: afterMock }));
+
 import {
   recordComplianceEvent,
   recordComplianceContentFiltered,
@@ -14,30 +20,44 @@ import {
   getComplianceStatistics,
   exportComplianceAudit,
   clearComplianceBuffer,
-} from "../compliance-audit-service";
+} from '../compliance-audit-service';
 // Types are used implicitly for type checking in tests
 
-describe("Compliance Audit Service (F-07)", () => {
+describe('Compliance Audit Service (F-07)', () => {
   beforeEach(() => {
     // Clear buffer between tests for isolation
     clearComplianceBuffer();
+    afterMock.mockClear();
   });
 
-  describe("recordComplianceEvent", () => {
-    it("should record a compliance event with required fields", () => {
-      const entryId = recordComplianceEvent("content_filtered", {
-        severity: "medium",
-        ageGroup: "teen",
-        eventDetails: { reason: "test" },
+  describe('recordComplianceEvent', () => {
+    it('should record a compliance event with required fields', () => {
+      const entryId = recordComplianceEvent('content_filtered', {
+        severity: 'medium',
+        ageGroup: 'teen',
+        eventDetails: { reason: 'test' },
       });
 
       expect(entryId).toMatch(/^comp_audit_/);
       expect(entryId.length).toBeGreaterThan(0);
     });
 
-    it("should include timestamp in ISO 8601 format", () => {
-      recordComplianceEvent("guardrail_triggered", {
-        severity: "medium",
+    it('issue #468/D-61: persists via after() instead of bare fire-and-forget', () => {
+      recordComplianceEvent('content_filtered', {
+        severity: 'medium',
+        ageGroup: 'teen',
+      });
+
+      // after() keeps the DB write alive past the response instead of a
+      // `void persistEntryToDb(entry)` that risked being dropped if the
+      // serverless function froze immediately after responding.
+      expect(afterMock).toHaveBeenCalledTimes(1);
+      expect(afterMock).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should include timestamp in ISO 8601 format', () => {
+      recordComplianceEvent('guardrail_triggered', {
+        severity: 'medium',
       });
 
       const entries = getComplianceEntries({ limit: 1 });
@@ -46,17 +66,15 @@ describe("Compliance Audit Service (F-07)", () => {
       const entry = entries[0];
       // Validate ISO 8601 format
       expect(new Date(entry.timestamp)).toBeInstanceOf(Date);
-      expect(entry.timestamp).toMatch(
-        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
-      );
+      expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     });
 
-    it("should include regulatory context", () => {
-      recordComplianceEvent("crisis_detected", {
-        severity: "critical",
+    it('should include regulatory context', () => {
+      recordComplianceEvent('crisis_detected', {
+        severity: 'critical',
       });
 
-      const entries = getComplianceEntries({ severity: "critical", limit: 1 });
+      const entries = getComplianceEntries({ severity: 'critical', limit: 1 });
       const entry = entries[0];
 
       expect(entry.regulatoryContext).toBeDefined();
@@ -65,162 +83,156 @@ describe("Compliance Audit Service (F-07)", () => {
       expect(entry.regulatoryContext.italianL132Art4).toBe(true);
     });
 
-    it("should include user context with anonymized session hash", () => {
-      recordComplianceEvent("content_filtered", {
-        sessionId: "test-session-12345",
-        ageGroup: "child",
+    it('should include user context with anonymized session hash', () => {
+      recordComplianceEvent('content_filtered', {
+        sessionId: 'test-session-12345',
+        ageGroup: 'child',
       });
 
-      const entries = getComplianceEntries({ ageGroup: "child", limit: 1 });
+      const entries = getComplianceEntries({ ageGroup: 'child', limit: 1 });
       const entry = entries[0];
 
       expect(entry.userContext).toBeDefined();
-      expect(entry.userContext.ageGroup).toBe("child");
+      expect(entry.userContext.ageGroup).toBe('child');
       expect(entry.userContext.sessionHash).toBeDefined();
       expect(entry.userContext.sessionHash).toMatch(/^sess_/);
-      expect(entry.userContext.region).toBe("EU");
+      expect(entry.userContext.region).toBe('EU');
     });
 
-    it("should include mitigation and outcome fields", () => {
-      recordComplianceEvent("content_filtered", {
-        mitigationApplied: "content_blocked",
-        outcome: "blocked",
+    it('should include mitigation and outcome fields', () => {
+      recordComplianceEvent('content_filtered', {
+        mitigationApplied: 'content_blocked',
+        outcome: 'blocked',
       });
 
       const entries = getComplianceEntries({ limit: 1 });
       const entry = entries[0];
 
-      expect(entry.mitigationApplied).toBe("content_blocked");
-      expect(entry.outcome).toBe("blocked");
+      expect(entry.mitigationApplied).toBe('content_blocked');
+      expect(entry.outcome).toBe('blocked');
     });
   });
 
-  describe("Event-specific recording functions", () => {
-    it("recordComplianceContentFiltered should set outcome to blocked", () => {
-      recordComplianceContentFiltered("profanity", {
-        ageGroup: "child",
+  describe('Event-specific recording functions', () => {
+    it('recordComplianceContentFiltered should set outcome to blocked', () => {
+      recordComplianceContentFiltered('profanity', {
+        ageGroup: 'child',
         confidence: 0.95,
       });
 
       const entries = getComplianceEntries({
-        eventType: "content_filtered",
+        eventType: 'content_filtered',
         limit: 1,
       });
       const entry = entries[0];
 
-      expect(entry.eventType).toBe("content_filtered");
-      expect(entry.outcome).toBe("blocked");
-      expect(entry.mitigationApplied).toBe("content_blocked");
+      expect(entry.eventType).toBe('content_filtered');
+      expect(entry.outcome).toBe('blocked');
+      expect(entry.mitigationApplied).toBe('content_blocked');
       expect(entry.confidenceScore).toBe(0.95);
     });
 
-    it("recordComplianceCrisisDetected should set severity to critical and outcome to escalated", () => {
-      recordComplianceCrisisDetected("self_harm", {
-        ageGroup: "teen",
+    it('recordComplianceCrisisDetected should set severity to critical and outcome to escalated', () => {
+      recordComplianceCrisisDetected('self_harm', {
+        ageGroup: 'teen',
       });
 
       const entries = getComplianceEntries({
-        eventType: "crisis_detected",
+        eventType: 'crisis_detected',
         limit: 1,
       });
       const entry = entries[0];
 
-      expect(entry.eventType).toBe("crisis_detected");
-      expect(entry.severity).toBe("critical");
-      expect(entry.outcome).toBe("escalated");
-      expect(entry.mitigationApplied).toBe("escalated_to_human");
+      expect(entry.eventType).toBe('crisis_detected');
+      expect(entry.severity).toBe('critical');
+      expect(entry.outcome).toBe('escalated');
+      expect(entry.mitigationApplied).toBe('escalated_to_human');
       expect(entry.regulatoryContext.coppa).toBe(true);
     });
 
-    it("recordComplianceJailbreakAttempt should set severity to high", () => {
+    it('recordComplianceJailbreakAttempt should set severity to high', () => {
       recordComplianceJailbreakAttempt({
-        pattern: "roleplay",
+        pattern: 'roleplay',
         confidence: 0.85,
       });
 
       const entries = getComplianceEntries({
-        eventType: "jailbreak_attempt",
+        eventType: 'jailbreak_attempt',
         limit: 1,
       });
       const entry = entries[0];
 
-      expect(entry.eventType).toBe("jailbreak_attempt");
-      expect(entry.severity).toBe("high");
-      expect(entry.outcome).toBe("blocked");
+      expect(entry.eventType).toBe('jailbreak_attempt');
+      expect(entry.severity).toBe('high');
+      expect(entry.outcome).toBe('blocked');
     });
 
-    it("recordComplianceGuardrailTriggered should set outcome to modified", () => {
-      recordComplianceGuardrailTriggered("bias-check-v1", {
+    it('recordComplianceGuardrailTriggered should set outcome to modified', () => {
+      recordComplianceGuardrailTriggered('bias-check-v1', {
         confidence: 0.72,
       });
 
       const entries = getComplianceEntries({
-        eventType: "guardrail_triggered",
+        eventType: 'guardrail_triggered',
         limit: 1,
       });
       const entry = entries[0];
 
-      expect(entry.eventType).toBe("guardrail_triggered");
-      expect(entry.severity).toBe("medium");
-      expect(entry.outcome).toBe("modified");
-      expect(entry.mitigationApplied).toBe("content_modified");
+      expect(entry.eventType).toBe('guardrail_triggered');
+      expect(entry.severity).toBe('medium');
+      expect(entry.outcome).toBe('modified');
+      expect(entry.mitigationApplied).toBe('content_modified');
     });
   });
 
-  describe("getComplianceEntries", () => {
+  describe('getComplianceEntries', () => {
     beforeEach(() => {
       // Record various events for filtering tests
-      recordComplianceEvent("content_filtered", {
-        severity: "medium",
-        ageGroup: "child",
+      recordComplianceEvent('content_filtered', {
+        severity: 'medium',
+        ageGroup: 'child',
       });
-      recordComplianceEvent("crisis_detected", {
-        severity: "critical",
-        ageGroup: "teen",
+      recordComplianceEvent('crisis_detected', {
+        severity: 'critical',
+        ageGroup: 'teen',
       });
-      recordComplianceEvent("jailbreak_attempt", {
-        severity: "high",
-        ageGroup: "adult",
+      recordComplianceEvent('jailbreak_attempt', {
+        severity: 'high',
+        ageGroup: 'adult',
       });
     });
 
-    it("should filter by event type", () => {
+    it('should filter by event type', () => {
       const entries = getComplianceEntries({
-        eventType: "content_filtered",
+        eventType: 'content_filtered',
       });
 
       expect(entries.length).toBeGreaterThan(0);
-      expect(entries.every((e) => e.eventType === "content_filtered")).toBe(
-        true,
-      );
+      expect(entries.every((e) => e.eventType === 'content_filtered')).toBe(true);
     });
 
-    it("should filter by severity", () => {
-      const criticalEntries = getComplianceEntries({ severity: "critical" });
+    it('should filter by severity', () => {
+      const criticalEntries = getComplianceEntries({ severity: 'critical' });
 
       expect(criticalEntries.length).toBeGreaterThan(0);
-      expect(criticalEntries.every((e) => e.severity === "critical")).toBe(
-        true,
-      );
+      expect(criticalEntries.every((e) => e.severity === 'critical')).toBe(true);
     });
 
-    it("should filter by age group", () => {
-      const childEntries = getComplianceEntries({ ageGroup: "child" });
+    it('should filter by age group', () => {
+      const childEntries = getComplianceEntries({ ageGroup: 'child' });
 
       expect(childEntries.length).toBeGreaterThan(0);
-      expect(
-        childEntries.every((e) => e.userContext.ageGroup === "child"),
-      ).toBe(true);
+      expect(childEntries.every((e) => e.userContext.ageGroup === 'child')).toBe(true);
     });
 
-    it("should filter by outcome", () => {
-      const blockedEntries = getComplianceEntries({ outcome: "blocked" });
+    it('should filter by outcome', () => {
+      const blockedEntries = getComplianceEntries({ outcome: 'blocked' });
 
       expect(blockedEntries.length).toBeGreaterThan(0);
-      expect(blockedEntries.every((e) => e.outcome === "blocked")).toBe(true);
+      expect(blockedEntries.every((e) => e.outcome === 'blocked')).toBe(true);
     });
 
-    it("should sort by timestamp descending", () => {
+    it('should sort by timestamp descending', () => {
       const entries = getComplianceEntries({});
 
       for (let i = 0; i < entries.length - 1; i++) {
@@ -230,50 +242,50 @@ describe("Compliance Audit Service (F-07)", () => {
       }
     });
 
-    it("should respect limit parameter", () => {
+    it('should respect limit parameter', () => {
       const limited = getComplianceEntries({ limit: 2 });
 
       expect(limited.length).toBeLessThanOrEqual(2);
     });
   });
 
-  describe("getComplianceStatistics", () => {
+  describe('getComplianceStatistics', () => {
     beforeEach(() => {
       // Record various events for statistics
       for (let i = 0; i < 3; i++) {
-        recordComplianceContentFiltered("test-filter", {
-          ageGroup: "child",
+        recordComplianceContentFiltered('test-filter', {
+          ageGroup: 'child',
         });
       }
       for (let i = 0; i < 2; i++) {
-        recordComplianceJailbreakAttempt({ ageGroup: "teen" });
+        recordComplianceJailbreakAttempt({ ageGroup: 'teen' });
       }
-      recordComplianceCrisisDetected("test-crisis", { ageGroup: "adult" });
+      recordComplianceCrisisDetected('test-crisis', { ageGroup: 'adult' });
     });
 
-    it("should calculate correct total events", () => {
+    it('should calculate correct total events', () => {
       const stats = getComplianceStatistics(30);
 
       expect(stats.totalEvents).toBeGreaterThanOrEqual(6);
     });
 
-    it("should count events by type", () => {
+    it('should count events by type', () => {
       const stats = getComplianceStatistics(30);
 
-      expect(stats.eventsByType["content_filtered"]).toBeGreaterThanOrEqual(3);
-      expect(stats.eventsByType["jailbreak_attempt"]).toBeGreaterThanOrEqual(2);
-      expect(stats.eventsByType["crisis_detected"]).toBeGreaterThanOrEqual(1);
+      expect(stats.eventsByType['content_filtered']).toBeGreaterThanOrEqual(3);
+      expect(stats.eventsByType['jailbreak_attempt']).toBeGreaterThanOrEqual(2);
+      expect(stats.eventsByType['crisis_detected']).toBeGreaterThanOrEqual(1);
     });
 
-    it("should count events by severity", () => {
+    it('should count events by severity', () => {
       const stats = getComplianceStatistics(30);
 
-      expect(stats.eventsBySeverity["critical"]).toBeGreaterThanOrEqual(1);
-      expect(stats.eventsBySeverity["high"]).toBeGreaterThanOrEqual(2);
-      expect(stats.eventsBySeverity["medium"]).toBeGreaterThanOrEqual(3);
+      expect(stats.eventsBySeverity['critical']).toBeGreaterThanOrEqual(1);
+      expect(stats.eventsBySeverity['high']).toBeGreaterThanOrEqual(2);
+      expect(stats.eventsBySeverity['medium']).toBeGreaterThanOrEqual(3);
     });
 
-    it("should track regulatory framework impact", () => {
+    it('should track regulatory framework impact', () => {
       const stats = getComplianceStatistics(30);
 
       expect(stats.regulatoryImpact.aiActEvents).toBeGreaterThan(0);
@@ -281,15 +293,15 @@ describe("Compliance Audit Service (F-07)", () => {
       expect(stats.regulatoryImpact.italianL132Art4Events).toBeGreaterThan(0);
     });
 
-    it("should count age group distribution", () => {
+    it('should count age group distribution', () => {
       const stats = getComplianceStatistics(30);
 
-      expect(stats.ageGroupDistribution["child"]).toBeGreaterThanOrEqual(3);
-      expect(stats.ageGroupDistribution["teen"]).toBeGreaterThanOrEqual(2);
-      expect(stats.ageGroupDistribution["adult"]).toBeGreaterThanOrEqual(1);
+      expect(stats.ageGroupDistribution['child']).toBeGreaterThanOrEqual(3);
+      expect(stats.ageGroupDistribution['teen']).toBeGreaterThanOrEqual(2);
+      expect(stats.ageGroupDistribution['adult']).toBeGreaterThanOrEqual(1);
     });
 
-    it("should calculate mitigation metrics", () => {
+    it('should calculate mitigation metrics', () => {
       const stats = getComplianceStatistics(30);
 
       expect(stats.mitigationMetrics.blockedCount).toBeGreaterThanOrEqual(5);
@@ -297,35 +309,33 @@ describe("Compliance Audit Service (F-07)", () => {
       expect(stats.mitigationMetrics.modifiedCount).toBeGreaterThanOrEqual(0);
     });
 
-    it("should include trend direction", () => {
+    it('should include trend direction', () => {
       const stats = getComplianceStatistics(30);
 
-      expect(["increasing", "decreasing", "stable"]).toContain(
-        stats.trendDirection,
-      );
+      expect(['increasing', 'decreasing', 'stable']).toContain(stats.trendDirection);
     });
 
-    it("should count critical events", () => {
+    it('should count critical events', () => {
       const stats = getComplianceStatistics(30);
 
       expect(stats.criticalEvents).toBeGreaterThanOrEqual(1);
     });
   });
 
-  describe("exportComplianceAudit", () => {
+  describe('exportComplianceAudit', () => {
     beforeEach(() => {
-      recordComplianceContentFiltered("test", { ageGroup: "child" });
-      recordComplianceCrisisDetected("test-crisis");
+      recordComplianceContentFiltered('test', { ageGroup: 'child' });
+      recordComplianceCrisisDetected('test-crisis');
     });
 
-    it("should export compliance audit with metadata", () => {
+    it('should export compliance audit with metadata', () => {
       const now = new Date();
       const periodStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
         .toISOString()
-        .split("T")[0];
-      const periodEnd = now.toISOString().split("T")[0];
+        .split('T')[0];
+      const periodEnd = now.toISOString().split('T')[0];
 
-      const exportData = exportComplianceAudit(periodStart, periodEnd, "admin");
+      const exportData = exportComplianceAudit(periodStart, periodEnd, 'admin');
 
       expect(exportData.metadata).toBeDefined();
       // anonymizeUserId keeps first N chars + "***" (where N = anonymizationKeyLength, default 8)
@@ -334,52 +344,52 @@ describe("Compliance Audit Service (F-07)", () => {
       expect(exportData.metadata.periodEnd).toBe(periodEnd);
     });
 
-    it("should include statistics in export", () => {
+    it('should include statistics in export', () => {
       const now = new Date();
       const periodStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
         .toISOString()
-        .split("T")[0];
-      const periodEnd = now.toISOString().split("T")[0];
+        .split('T')[0];
+      const periodEnd = now.toISOString().split('T')[0];
 
-      const exportData = exportComplianceAudit(periodStart, periodEnd, "admin");
+      const exportData = exportComplianceAudit(periodStart, periodEnd, 'admin');
 
       expect(exportData.statistics).toBeDefined();
       expect(exportData.statistics.totalEvents).toBeGreaterThanOrEqual(2);
     });
 
-    it("should include audit entries in export", () => {
+    it('should include audit entries in export', () => {
       const now = new Date();
       const periodStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
         .toISOString()
-        .split("T")[0];
-      const periodEnd = now.toISOString().split("T")[0];
+        .split('T')[0];
+      const periodEnd = now.toISOString().split('T')[0];
 
-      const exportData = exportComplianceAudit(periodStart, periodEnd, "admin");
+      const exportData = exportComplianceAudit(periodStart, periodEnd, 'admin');
 
       expect(exportData.entries).toBeDefined();
       expect(Array.isArray(exportData.entries)).toBe(true);
     });
 
-    it("should include summary in export", () => {
+    it('should include summary in export', () => {
       const now = new Date();
       const periodStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
         .toISOString()
-        .split("T")[0];
-      const periodEnd = now.toISOString().split("T")[0];
+        .split('T')[0];
+      const periodEnd = now.toISOString().split('T')[0];
 
-      const exportData = exportComplianceAudit(periodStart, periodEnd, "admin");
+      const exportData = exportComplianceAudit(periodStart, periodEnd, 'admin');
 
       expect(exportData.summary).toBeDefined();
-      expect(exportData.summary).toContain("Compliance Audit Summary");
-      expect(exportData.summary).toContain("Regulatory Framework Impact");
+      expect(exportData.summary).toContain('Compliance Audit Summary');
+      expect(exportData.summary).toContain('Regulatory Framework Impact');
     });
   });
 
-  describe("GDPR Compliance", () => {
-    it("should anonymize user identifiers", () => {
-      recordComplianceEvent("content_filtered", {
+  describe('GDPR Compliance', () => {
+    it('should anonymize user identifiers', () => {
+      recordComplianceEvent('content_filtered', {
         eventDetails: {
-          userId: "user-very-long-id-12345",
+          userId: 'user-very-long-id-12345',
         },
       });
 
@@ -387,34 +397,32 @@ describe("Compliance Audit Service (F-07)", () => {
       const entry = entries[0];
 
       // User details should not leak into event details
-      expect(JSON.stringify(entry)).not.toContain("user-very-long");
+      expect(JSON.stringify(entry)).not.toContain('user-very-long');
     });
 
-    it("should generate unique session hashes per event", () => {
-      recordComplianceEvent("content_filtered", {
-        sessionId: "same-session",
+    it('should generate unique session hashes per event', () => {
+      recordComplianceEvent('content_filtered', {
+        sessionId: 'same-session',
       });
-      recordComplianceEvent("guardrail_triggered", {
-        sessionId: "same-session",
+      recordComplianceEvent('guardrail_triggered', {
+        sessionId: 'same-session',
       });
 
       const entries = getComplianceEntries({ limit: 2 });
 
       // Same session ID should produce same hash
       if (entries.length >= 2) {
-        expect(entries[0].userContext.sessionHash).toBe(
-          entries[1].userContext.sessionHash,
-        );
+        expect(entries[0].userContext.sessionHash).toBe(entries[1].userContext.sessionHash);
       }
     });
   });
 
-  describe("Regulatory Context Mapping", () => {
-    it("should mark crisis detection as all regulatory frameworks", () => {
-      recordComplianceCrisisDetected("test");
+  describe('Regulatory Context Mapping', () => {
+    it('should mark crisis detection as all regulatory frameworks', () => {
+      recordComplianceCrisisDetected('test');
 
       const entries = getComplianceEntries({
-        eventType: "crisis_detected",
+        eventType: 'crisis_detected',
         limit: 1,
       });
       const entry = entries[0];
@@ -425,11 +433,11 @@ describe("Compliance Audit Service (F-07)", () => {
       expect(entry.regulatoryContext.italianL132Art4).toBe(true);
     });
 
-    it("should mark jailbreak attempt as AI Act relevant", () => {
+    it('should mark jailbreak attempt as AI Act relevant', () => {
       recordComplianceJailbreakAttempt();
 
       const entries = getComplianceEntries({
-        eventType: "jailbreak_attempt",
+        eventType: 'jailbreak_attempt',
         limit: 1,
       });
       const entry = entries[0];

--- a/apps/web/src/lib/safety/audit/compliance-audit-service.ts
+++ b/apps/web/src/lib/safety/audit/compliance-audit-service.ts
@@ -6,7 +6,8 @@
  * Ensures GDPR-compliant anonymization and regulatory framework tracking.
  */
 
-import { logger } from "@/lib/logger";
+import { after } from 'next/server';
+import { logger } from '@/lib/logger';
 import {
   ComplianceAuditEntry,
   RegulatoryContext,
@@ -16,13 +17,10 @@ import {
   ComplianceAuditStats,
   ComplianceAuditExport,
   DEFAULT_COMPLIANCE_CONFIG,
-} from "./compliance-audit-types";
-import {
-  buildRegulatoryContext,
-  computeComplianceStatistics,
-} from "./compliance-audit-stats";
+} from './compliance-audit-types';
+import { buildRegulatoryContext, computeComplianceStatistics } from './compliance-audit-stats';
 
-const log = logger.child({ module: "compliance-audit" });
+const log = logger.child({ module: 'compliance-audit' });
 
 /**
  * In-memory compliance audit buffer.
@@ -42,14 +40,14 @@ const BUFFER_TRIM_INTERVAL_MS = 60000; // 1 minute
  * Fire-and-forget with error handling — recording must never block or throw.
  */
 async function persistEntryToDb(entry: ComplianceAuditEntry): Promise<void> {
-  if (typeof window !== "undefined") {
+  if (typeof window !== 'undefined') {
     return;
   }
   try {
-    const { persistComplianceEntry } = await import("./compliance-audit-db");
+    const { persistComplianceEntry } = await import('./compliance-audit-db');
     await persistComplianceEntry(entry);
   } catch (error) {
-    log.error("Failed to persist compliance entry", {
+    log.error('Failed to persist compliance entry', {
       auditId: entry.id,
       error: error instanceof Error ? error.message : String(error),
     });
@@ -60,11 +58,11 @@ async function persistEntryToDb(entry: ComplianceAuditEntry): Promise<void> {
  * Record a compliance audit event
  */
 export function recordComplianceEvent(
-  eventType: ComplianceAuditEntry["eventType"],
+  eventType: ComplianceAuditEntry['eventType'],
   options: {
-    severity?: ComplianceAuditEntry["severity"];
+    severity?: ComplianceAuditEntry['severity'];
     sessionId?: string;
-    ageGroup?: ComplianceUserContext["ageGroup"];
+    ageGroup?: ComplianceUserContext['ageGroup'];
     maestroId?: string;
     eventDetails?: Record<string, unknown>;
     mitigationApplied?: MitigationAction;
@@ -81,25 +79,18 @@ export function recordComplianceEvent(
   const timestamp = new Date().toISOString();
 
   // Build regulatory context
-  const regulatoryContext = buildRegulatoryContext(
-    eventType,
-    options.regulatoryContext,
-  );
+  const regulatoryContext = buildRegulatoryContext(eventType, options.regulatoryContext);
 
   // Build user context
   const userContext: ComplianceUserContext = {
-    sessionHash: options.sessionId
-      ? hashSessionId(options.sessionId)
-      : generateSessionHash(),
-    ageGroup: options.ageGroup || "unknown",
+    sessionHash: options.sessionId ? hashSessionId(options.sessionId) : generateSessionHash(),
+    ageGroup: options.ageGroup || 'unknown',
     region: DEFAULT_COMPLIANCE_CONFIG.defaultRegion,
   };
 
   // Determine mitigation and outcome
-  const mitigationApplied =
-    options.mitigationApplied || determineMitigation(eventType);
-  const outcome =
-    options.outcome || determineOutcome(eventType, mitigationApplied);
+  const mitigationApplied = options.mitigationApplied || determineMitigation(eventType);
+  const outcome = options.outcome || determineOutcome(eventType, mitigationApplied);
 
   const entry: ComplianceAuditEntry = {
     id: entryId,
@@ -108,9 +99,7 @@ export function recordComplianceEvent(
     severity,
     regulatoryContext,
     userContext,
-    eventDetails: options.eventDetails
-      ? sanitizeEventDetails(options.eventDetails)
-      : {},
+    eventDetails: options.eventDetails ? sanitizeEventDetails(options.eventDetails) : {},
     mitigationApplied,
     outcome,
     maestroId: options.maestroId,
@@ -123,18 +112,25 @@ export function recordComplianceEvent(
   // Add to buffer (in-process cache)
   complianceBuffer.push(entry);
 
-  // D-07: persist immediately to the durable store — on serverless the
+  // D-07/D-61: persist to the durable store — on serverless the in-process
   // buffer resets per instance, so the database is the source of truth.
-  void persistEntryToDb(entry);
+  // `after()` keeps the write alive past the response instead of a bare
+  // `void` fire-and-forget, which risked the function freezing immediately
+  // after responding and silently dropping the write (issue #468).
+  try {
+    after(() => persistEntryToDb(entry));
+  } catch {
+    // after() throws outside a request-scoped execution context (e.g. a
+    // plain script or test run outside route handlers) — fall back to
+    // fire-and-forget rather than losing the audit write entirely.
+    void persistEntryToDb(entry);
+  }
 
   // Log based on severity and regulatory impact
   logComplianceEvent(entry, regulatoryContext);
 
   // Critical events with regulatory impact get immediate attention
-  if (
-    severity === "critical" &&
-    DEFAULT_COMPLIANCE_CONFIG.criticalEscalationEnabled
-  ) {
+  if (severity === 'critical' && DEFAULT_COMPLIANCE_CONFIG.criticalEscalationEnabled) {
     escalateComplianceEvent(entry);
   }
 
@@ -153,21 +149,21 @@ export function recordComplianceContentFiltered(
   filterType: string,
   options: {
     sessionId?: string;
-    ageGroup?: ComplianceUserContext["ageGroup"];
+    ageGroup?: ComplianceUserContext['ageGroup'];
     maestroId?: string;
     confidence?: number;
     reason?: string;
   } = {},
 ): string {
-  return recordComplianceEvent("content_filtered", {
-    severity: "medium",
+  return recordComplianceEvent('content_filtered', {
+    severity: 'medium',
     ...options,
     eventDetails: {
       filterType,
       reason: options.reason,
     },
-    mitigationApplied: "content_blocked",
-    outcome: "blocked",
+    mitigationApplied: 'content_blocked',
+    outcome: 'blocked',
     confidenceScore: options.confidence,
   });
 }
@@ -179,21 +175,21 @@ export function recordComplianceCrisisDetected(
   crisisType: string,
   options: {
     sessionId?: string;
-    ageGroup?: ComplianceUserContext["ageGroup"];
+    ageGroup?: ComplianceUserContext['ageGroup'];
     maestroId?: string;
     confidence?: number;
     indicator?: string;
   } = {},
 ): string {
-  return recordComplianceEvent("crisis_detected", {
-    severity: "critical",
+  return recordComplianceEvent('crisis_detected', {
+    severity: 'critical',
     ...options,
     eventDetails: {
       crisisType,
       indicator: options.indicator,
     },
-    mitigationApplied: "escalated_to_human",
-    outcome: "escalated",
+    mitigationApplied: 'escalated_to_human',
+    outcome: 'escalated',
     confidenceScore: options.confidence,
     regulatoryContext: {
       aiAct: true,
@@ -210,20 +206,20 @@ export function recordComplianceCrisisDetected(
 export function recordComplianceJailbreakAttempt(
   options: {
     sessionId?: string;
-    ageGroup?: ComplianceUserContext["ageGroup"];
+    ageGroup?: ComplianceUserContext['ageGroup'];
     maestroId?: string;
     pattern?: string;
     confidence?: number;
   } = {},
 ): string {
-  return recordComplianceEvent("jailbreak_attempt", {
-    severity: "high",
+  return recordComplianceEvent('jailbreak_attempt', {
+    severity: 'high',
     ...options,
     eventDetails: {
-      patternType: options.pattern || "unknown",
+      patternType: options.pattern || 'unknown',
     },
-    mitigationApplied: "content_blocked",
-    outcome: "blocked",
+    mitigationApplied: 'content_blocked',
+    outcome: 'blocked',
     confidenceScore: options.confidence,
     regulatoryContext: {
       aiAct: true,
@@ -241,21 +237,21 @@ export function recordComplianceGuardrailTriggered(
   ruleId: string,
   options: {
     sessionId?: string;
-    ageGroup?: ComplianceUserContext["ageGroup"];
+    ageGroup?: ComplianceUserContext['ageGroup'];
     maestroId?: string;
     confidence?: number;
     ruleCategory?: string;
   } = {},
 ): string {
-  return recordComplianceEvent("guardrail_triggered", {
-    severity: "medium",
+  return recordComplianceEvent('guardrail_triggered', {
+    severity: 'medium',
     ...options,
     eventDetails: {
       ruleId,
       ruleCategory: options.ruleCategory,
     },
-    mitigationApplied: "content_modified",
-    outcome: "modified",
+    mitigationApplied: 'content_modified',
+    outcome: 'modified',
     confidenceScore: options.confidence,
   });
 }
@@ -264,13 +260,13 @@ export function recordComplianceGuardrailTriggered(
  * Get compliance audit entries for analysis
  */
 export function getComplianceEntries(options: {
-  eventType?: ComplianceAuditEntry["eventType"];
-  severity?: ComplianceAuditEntry["severity"];
+  eventType?: ComplianceAuditEntry['eventType'];
+  severity?: ComplianceAuditEntry['severity'];
   outcome?: ComplianceOutcome;
   startDate?: string;
   endDate?: string;
   limit?: number;
-  ageGroup?: ComplianceUserContext["ageGroup"];
+  ageGroup?: ComplianceUserContext['ageGroup'];
 }): ComplianceAuditEntry[] {
   let entries = [...complianceBuffer];
 
@@ -287,9 +283,7 @@ export function getComplianceEntries(options: {
   }
 
   if (options.ageGroup) {
-    entries = entries.filter(
-      (e) => e.userContext.ageGroup === options.ageGroup,
-    );
+    entries = entries.filter((e) => e.userContext.ageGroup === options.ageGroup);
   }
 
   if (options.startDate) {
@@ -300,9 +294,7 @@ export function getComplianceEntries(options: {
     entries = entries.filter((e) => e.timestamp <= options.endDate!);
   }
 
-  entries.sort(
-    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
-  );
+  entries.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
 
   if (options.limit) {
     entries = entries.slice(0, options.limit);
@@ -315,13 +307,9 @@ export function getComplianceEntries(options: {
  * Generate compliance audit statistics (from the in-process cache).
  * For durable statistics use getComplianceStatisticsFromDb (server-only).
  */
-export function getComplianceStatistics(
-  periodDays: number = 30,
-): ComplianceAuditStats {
+export function getComplianceStatistics(periodDays: number = 30): ComplianceAuditStats {
   const now = new Date();
-  const periodStart = new Date(
-    now.getTime() - periodDays * 24 * 60 * 60 * 1000,
-  ).toISOString();
+  const periodStart = new Date(now.getTime() - periodDays * 24 * 60 * 60 * 1000).toISOString();
   const periodEnd = now.toISOString();
 
   return computeComplianceStatistics(complianceBuffer, periodStart, periodEnd);
@@ -375,25 +363,21 @@ function hashSessionId(sessionId: string): string {
 }
 
 function anonymizeUserId(userId: string): string {
-  return (
-    userId.slice(0, DEFAULT_COMPLIANCE_CONFIG.anonymizationKeyLength) + "***"
-  );
+  return userId.slice(0, DEFAULT_COMPLIANCE_CONFIG.anonymizationKeyLength) + '***';
 }
 
 /**
  * Sanitize event details to remove PII fields (GDPR compliance)
  */
-function sanitizeEventDetails(
-  details: Record<string, unknown>,
-): Record<string, unknown> {
-  const piiFields = ["userId", "email", "name", "phone", "address", "ip"];
+function sanitizeEventDetails(details: Record<string, unknown>): Record<string, unknown> {
+  const piiFields = ['userId', 'email', 'name', 'phone', 'address', 'ip'];
   const sanitized: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(details)) {
     if (piiFields.includes(key.toLowerCase())) {
       // Redact PII fields
-      sanitized[key] = "[REDACTED]";
-    } else if (typeof value === "string" && key.toLowerCase().includes("id")) {
+      sanitized[key] = '[REDACTED]';
+    } else if (typeof value === 'string' && key.toLowerCase().includes('id')) {
       // Anonymize any *Id fields that might contain user identifiers
       sanitized[key] = anonymizeUserId(value);
     } else {
@@ -404,59 +388,57 @@ function sanitizeEventDetails(
   return sanitized;
 }
 
-function determineMitigation(
-  eventType: ComplianceAuditEntry["eventType"],
-): MitigationAction {
+function determineMitigation(eventType: ComplianceAuditEntry['eventType']): MitigationAction {
   switch (eventType) {
-    case "crisis_detected":
-      return "escalated_to_human";
-    case "jailbreak_attempt":
-    case "content_filtered":
-      return "content_blocked";
-    case "guardrail_triggered":
-      return "content_modified";
+    case 'crisis_detected':
+      return 'escalated_to_human';
+    case 'jailbreak_attempt':
+    case 'content_filtered':
+      return 'content_blocked';
+    case 'guardrail_triggered':
+      return 'content_modified';
     default:
-      return "none";
+      return 'none';
   }
 }
 
 function determineOutcome(
-  eventType: ComplianceAuditEntry["eventType"],
+  eventType: ComplianceAuditEntry['eventType'],
   mitigation: MitigationAction,
 ): ComplianceOutcome {
   switch (mitigation) {
-    case "content_blocked":
-      return "blocked";
-    case "content_modified":
-      return "modified";
-    case "escalated_to_human":
-      return "escalated";
-    case "user_warned":
-    case "session_paused":
-    case "account_restricted":
-      return "monitored";
+    case 'content_blocked':
+      return 'blocked';
+    case 'content_modified':
+      return 'modified';
+    case 'escalated_to_human':
+      return 'escalated';
+    case 'user_warned':
+    case 'session_paused':
+    case 'account_restricted':
+      return 'monitored';
     default:
-      return "allowed";
+      return 'allowed';
   }
 }
 
 function inferComplianceSeverity(
-  eventType: ComplianceAuditEntry["eventType"],
-): ComplianceAuditEntry["severity"] {
+  eventType: ComplianceAuditEntry['eventType'],
+): ComplianceAuditEntry['severity'] {
   switch (eventType) {
-    case "crisis_detected":
-      return "critical";
-    case "jailbreak_attempt":
-    case "prompt_injection_attempt":
-    case "escalation_triggered":
-    case "safety_config_changed":
-      return "high";
-    case "content_filtered":
-    case "guardrail_triggered":
-    case "knowledge_base_updated":
-      return "medium";
+    case 'crisis_detected':
+      return 'critical';
+    case 'jailbreak_attempt':
+    case 'prompt_injection_attempt':
+    case 'escalation_triggered':
+    case 'safety_config_changed':
+      return 'high';
+    case 'content_filtered':
+    case 'guardrail_triggered':
+    case 'knowledge_base_updated':
+      return 'medium';
     default:
-      return "low";
+      return 'low';
   }
 }
 
@@ -479,30 +461,27 @@ function logComplianceEvent(
   };
 
   switch (entry.severity) {
-    case "critical":
-      log.error("CRITICAL compliance event", logData);
+    case 'critical':
+      log.error('CRITICAL compliance event', logData);
       break;
-    case "high":
-      log.warn("High severity compliance event", logData);
+    case 'high':
+      log.warn('High severity compliance event', logData);
       break;
-    case "medium":
-      log.info("Compliance event recorded", logData);
+    case 'medium':
+      log.info('Compliance event recorded', logData);
       break;
     default:
-      log.debug("Compliance event", logData);
+      log.debug('Compliance event', logData);
   }
 }
 
 function escalateComplianceEvent(entry: ComplianceAuditEntry): void {
-  log.error(
-    "ESCALATION: Critical compliance event requiring immediate attention",
-    {
-      auditId: entry.id,
-      eventType: entry.eventType,
-      timestamp: entry.timestamp,
-      ageGroup: entry.userContext.ageGroup,
-    },
-  );
+  log.error('ESCALATION: Critical compliance event requiring immediate attention', {
+    auditId: entry.id,
+    eventType: entry.eventType,
+    timestamp: entry.timestamp,
+    ageGroup: entry.userContext.ageGroup,
+  });
   // In production, this would trigger alerts, notifications, etc.
 }
 
@@ -521,10 +500,7 @@ export function clearComplianceBuffer(): void {
   complianceBuffer.length = 0;
 }
 
-function generateComplianceSummary(
-  stats: ComplianceAuditStats,
-  _totalEntries: number,
-): string {
+function generateComplianceSummary(stats: ComplianceAuditStats, _totalEntries: number): string {
   let summary = `## Compliance Audit Summary\n`;
   summary += `**Period**: ${stats.periodStart} to ${stats.periodEnd}\n`;
   summary += `**Total Events**: ${stats.totalEvents}\n`;
@@ -554,6 +530,6 @@ function generateComplianceSummary(
 }
 
 // Set up periodic cache trim
-if (typeof setInterval !== "undefined") {
+if (typeof setInterval !== 'undefined') {
   setInterval(trimComplianceBuffer, BUFFER_TRIM_INTERVAL_MS);
 }


### PR DESCRIPTION
## Summary
- Closes #467: bias detection now runs on the streaming chat path (only the non-streaming path had it) — checks the full accumulated output post-hoc and appends a flagged corrective message when bias is detected.
- Closes #468: compliance-audit and crisis side-effect writes (logging, escalation, parent notification) now survive past the response via `next/server`'s `after()` instead of bare fire-and-forget `void` calls, which risked being dropped on a serverless freeze right after responding.
- Partial #469: `triggerSafetyIntervention` no longer silently no-ops when the WebRTC data channel is closed — it now tears down local/remote audio via a `pauseAudio` fallback and still surfaces the UI warning + VCE-004 audit log.

## Deliberately deferred (documented on #469)
The incremental delta-based transcript checking (closing the "audio already played before the `.done` event fires" race) is **not** included here. It would change live WebRTC audio control flow that cannot be verified without a real device/browser session — unverifiable in this environment, and the review that raised #469 already flagged it as future work. Left as a residual limitation on the issue.

## Test plan
- [x] `npx vitest run` on all touched suites (voice-session safety, streaming safety integration, compliance-audit, crisis-flow, check-input-safety) — 304+ tests passing
- [x] `npm run ci:summary` — typecheck/build/lint clean (183 pre-existing lint warnings, unrelated)
- [x] New unit tests added for: bias-on-streaming, `after()`-based audit persistence, closed-channel audio-pause fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhQVTk4CazPswSPN1HSEaZ