### PR TITLE
test(tier): regression coverage for tier-lock intent dialog (TJ.10 verification)

### DIFF
--- a/apps/web/src/app/[locale]/__tests__/home-intent-chooser-tier-lock.test.tsx
+++ b/apps/web/src/app/[locale]/__tests__/home-intent-chooser-tier-lock.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * HomeIntentChooser — tier-lock dialog regression coverage (TJ.10 verification)
+ * @vitest-environment jsdom
+ *
+ * Context: a prior audit (TJ.10) flagged that hitting a tier-gated feature could
+ * silently redirect with no explanation. Investigation found that surface
+ * (this intent picker) already replaced the silent bounce with an explicit,
+ * i18n'd, accessible "ask a grown-up" dialog (UX-03 dialog, home-intent-chooser.tsx),
+ * but the dialog had ZERO test coverage. These tests lock that behavior in:
+ *
+ * - A Trial user (features.mindMaps / features.quizzes = false) tapping a
+ *   gated intent card sees the explicit dialog — never a silent no-op/redirect.
+ * - A user WITH the required tier feature passes straight through to the
+ *   subject-picker step (no regression, no dialog).
+ * - The dialog's i18n keys resolve to real, non-empty copy (not raw keys).
+ */
+
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useTranslations } from 'next-intl';
+import { HomeIntentChooser } from '../home-intent-chooser';
+import { useTierFeatures } from '@/hooks/useTierFeatures';
+
+// --- next-intl -----------------------------------------------------------
+// Minimal real-ish translation table so assertions can check actual copy,
+// not just that *a* string rendered.
+const HOME_MESSAGES: Record<string, string> = {
+  'intent.greeting': 'Ciao! Cosa facciamo oggi?',
+  'intent.greetingNamed': 'Ciao {name}! Cosa facciamo oggi?',
+  'intent.question': 'Scegli da dove partire: ci penso io a guidarti.',
+  'intent.back': 'Indietro',
+  'intent.lockedHint': 'Chiedi a un grande di aprirla',
+  'intent.ttsCardLabel': 'Ascolta: {label}',
+  'intent.subjectSubtitle': 'Scegli la materia: ti porto il professore giusto.',
+  'intent.subjectAny': 'Non lo so / Un po di tutto',
+  'intent.lockedDialog.title': 'Chiedi a un grande di aprirla',
+  'intent.lockedDialog.body':
+    'Questa attività è chiusa con un lucchetto. Chiama mamma, papà o la maestra: possono aprirla per te!',
+  'intent.lockedDialog.listen': 'Ascolta',
+  'intent.lockedDialog.gotIt': 'Ho capito',
+  'intent.homework.title': 'Fare i compiti',
+  'intent.homework.subtitle': 'Ti aiuto passo passo',
+  'intent.homework.subjectTitle': 'Con cosa hai bisogno di aiuto?',
+  'intent.homework.contextMessage': 'contesto compiti',
+  'intent.study.title': 'Studiare',
+  'intent.study.subtitle': 'Facciamo una mappa insieme',
+  'intent.study.subjectTitle': 'Cosa vuoi studiare?',
+  'intent.study.contextMessage': 'contesto studio',
+  'intent.quizMe.title': 'Mettiti alla prova',
+  'intent.quizMe.subtitle': 'Ti faccio io le domande',
+  'intent.quizMe.subjectTitle': 'Su cosa ti metto alla prova?',
+  'intent.quizMe.contextMessage': 'contesto quiz',
+};
+
+function fakeT(key: string, values?: Record<string, string | number>): string {
+  const template = HOME_MESSAGES[key] ?? key;
+  if (!values) return template;
+  return Object.entries(values).reduce(
+    (acc, [name, value]) => acc.replaceAll(`{${name}}`, String(value)),
+    template,
+  );
+}
+
+vi.mock('next-intl', () => ({
+  useTranslations: vi.fn(),
+}));
+
+// --- framer-motion (avoid animation/act warnings, matches existing pattern) --
+vi.mock('framer-motion', () => ({
+  motion: {
+    section: ({ children, ...props }: any) => <section {...props}>{children}</section>,
+  },
+}));
+
+// --- accessibility (TTS) --------------------------------------------------
+const speak = vi.fn();
+vi.mock('@/components/accessibility', () => ({
+  useTTS: () => ({ speak, stop: vi.fn(), enabled: false }),
+}));
+
+// --- tier features ---------------------------------------------------------
+vi.mock('@/hooks/useTierFeatures', () => ({
+  useTierFeatures: vi.fn(),
+}));
+
+describe('HomeIntentChooser — tier-lock dialog (TJ.10 verification)', () => {
+  const onStart = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTranslations as any).mockReturnValue(fakeT);
+  });
+
+  function setTier(features: Record<string, boolean>, isLoading = false) {
+    (useTierFeatures as any).mockReturnValue({
+      hasFeature: (key: string) => features[key] ?? false,
+      isLoading,
+      tier: 'trial',
+      features,
+      isSimulated: false,
+    });
+  }
+
+  it('shows the explicit "ask a grown-up" dialog when a Trial user taps a gated intent (no silent redirect)', () => {
+    setTier({ mindMaps: false, quizzes: false });
+    render(<HomeIntentChooser onStart={onStart} />);
+
+    // Dialog is not present before interaction.
+    expect(screen.queryByTestId('intent-locked-dialog')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('intent-card-study'));
+
+    const dialog = screen.getByTestId('intent-locked-dialog');
+    expect(dialog).toBeInTheDocument();
+    const withinDialog = within(dialog);
+    expect(withinDialog.getByText(HOME_MESSAGES['intent.lockedDialog.title'])).toBeInTheDocument();
+    expect(withinDialog.getByText(HOME_MESSAGES['intent.lockedDialog.body'])).toBeInTheDocument();
+
+    // No navigation/session-start happened — the app did not silently bounce
+    // the user anywhere, it explained the gate in place.
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('marks the locked card as aria-disabled with a discoverable reason (not a hidden/dead control)', () => {
+    setTier({ mindMaps: false, quizzes: false });
+    render(<HomeIntentChooser onStart={onStart} />);
+
+    const card = screen.getByTestId('intent-card-quizMe');
+    expect(card).toHaveAttribute('aria-disabled', 'true');
+    const describedBy = card.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)).toHaveTextContent(
+      HOME_MESSAGES['intent.lockedHint'],
+    );
+  });
+
+  it('closes the dialog via the "Got it" button without starting a session', () => {
+    setTier({ mindMaps: false, quizzes: false });
+    render(<HomeIntentChooser onStart={onStart} />);
+
+    fireEvent.click(screen.getByTestId('intent-card-study'));
+    expect(screen.getByTestId('intent-locked-dialog')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('intent-locked-dialog-close'));
+    expect(screen.queryByTestId('intent-locked-dialog')).not.toBeInTheDocument();
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('lets a user WITH the required tier feature pass straight through to the subject step (no regression)', () => {
+    setTier({ mindMaps: true, quizzes: true });
+    render(<HomeIntentChooser onStart={onStart} />);
+
+    const card = screen.getByTestId('intent-card-study');
+    expect(card).toHaveAttribute('aria-disabled', 'false');
+
+    fireEvent.click(card);
+
+    // No lock dialog — the click advances to the subject-picker step instead.
+    expect(screen.queryByTestId('intent-locked-dialog')).not.toBeInTheDocument();
+    expect(screen.getByText(HOME_MESSAGES['intent.study.subjectTitle'])).toBeInTheDocument();
+  });
+
+  it('always allows the always-on homework intent regardless of tier', () => {
+    setTier({ mindMaps: false, quizzes: false });
+    render(<HomeIntentChooser onStart={onStart} />);
+
+    const card = screen.getByTestId('intent-card-homework');
+    expect(card).toHaveAttribute('aria-disabled', 'false');
+
+    fireEvent.click(card);
+    expect(screen.queryByTestId('intent-locked-dialog')).not.toBeInTheDocument();
+    expect(screen.getByText(HOME_MESSAGES['intent.homework.subjectTitle'])).toBeInTheDocument();
+  });
+
+  it('renders the mocked lockedDialog copy in the dialog (wiring sanity check)', () => {
+    setTier({ mindMaps: false, quizzes: false });
+    render(<HomeIntentChooser onStart={onStart} />);
+
+    fireEvent.click(screen.getByTestId('intent-card-quizMe'));
+
+    const dialog = screen.getByTestId('intent-locked-dialog');
+    const withinDialog = within(dialog);
+    for (const key of [
+      'intent.lockedDialog.title',
+      'intent.lockedDialog.body',
+      'intent.lockedDialog.gotIt',
+    ]) {
+      expect(withinDialog.getByText(HOME_MESSAGES[key])).toBeInTheDocument();
+    }
+  });
+
+  describe('i18n coverage — real message catalogs (not the test mock)', () => {
+    // Task item 4c: "i18n keys exist and resolve". Reading the actual JSON
+    // catalogs (rather than asserting against our own HOME_MESSAGES mock)
+    // guards against a key existing in the mock but missing/empty for real —
+    // `npm run i18n:check` already enforces cross-locale parity (7762/7762 x5),
+    // this locks down that these SPECIFIC keys used by the dialog are present
+    // and non-empty in every shipped locale.
+    const LOCALES = ['it', 'en', 'fr', 'de', 'es'] as const;
+    const DIALOG_KEYS = ['title', 'body', 'listen', 'gotIt'] as const;
+
+    it.each(LOCALES)('messages/%s/home.json has non-empty intent.lockedDialog.*', async (locale) => {
+      const messages = (await import(`../../../../messages/${locale}/home.json`)).default;
+      const lockedDialog = messages?.home?.intent?.lockedDialog;
+      expect(lockedDialog).toBeDefined();
+      for (const key of DIALOG_KEYS) {
+        expect(typeof lockedDialog[key]).toBe('string');
+        expect(lockedDialog[key].trim().length).toBeGreaterThan(0);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Finding first (TJ.10 verification — no code fix needed)

TJ.10's premise — a tier-gated feature silently issuing a 307 redirect with
no explanation — does **not** exist on `main`. Investigated and ruled out
every candidate surface:

- `apps/web/src/proxy.ts:442-445` — the only session-related redirect —
  gates on `!isAuthenticated && !hasTrialSession` (i.e. no auth/trial
  session at all), not on tier **features**. A Trial user with a valid
  visitor cookie passes straight through; nothing here reads
  `mindMaps`/`quizzes`/tier.
- No `page.tsx`/`layout.tsx` does a server-side tier redirect (grepped all
  `redirect(...)` call sites — the rest are locale-routing/login/admin
  stubs, unrelated to tier).
- `useTierFeatures().hasFeature` is consumed in exactly one place in app
  code: `apps/web/src/app/[locale]/home-intent-chooser.tsx`. That's the
  intent picker (Compiti / Studiare / Mettiti alla prova) — tapping a
  locked Study/Quiz card does **not** redirect anywhere. It already opens
  an explicit, child-friendly "ask a grown-up" dialog
  (`home-intent-chooser.tsx:189-197`, dialog at `:430-485`) — shipped in
  PR #430 (UX-03): `aria-describedby` locked hint on the card, focus
  restored to the triggering card on close (WCAG 2.4.3), optional TTS
  readout, and copy in all 5 locales
  (`messages/{it,en,fr,de,es}/home.json` → `home.intent.lockedDialog.*`).
- `docs/plans/PLAN-mirrorbuddy-release.md` only goes up to TJ.9; TJ.10 isn't
  present in the current plan doc.

So the UX this task asked for is already live. What was missing: **zero
test coverage** on that dialog — a real, actionable gap matching task item
4. This PR closes that gap only; no source/UX/i18n changes.

## What changed
- `apps/web/src/app/[locale]/__tests__/home-intent-chooser-tier-lock.test.tsx` (new): regression tests for the tier-lock dialog.

## Test plan
- [x] Trial user (`mindMaps`/`quizzes` off) tapping a gated intent card sees the explicit dialog, not a silent no-op/redirect (`onStart` never called).
- [x] Locked card is `aria-disabled` with a discoverable `aria-describedby` hint (not hidden/dead).
- [x] Dialog dismiss via "Got it" closes without starting a session.
- [x] User **with** the tier feature passes straight through to the subject step — no regression.
- [x] Always-on `homework` intent unaffected by tier.
- [x] `intent.lockedDialog.*` keys resolve to non-empty strings by reading the **real** `messages/{it,en,fr,de,es}/home.json` catalogs (not a test mock) — 5 locale-parameterized assertions.
- [x] `npx vitest run --root apps/web --reporter=dot "src/app/[locale]/__tests__/home-intent-chooser-tier-lock.test.tsx"` — 11/11 passing.
- [x] `npm run i18n:check` — 7762/7762 keys, all 5 locales PASS (unchanged by this PR).
- [x] `./scripts/ci-summary.sh --types` — typecheck PASS.
- [x] Local `next build` fails in this sandboxed worktree only (no `node_modules` installed here — Turbopack refuses to infer a workspace root outside the project dir); confirmed pre-existing and unrelated by removing the new test file and reproducing the identical error. GitHub CI's Build & Lint check is the real gate here.

Observation (not fixed, out of scope): `LockedFeatureOverlay` /
`UpgradePromptModal` under `apps/web/src/components/tier/` are fully unused
(zero non-test/non-example call sites) — dead code from an earlier
"Pro-only overlay" pattern that was never wired up. Flagging for future
cleanup; not wiring it here since no surface currently needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhQVTk4CazPswSPN1HSEaZ