### PR TITLE
fix(security): pin undici/linkify-it to close high-severity advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,8 @@
     "terser-webpack-plugin": "5.3.17",
     "protobufjs": "7.6.4",
     "fast-uri": "3.1.2",
+    "undici": "6.27.0",
+    "linkify-it": "5.0.2",
     "@opentelemetry/otlp-transformer": {
       "protobufjs": "8.6.4"
     },
@@ -259,6 +261,8 @@
       "terser-webpack-plugin": "5.3.17",
       "protobufjs": "7.6.4",
       "fast-uri": "3.1.2",
+      "undici": "6.27.0",
+      "linkify-it": "5.0.2",
       "@opentelemetry/otlp-transformer>protobufjs": "8.6.4",
       "vite": "8.0.16",
       "@grpc/grpc-js": "1.14.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,8 @@ overrides:
   terser-webpack-plugin: 5.3.17
   protobufjs: 7.6.4
   fast-uri: 3.1.2
+  undici: 6.27.0
+  linkify-it: 5.0.2
   '@opentelemetry/otlp-transformer>protobufjs': 8.6.4
   vite: 8.0.16
   '@grpc/grpc-js': 1.14.4
@@ -6491,8 +6493,8 @@ packages:
   linebreak@1.1.0:
     resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
@@ -8415,8 +8417,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   unicode-properties@1.4.1:
@@ -13322,7 +13324,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 6.25.0
+      undici: 6.27.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -14113,7 +14115,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -14152,7 +14154,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -14167,7 +14169,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15537,7 +15539,7 @@ snapshots:
       base64-js: 0.0.8
       unicode-trie: 2.0.0
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -15653,7 +15655,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -16324,7 +16326,7 @@ snapshots:
       semver: 7.7.4
       tar: 7.5.13
       tinyglobby: 0.2.16
-      undici: 6.25.0
+      undici: 6.27.0
       which: 6.0.1
 
   node-readable-to-web-readable-stream@0.4.2:
@@ -17975,7 +17977,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@6.25.0: {}
+  undici@6.27.0: {}
 
   unicode-properties@1.4.1:
     dependencies:


### PR DESCRIPTION
## Summary
Closes #448, closes #451. Both are the same weekly automated pnpm-audit issue (opened 2026-06-22 and 2026-06-29 respectively, same 2 high-severity findings each week — the workflow opens a new issue per run rather than updating one).

- **undici <6.27.0** (GHSA-vxpw-j846-p89q, DoS via WebSocket fragment-count bypass) — transitive via `cheerio > markmap-html-parser > markmap-lib` and `node-gyp` (devDependency).
- **linkify-it <=5.0.0** (GHSA-22p9-wv53-3rq4, quadratic ReDoS) — transitive via `markdown-it > markmap-lib`.

Both resolve to a single version repo-wide (verified with `pnpm why`) with no direct API surface in our code, so pinning via the existing `pnpm.overrides`/`overrides` mechanism (already used for 9 other transitive deps in this repo) is the safe, minimal fix — no major-version jump, no code changes required.

## Test plan
- [x] `pnpm why undici` / `pnpm why linkify-it` — confirm single resolved version each, pinned to patched releases (6.27.0, 5.0.2)
- [x] `pnpm audit --audit-level=high` — 0 high (was 2), 17 total (was 30)
- [x] `npm run ci:summary` — typecheck/build clean, same 183 pre-existing baseline lint warnings
- [x] `npx vitest run -t "markmap"` — 41/41 passing (mind-map feature is the consumer of the linkify-it chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhQVTk4CazPswSPN1HSEaZ