### PR TITLE
fix(hooks): pre-push dedupe check false-positives on merge-sync commits

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -8,8 +8,12 @@ set -euo pipefail
 # i18n validation (unconditional - ensures translation consistency)
 npm run i18n:check || exit 1
 
-# Check for duplicate commit messages in last 5 commits
-DUPLICATE_COMMITS=$(git log --oneline -5 | awk '{$1=""; print $0}' | sort | uniq -d)
+# Check for duplicate commit messages in last 5 commits. Excludes generic
+# "Merge branch 'main' into X" sync commits: GitHub's PR update-branch API
+# legitimately produces one of these per re-sync against a moving base, so
+# the same message repeating is expected noise, not an accidental duplicate
+# commit — the check's actual target.
+DUPLICATE_COMMITS=$(git log --oneline -5 | awk '{$1=""; print $0}' | grep -v "^ Merge branch '.*' into " | sort | uniq -d)
 if [ -n "$DUPLICATE_COMMITS" ]; then
   echo "ERROR: Duplicate commit messages found in last 5 commits:"
   echo "$DUPLICATE_COMMITS"


### PR DESCRIPTION
## Summary
`.husky/pre-push`'s duplicate-commit-message check (last 5 commits) exists to catch accidental duplicate work. This session's heavy use of GitHub's PR `update-branch` API — re-syncing several concurrent PRs against a fast-moving `main`, one merge commit per re-sync — legitimately produces repeated `Merge branch 'main' into X` messages. That blocked every push whose last-5-commit window happened to contain 2+ of them, with no fix available short of rewriting already-pushed history.

## Fix
Exclude the generic `Merge branch '...' into ...` message pattern from the dedup check; every other message still triggers it as before.

## Test plan
- [x] Simulated the check against the actual recent `main` history containing 3 such merge-sync commits in a 5-commit window — passes (empty output) after the fix, failed before
- [x] Simulated a synthetic genuine duplicate (`fix: same message` appearing twice) — still correctly caught
- [x] `bash -n .husky/pre-push` — syntax valid
- [x] `npm run ci:summary` / pre-push Vercel check — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhQVTk4CazPswSPN1HSEaZ