### PR TITLE
docs(plan): update debt registry with session outcomes

### DIFF
--- a/docs/plans/PLAN-mirrorbuddy-release.md
+++ b/docs/plans/PLAN-mirrorbuddy-release.md
@@ -50,309 +50,380 @@
 
 ## Milestone
 
-| Milestone | Contenuto | Uscita |
-|---|---|---|
-| **M0 — Realtà validata** | Fase V completa | Tutte le assunzioni verificate, decisioni prese |
-| **M1 — GA web IT-first** | Fasi 0, 1, 2 (IT), 2-J, 3, 4, C, 5, R complete | Rilascio pubblico italiano |
-| **M2 — Multilingua** | Fase 2 completa (TTS, traduzioni, parity) + Fase C sulle 4 locale | en/fr/de/es attive |
-| **M3 — Mobile** | Fase 6 completa | App Store / Play Store |
+| Milestone                | Contenuto                                                         | Uscita                                          |
+| ------------------------ | ----------------------------------------------------------------- | ----------------------------------------------- |
+| **M0 — Realtà validata** | Fase V completa                                                   | Tutte le assunzioni verificate, decisioni prese |
+| **M1 — GA web IT-first** | Fasi 0, 1, 2 (IT), 2-J, 3, 4, C, 5, R complete                    | Rilascio pubblico italiano                      |
+| **M2 — Multilingua**     | Fase 2 completa (TTS, traduzioni, parity) + Fase C sulle 4 locale | en/fr/de/es attive                              |
+| **M3 — Mobile**          | Fase 6 completa                                                   | App Store / Play Store                          |
 
 **Nota di onestà sulla stima:** la barra "debito zero" costa. M1 ≈ **6–9 settimane-agente** di lavoro seriale (era 2–3 per la versione minima). Con 3–4 worktree paralleli ben orchestrati: **~3–4 settimane di calendario**. Il grosso dell'aumento viene da: refactor in-scope, contratto delle aspettative, purge totale, prova generale. Tagliare è legittimo — ma si taglia spostando voci ad ACCETTATO nel registro, non ignorandole.
 
 ---
 
 # FASE V — Validare la realtà (bloccante, prima di tutto)
-*"Non dare niente per scontato." Ogni assunzione degli audit va verificata a runtime prima di costruirci sopra. Un giorno di lavoro che evita settimane sbagliate. Molte richiedono accessi che solo il maintainer ha.*
+
+_"Non dare niente per scontato." Ogni assunzione degli audit va verificata a runtime prima di costruirci sopra. Un giorno di lavoro che evita settimane sbagliate. Molte richiedono accessi che solo il maintainer ha._
 
 ### TV.1 — Verità del deploy Vercel — **P0 · S · umano+Sonnet**
+
 Dashboard Vercel → Settings → Git: Production Branch? Ignored Build Step? L'ultimo deployment Production corrisponde all'ultimo merge su `main`? Documenta lo stato reale in `docs/ops/DEPLOY-REALITY.md`. Questo decide T0.1.
 
 ### TV.2 — Conflitto di route su `/[locale]` — **P0 · S · Opus**
+
 Builda (`npm run build`) e determina chi vince tra `[locale]/page.tsx` e `[locale]/(marketing)/page.tsx`. Se il build fallisce o warnica: è il primo fix (TJ.1). Se il marketing è morto: va nel registro come demolizione.
 
 ### TV.3 — Quale path chat usa la UI — **P0 · S · Sonnet**
+
 Grep dei call-site client (`/api/chat` vs `/api/chat/stream`) + verifica runtime con network tab su staging. Determina la severità operativa di T1.2 (comunque da fixare entrambi i path).
 
 ### TV.4 — Stato flag di produzione — **P0 · S · umano+Sonnet**
+
 Dump dei feature flag in prod (via /admin o DB): `voice_transcript_safety` (se OFF: la voce non ha NESSUN filtro), `voice_full_prompt`, `voice_ga_protocol`, `coming_soon_overlay`, tutti gli altri. Tabella stato→atteso in `docs/ops/FLAGS.md`. Ogni flag senza consumer va nel registro (demolizione).
 
 ### TV.5 — Comportamento sessione scaduta — **P1 · S · Sonnet**
+
 Verifica runtime del downgrade a trial (`proxy.ts:442-446`): con un cookie account scaduto, dove si atterra davvero? Decide la forma di TJ.6.
 
 ### TV.6 — SSO e Google OAuth: usati da qualcuno? — **P1 · S · umano**
+
 Qualche scuola/tenant usa le route SSO? `lib/google/oauth.ts` è sign-in o solo Drive? Decide TJ.7 (esporre vs potare).
 
 ### TV.7 — Accessi mancanti per l'esecuzione — **P0 · S · umano**
+
 (a) Token Sentry read-only (org `fightthestroke`, project `mirrorbuddy`) → sblocca T5.3; (b) conferma che l'ambiente dell'esecutore raggiunge `binaries.prisma.sh` e può buildare (nel sandbox di questa sessione era bloccato); (c) quota Sentry attuale.
 
 ### TV.8 — Backup e restore del DB — **P0 · S · umano+Sonnet**
+
 Supabase: backup automatici attivi? Point-in-time recovery? **Fai una prova di restore su un progetto scratch** e documenta la procedura in `docs/ops/RUNBOOK-RESTORE.md`. Un prodotto per bambini senza restore provato non si rilascia.
 
 ### TV.9 — Decisioni del maintainer — **✅ CHIUSO il 2026-07-02: il maintainer ha ACCETTATO tutti i default D1–D7** (conferma esplicita in sessione). La tabella resta come riferimento.
-| # | Decisione | Default proposto |
-|---|-----------|------------------|
-| D1 | Trasparenza genitori: transcript o copy | **(b) copy onesto** ("un adulto può vedere un riassunto") + roadmap transcript opzionale |
-| D2 | Workspace packages | **(b) archiviare gli shell inutilizzati**, `apps/web/src/lib` è la casa (finché non esiste una seconda app) |
-| D3 | DEC-06 `maestriLimit` | **Deprecare**: rimuovere da features JSON, seeds, tipi; ADR di chiusura |
-| D4 | SSO | **Potare le route** se TV.6 dice "nessuno le usa"; si riaggiungono quando c'è un tenant |
-| D5 | Onboarding | **1 step essenziale** (nome+età) obbligatorio, resto opzionale (TJ.4) |
-| D6 | Classificazione AI Act | **Richiede legale** — nessun default tecnico possibile; nel frattempo il codice smette di autodefinirsi Art. 14 (coerenza interna, T1.12) |
-| D7 | Gate deploy | **Gate autoritativo** (T0.1 opzione ignoreCommand); l'alternativa "prod = main" è accettabile solo se dichiarata |
+
+| #   | Decisione                               | Default proposto                                                                                                                          |
+| --- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Trasparenza genitori: transcript o copy | **(b) copy onesto** ("un adulto può vedere un riassunto") + roadmap transcript opzionale                                                  |
+| D2  | Workspace packages                      | **(b) archiviare gli shell inutilizzati**, `apps/web/src/lib` è la casa (finché non esiste una seconda app)                               |
+| D3  | DEC-06 `maestriLimit`                   | **Deprecare**: rimuovere da features JSON, seeds, tipi; ADR di chiusura                                                                   |
+| D4  | SSO                                     | **Potare le route** se TV.6 dice "nessuno le usa"; si riaggiungono quando c'è un tenant                                                   |
+| D5  | Onboarding                              | **1 step essenziale** (nome+età) obbligatorio, resto opzionale (TJ.4)                                                                     |
+| D6  | Classificazione AI Act                  | **Richiede legale** — nessun default tecnico possibile; nel frattempo il codice smette di autodefinirsi Art. 14 (coerenza interna, T1.12) |
+| D7  | Gate deploy                             | **Gate autoritativo** (T0.1 opzione ignoreCommand); l'alternativa "prod = main" è accettabile solo se dichiarata                          |
 
 ---
 
 # FASE 0 — Integrità del deploy e verità del CI
-*Quello che il CI dice deve essere vero; quello che va in prod deve passare dal gate. Senza questa fase, ogni altra garanzia è decorativa.*
+
+_Quello che il CI dice deve essere vero; quello che va in prod deve passare dal gate. Senza questa fase, ogni altra garanzia è decorativa._
 
 ### T0.1 — Rendere il Deployment Gate autoritativo su Vercel — **P0 · S · Sonnet (dopo TV.1)**
+
 - **Problema:** `vercel.json` non contiene `ignoreCommand` né config `git`; il commento in `.github/workflows/ci.yml:1900` ("Auto-deploy is disabled via ignoreCommand in vercel.json") è **falso**. Ogni push su `main` deploya in produzione bypassando gate e promote workflow.
 - **Passi:** (1) esito TV.1 alla mano, aggiungi `"ignoreCommand": "exit 0"` a `vercel.json` (i build Git-triggered vengono saltati; `vercel deploy --prebuilt` del CI non è affetto — testa su branch prima); (2) correggi il commento in `ci.yml:1900`; (3) documenta il flusso reale in `docs/ops/DEPLOY-REALITY.md`.
 - **Accettazione:** merge banale su `main` → NESSUN deployment production su Vercel; promote workflow → deployment production. Commento CI vero.
 
 ### T0.2 — Portare `main` E2E al verde: i 10 test `home-intent*` + i 2 flaky — **P0 · M · Opus**
+
 - **Contesto (verificato in sessione):** falliscono 10 spec tra `home-intent.spec.ts`, `home-intent-a11y.spec.ts`, `home-intent-dsa-a11y.spec.ts`, `home-intent-dsa-personas.spec.ts` (i testid esistono in `home-intent-chooser.tsx`: fallimenti runtime, sopravvivono a 3 retry — NON flake, NON il rumore `duplicate key User_pkey` che è gestito da `session-auth.ts`). Più 2 flaky-su-retry da stabilizzare: `locale-switching.spec.ts:146`, `welcome-language-switcher.spec.ts:122`.
 - **Passi:** (1) riproduci localmente contro build prod (`npm run build && npm start` + `npx playwright test apps/web/e2e/home-intent.spec.ts --project=chromium`); (2) diagnosi probabile: mock mancanti in `e2e/fixtures/api-mocks.ts` per API chiamate al mount, o race sul tier-loading; (3) fixa la causa — NON allentare le assertion a11y (proteggono i profili DSA); (4) stabilizza i 2 flaky (attese esplicite, non timeout più lunghi).
 - **Accettazione:** `e2e-tests` e `mobile-e2e` verdi su `main`; 3 run consecutivi senza retry necessari sui 12 spec citati.
 
 ### T0.3 — Report Playwright come artifact CI — **P1 · S · Sonnet**
+
 - Oggi in caso di failure il CI carica solo screenshot; nessun report HTML/trace → il debugging (questa sessione ne ha sofferto) richiede scavare log grezzi. Aggiungi reporter `html` + upload artifact (report + trace) on-failure nel job E2E.
 - **Accettazione:** run fallito di prova → artifact scaricabile con report navigabile.
 
 ### T0.4 — Uptime monitor su produzione — **P1 · S · Sonnet**
+
 - `/api/health` è chiamato solo post-deploy; `infra-monitor.yml` è settimanale. Aggiungi poll schedulato (5-10 min) con notifica email (pattern Resend già in `infra-monitor.yml`) o monitor esterno documentato in `SETUP-PRODUCTION.md`.
 - **Accettazione:** health check fallito di prova → notifica ricevuta.
 
 ### T0.5 — Verità minori del CI — **P2 · S · Sonnet**
+
 - `nightly-benchmark.yml` gira trimestralmente (`0 2 1 */3 *`): correggi schedule o nome. Cron orfani senza schedule: `api/cron/hierarchical-summary`, `api/cron/waitlist-cleanup` → schedule o rimozione.
 - **Accettazione:** ogni cron route ha schedule o non esiste; nomi workflow veritieri.
 
 ---
 
 # FASE 1 — Safety per bambini: collegare ciò che esiste
-*Chiudere il gap "defined-but-not-invoked". Ogni task produce anche un test d'integrazione che fallirebbe se il wiring regredisse. Modello: **Opus/Fable per tutta la fase**. Prima e dopo: `npx tsx scripts/compliance-check.ts --category safety` per documentare che il check statico non coglieva i gap.*
+
+_Chiudere il gap "defined-but-not-invoked". Ogni task produce anche un test d'integrazione che fallirebbe se il wiring regredisse. Modello: **Opus/Fable per tutta la fase**. Prima e dopo: `npx tsx scripts/compliance-check.ts --category safety` per documentare che il check statico non coglieva i gap._
 
 ### T1.1 — Collegare l'intervento safety nel path vocale — **P0 · M**
+
 - **Problema (doppia conferma):** `lib/hooks/voice-session/event-handlers.ts:170-180` (transcript utente) e `:225-239` (transcript assistente) eseguono i check ma su flag/`reject` fanno solo log ("T2-06 will wire"). `triggerSafetyIntervention` (`safety-intervention.ts:114`) è implementato, testato, mai chiamato.
 - **Passi:** (1) transcript utente con `actionTaken !== 'allow'` → `triggerSafetyIntervention(...)` col data channel (`response.cancel` + redirect + audit); (2) transcript assistente `reject` → stop playback (riusa il pattern barge-in `:116-129`) + escalation; (3) escalation crisi vocale allo stesso percorso della chat non-streaming (probabile nuova route `POST /api/safety/escalate` con `withAuth`+`withCSRF`, il voice gira nel browser); (4) unit test del wiring + test che NON scatta su `allow`.
 - **Accettazione:** test verdi che dimostrano cancel+redirect+audit (utente) e stop+escalation (assistente); zero commenti "T2-06" residui (grep).
 
 ### T1.2 — Ripristinare l'escalation di crisi sul path chat streaming — **P0 · S**
+
 - **Problema:** `app/api/chat/stream/route.ts:176` chiama `checkInputSafety` **senza** context; il blocco escalation in `stream/helpers.ts:193-223` è gated su `context` → niente notifica genitori né escalation sul path streaming.
 - **Passi:** passa `{ userId, conversationId, maestroId, locale }`; test d'integrazione: keyword di crisi su streaming → `escalateCrisisDetected` + `notifyParentOfCrisis` invocati.
 - **Accettazione:** parità di comportamento crisi tra i due path; test verde.
 
 ### T1.3 — Parità safety sul path streaming: STEM + bias + sanitizer — **P1 · M**
+
 - `checkSTEMSafety` (`chat/route.ts:357`) e `detectBias` (`:578-586`) esistono solo sul non-streaming. Esegui STEM-check sull'input in `stream/route.ts` pre-stream; bias+sanitize sull'output nel flush finale (documenta il compromesso streaming scelto).
 - **Accettazione:** query STEM pericolosa bloccata su entrambi i path (test).
 
 ### T1.4 — Il bias detection deve avere effetto — **P1 · S**
+
 - `chat/route.ts:578-586`: solo `log.warn`. Su `hasBias && !safeForEducation` → rigenera o fallback educativo; log per audit resta.
 - **Accettazione:** test con output biased mockato → non servito al bambino.
 
 ### T1.5 — Attivare il jailbreak detector — **P1 · M**
+
 - `detectJailbreak`/`escalateRepeatedJailbreak` hanno zero call-site. Invocali su input in `/api/chat`, `/api/chat/stream`, e nel check transcript voce. Soglia `isObviousJailbreak` per il blocco duro, log-only per il resto (falsi positivi con bambini), poi calibra.
 - **Accettazione:** prompt-injection nota → redirect + audit; frase innocua → passa (test).
 
 ### T1.6 — Blocco server-side dei minori sul checkout Stripe — **P1 · S**
+
 - Grown-up gate è client-only (`grown-up-gate-state.ts:6-9`); `/api/checkout/route.ts:24-51` non ha check età/consenso. Aggiungi verifica server-side (usa `CoppaConsent`; in assenza di segnale → 403 con messaggio "chiedi a un genitore") su `/api/checkout` e `/api/billing/portal`.
 - **Accettazione:** test: minore senza consenso → 403; adulto → 200.
 
 ### T1.7 — Dashboard admin safety: DB, non buffer volatili — **P1 · M**
+
 - `/api/admin/safety` legge array in-memory (`escalation-service.ts:43,272-281`; `compliance-audit-service.ts:26,233,284`) che si azzerano per istanza serverless. I percorsi durevoli esistono (`escalation/db-storage.ts`, `ComplianceAuditEntry`). Ripunta letture (e verifica le scritture) al DB.
 - **Accettazione:** eventi scritti → visibili da modulo re-importato (test con Prisma mock).
 
 ### T1.8 — `compliance-check.ts`: da presenza statica a verifica di wiring — **P1 · M**
+
 - I check fanno `fileExists`/`fileContains` (`compliance-checks/safety-systems.ts:12-124`) e alcuni path sono stantii (es. `content-filter/patterns.ts` vs reale `content-filter-patterns.ts`) → false assurance. (1) Correggi i path; (2) aggiungi assertion di call-site per T1.1-T1.5; (3) preferisci test d'integrazione vitest ai grep.
 - **Accettazione:** revert locale temporaneo di un wiring → il check fallisce (dimostralo).
 
 ### T1.9 — Consolidare i moduli safety "gemelli" — **P1 · M**
+
 - 4 moduli in doppia copia con vincitori incoerenti: content-filter (flat vivo), age-gating (flat vivo), output-sanitizer (subdir vivo), jailbreak-detector (subdir vivo); ~1.571 LOC morte (evidenza: import di `lib/safety/index.ts`). Per ciascuno: identifica il vivo, migra le differenze utili, elimina il morto, ripunta i test. Rimuovi gli alias `_legacy`.
 - **Accettazione:** una copia per modulo; grep dei nomi morti = 0; suite safety verde.
 
-### T1.10 — Collegare l'age-gating per fascia d'età — **P1 · M** *(alzato da P2: con TJ.4 il sistema torna ad avere l'età — usarla)*
+### T1.10 — Collegare l'age-gating per fascia d'età — **P1 · M** _(alzato da P2: con TJ.4 il sistema torna ad avere l'età — usarla)_
+
 - `checkAgeGate`/`filterForAge` definiti+testati, mai chiamati. Applica `getAgeGatePrompt`/`filterForAge` con l'età del profilo nel prompt-build di chat E voce (`session-config.ts`).
 - **Accettazione:** stessa domanda, età diverse → istruzioni diverse (test).
 
 ### T1.11 — Alert su tasso di decrypt-failure — **P1 · S**
+
 - `pii-middleware.ts:190-196` degrada silenziosamente a `'[decryption-failed]'`: una rotazione chiavi sbagliata produrrebbe placeholder ovunque senza allarme. Aggiungi metrica + alert (canale di T5.1) su rate > soglia; verifica `lib/security/key-rotation.ts`.
 - **Accettazione:** decrypt-failure simulato → alert.
 
 ### T1.12 — Allineare i documenti compliance alla realtà — **P1 · S (dopo T1.7 e D6)**
+
 - `POST-MARKET-MONITORING-PLAN.md:85,125,242` promette moderazione umana e dashboard realtime (← buffer volatili); classificazione "limited-risk Art. 52" (`:13`) vs codice che cita Art. 14 (`api/admin/safety/route.ts:5`). Aggiorna i doc post-T1.7 e post-decisione D6. Confluisce nella Fase C.
 
 ---
 
 # FASE 2 — Esperienza utente: accessibilità, i18n, tono
-*Il sottoinsieme **[GA-IT]** blocca M1; il resto blocca M2.*
+
+_Il sottoinsieme **[GA-IT]** blocca M1; il resto blocca M2._
 
 ### T2.1 — TTS multilingua — **P0 (M2) · S · Sonnet**
+
 - `accessibility-provider.tsx:189-198`: `utterance.lang = "it-IT"` hardcoded + voce solo italiana; i profili CP/visual auto-attivano TTS (`profiles.ts:48,106`). Passa il locale attivo in `speak()`; voce per prefisso `lang`; fallback documentato.
 - **Accettazione:** test mapping locale→lang; verifica manuale su 2 locale.
 
 ### T2.2 — [GA-IT] Mantenere la promessa "i genitori vedono" — **P0 · M · Opus (decisione D1)**
-- Il prompt dice *"Tutto ciò che scriviamo qui è visibile ai tuoi genitori nella dashboard"* (`safety-prompts-core.ts:220-222`); la parent dashboard mostra solo aggregati. Col default D1(b): copy onesto ("un adulto di fiducia può vedere un riassunto di ciò di cui parliamo") in §8.3 + test aggiornati. Se D1(a): vista transcript con accesso solo genitore verificato.
+
+- Il prompt dice _"Tutto ciò che scriviamo qui è visibile ai tuoi genitori nella dashboard"_ (`safety-prompts-core.ts:220-222`); la parent dashboard mostra solo aggregati. Col default D1(b): copy onesto ("un adulto di fiducia può vedere un riassunto di ciò di cui parliamo") in §8.3 + test aggiornati. Se D1(a): vista transcript con accesso solo genitore verificato.
 - **Accettazione:** copy e realtà coincidono; test verdi.
 
 ### T2.3 — [GA-IT] Error copy child-friendly + namespace `errors` risanato — **P1 · M · Sonnet**
+
 - Copy tecnico anche in IT ("Timeout richiesta" — `messages/it/errors.json:3-9`); struttura corrotta in tutte le locale (chiavi generiche annidate in `validation`, `it/errors.json:29-49`, con "Not Found" inglese nell'IT); `de/errors.json` in gran parte inglese + residuo italiano.
 - **Passi:** risana struttura (ADR 0104/0091); varianti child-tone per gli errori child-facing, usate nei componenti child-space; completa il tedesco; sync + check.
 - **Accettazione:** `npm run i18n:check` verde; zero stringhe inglesi nei json IT; errore chat child-space mostra il nuovo copy (test/screenshot).
 
 ### T2.4 — Sweep `[TRANSLATE]` + parity namespace `voice` + fix del checker — **P1 · S · Sonnet**
+
 - `fr/home.json` ha `"[TRANSLATE] Clicca..."` visibile; `it/voice.json` manca di 9 sotto-namespace presenti nelle altre 4 locale (115 vs 125 chiavi) e `i18n:check` non l'ha colto (probabile check unidirezionale IT→altre). Traduci, riconcilia (grep dei call-site per capire le chiavi vive), rendi il check bidirezionale.
 - **Accettazione:** zero `[TRANSLATE]`; parity 5-locale; `i18n:check` esteso fallisce su chiavi orfane (dimostralo).
 
 ### T2.5 — [GA-IT] Date/orari localizzati — **P1 · S · Sonnet**
+
 - `recent-sessions-list.tsx:22-25` ("Oggi"/"Ieri", `toLocaleDateString("it-IT")`), `message-bubble.tsx:122` (`toLocaleTimeString('it-IT')`) → `useFormatter()` di next-intl. Indaga perché `no-hardcoded-italian` non li becca ed estendi la regola se possibile.
 - **Accettazione:** zero `it-IT` hardcoded nei componenti; lint verde.
 
 ### T2.6 — [GA-IT] Profili DSA mutuamente esclusivi — **P1 · S · Opus**
+
 - `accessibility-store/profiles.ts`: ogni `apply*Profile` fa spread senza azzerare i flag del precedente → stato sovrapposto imprevedibile (per bambini autistici/ADHD la prevedibilità È la feature). Reset a `defaultAccessibilitySettings` prima di applicare (preservando esplicitamente le preferenze non-profilo scelte — decidi e documenta quali).
 - **Accettazione:** test: ADHD→Visual non lascia `adhdMode`/`distractionFreeMode` attivi.
 
-### T2.7 — [GA-IT] Stati di caricamento/errore/vuoto nello spazio bambino — **P1 · M · Opus** *(nuovo in v2)*
+### T2.7 — [GA-IT] Stati di caricamento/errore/vuoto nello spazio bambino — **P1 · M · Opus** _(nuovo in v2)_
+
 - Censimento sistematico: per ogni superficie child-facing (home, chat, voce, tool, archivio) verifica che loading/errore/vuoto siano calmi, i18n, con azione chiara ("Riprova", "Chiama un grande") e TTS-leggibili. Il caso noto: "Caricamento..." bloccato = CSP (root CLAUDE.md) — lo stato d'errore deve dirlo in linguaggio da bambino, non restare muto.
 - **Accettazione:** tabella superfici×stati completata in `docs/UX-STATES.md`; fix applicati; E2E per i 3 stati sulla chat.
 
-### T2.8 — Guida al tono di voce child-first — **P2 · S · Opus** *(nuovo in v2)*
+### T2.8 — Guida al tono di voce child-first — **P2 · S · Opus** _(nuovo in v2)_
+
 - Le regole implicite (frasi brevi, zero jargon, rassicurante, mai colpevolizzante, prezzo/commercio mai nel child-space) diventano `docs/UX-WRITING.md` con esempi giusto/sbagliato per: errori, limiti trial, lock di tier, onboarding, safety redirect. Diventa il riferimento per ogni PR con testo UI.
 - **Accettazione:** documento + linter di massima (lista parole vietate nel child-space, es. "errore del server", "non autorizzato", "9.99").
 
 ### T2.9 — `syncWithSystem` reale + suggerimento profilo — **P2 · M · Sonnet**
+
 - `browser-detection.ts:41-57` mappa solo reduced-motion/contrast; `syncWithSystem()` è stub vuoto (`accessibility-provider.tsx:128-137`). Implementa + nudge dismissibile al primo accesso ("Ho notato che preferisci meno animazioni — vuoi il profilo calmo?"). Persistenza cookie/DB (no localStorage).
 - **Accettazione:** unit test mapping; nudge una-tantum verificato.
 
 ---
 
 # FASE 2-J — Rifare il funnel: landing → autenticazione → primo uso
-*Mappa completa con evidenze in Appendice C. Il layer proxy/routing è pulito; il caos è sopra: tre landing sovrapposte, conflitto di route su `/`, gate morti, CTA primaria che azzera l'onboarding, genitore che compila l'identità del figlio senza handoff. Modello: Opus per TJ.1/TJ.4/TJ.5, Sonnet per il resto. **Tutta la fase è [GA-IT].***
+
+\*Mappa completa con evidenze in Appendice C. Il layer proxy/routing è pulito; il caos è sopra: tre landing sovrapposte, conflitto di route su `/`, gate morti, CTA primaria che azzera l'onboarding, genitore che compila l'identità del figlio senza handoff. Modello: Opus per TJ.1/TJ.4/TJ.5, Sonnet per il resto. **Tutta la fase è [GA-IT].\***
 
 **Journey target (definizione di fatto):**
+
 - **Bambino trial**: prima schermata → valore in **≤3 interazioni** (oggi ~5, o ~9-10 con onboarding vocale).
 - **Genitore invitato**: percorso esplicitamente da adulto (login → setup profilo figlio → handoff "passa il dispositivo a…"), mai ambiguo chi è alla tastiera.
 - **Bambino di ritorno**: ≤2 interazioni (oggi ~2-3, preservare).
 - **UNA** landing pubblica; `/welcome` = solo onboarding.
 
 ### TJ.1 — Risolvere il conflitto di route su `/[locale]` — **P0 · S · Opus (dopo TV.2)**
+
 - `[locale]/page.tsx` (home bambino) E `[locale]/(marketing)/page.tsx` risolvono entrambe a `/[locale]`. Esito TV.2 alla mano: elimina il gruppo `(marketing)` o spostalo su path reale (`/scopri`).
 - **Accettazione:** una sola page per `/[locale]`; build pulito; decisione nel registro.
 
 ### TJ.2 — Una sola landing — **P1 · M · Sonnet**
+
 - Tre superfici: `(marketing)/page.tsx`; `welcome/components/landing-page.tsx` dentro `/welcome` (`welcome/page.tsx:39,118-122`); `[locale]/landing/page.tsx` (fallback provider, `proxy.ts:453-457`). Consolida su una landing pubblica; `/welcome` = solo onboarding; il fallback diventa `/service-unavailable`.
 - **Accettazione:** un solo componente landing (grep); E2E percorso anonimo aggiornato.
 
 ### TJ.3 — Bonifica del codice morto del funnel — **P1 · S · Sonnet**
+
 - Elimina: `TosGateProvider`, `TrialConsentGate`, `CookieConsentWall` (zero import non-test; vive solo `UnifiedConsentWall`, `providers.tsx:10,170`) + riferimenti in ADR 0098; duplicato `app/invite/request/page.tsx:11-13`; vestigia waitlist/coming-soon (flag OFF default `feature-flags-service.ts:174-180`, pagina inesistente, CHANGELOG che descrive redirect mai esistiti → correggi anche il CHANGELOG, vedi Fase C). Aggiorna `e2e/global-setup.ts` e fixture che mockano i gate morti.
 - **Accettazione:** grep componenti morti = 0; `ci:summary` verde; ADR/CHANGELOG corretti.
 
 ### TJ.4 — Onboarding: 1 step essenziale, mai falsificato — **P1 · M · Opus (decisione D5)**
+
 - "Prova gratis" POSTa `hasCompletedOnboarding:true` saltando tutto (`landing-page.tsx:88-102`): il bambino non dà mai nome/età → personalizzazione e age-gating (T1.10) azzoppati; lo stato in DB è falso. Ridisegna: 1 step obbligatorio (nome+età, opzione vocale, TTS) + resto opzionale/riprendibile; stato `skipped` esplicito, mai `completed` fasullo. Sostituisce il vecchio T2.7-v1 ("salta e prova").
 - **Accettazione:** trial → valore in ≤3 interazioni CON nome+età raccolti; stato onboarding veritiero (test DB); E2E aggiornato.
 
 ### TJ.5 — Handoff genitore→bambino dopo il primo login — **P1 · M · Opus**
+
 - Il genitore invitato fa login → cambio password → onboarding vocale che chiede i dati DEL FIGLIO senza cambio di contesto (Journey B). Aggiungi branch post-primo-login: "Sei un genitore/tutor? Configura il profilo di tuo figlio" (form adulto) → schermata handoff "Passa il dispositivo a {nome}" → home bambino. Riusa il grown-up gate per il rientro nell'area adulti.
 - **Accettazione:** E2E Journey B: nessuna schermata child-voice al genitore; dati minore raccolti in contesto dichiaratamente adulto.
 
 ### TJ.6 — Sessione account scaduta → `/login`, non downgrade a trial — **P1 · S · Sonnet (dopo TV.5)**
+
 - `proxy.ts:442-446`: route protetta senza sessione → `/welcome` (crea trial). Minimo: route `AUTH_ONLY` (`/parent-dashboard`, `proxy.ts:85,431-438`) → SEMPRE `/login`; con evidenza di account precedente → `/login`, altrimenti `/welcome`.
 - **Accettazione:** test proxy: AUTH_ONLY senza sessione → `/login`.
 
 ### TJ.7 — SSO e Google: esporre o potare — **P1 · S/M · (decisione D4, dopo TV.6)**
+
 - Backend SSO MS365/Google-Workspace/OIDC senza entry-point UI; `/login` solo email+password; `lib/google/oauth.ts` probabilmente solo Drive. Default D4: pota le route; documenta Google=Drive.
 - **Accettazione:** o UI presente e testata, o route rimosse; registro aggiornato.
 
 ### TJ.8 — "Richiedi accesso" fuori dalla sidebar del bambino — **P1 · S · Sonnet**
+
 - `home-sidebar.tsx:230-239`: link a form PII nello spazio bambino; i commenti (`page.tsx:41,291-294`) mostrano leakage combattuta ad hoc. Sposta la CTA dietro il grown-up gate nell'area genitori; nella sidebar bambino al massimo "Chiedi a un grande" senza form.
 - **Accettazione:** nessun form PII raggiungibile dal child-space senza gate; E2E aggiornato.
 
-### TJ.9 — Misurare il funnel — **P2 · M · Sonnet** *(nuovo in v2)*
+### TJ.9 — Misurare il funnel — **P2 · M · Sonnet** _(nuovo in v2)_
+
 - Esiste `lib/funnel` (tracking mockato negli E2E) ma nessuna misura dichiarata dei target di journey. Definisci i 5 eventi chiave (landing_view, trial_start, first_message, first_tool, return_visit), verifica che il tracking spari davvero (test), crea query/dashboard minima (Grafana già in stack) per verificare i target ≤3/≤2 interazioni dopo il rilascio.
 - **Accettazione:** eventi documentati in `docs/analytics/FUNNEL.md`; test tracking; dashboard con le 5 serie.
 
 ---
 
 # FASE 3 — Correttezza del core educativo
-*Regola v2: ogni feature visibile in UI funziona end-to-end (create → render → persist → riapri) o esce dalla UI. Nessuna feature vetrina.*
+
+_Regola v2: ogni feature visibile in UI funziona end-to-end (create → render → persist → riapri) o esce dalla UI. Nessuna feature vetrina._
 
 ### T3.1 — Persistere il progresso flashcard (FSRS) — **P1 · M · Opus**
+
 - Il review flow salva il deck come JSON in `/api/materials` (`use-flashcards-view.ts:97-110,122-154`) e non scrive MAI `FlashcardProgress` → `scheduler/check-due:76-84` (push "Flashcard pronte!") e `dashboard/fsrs-stats:25-89` girano su tabella vuota per sempre. POST per-card a `/api/flashcards/progress` (route esistente e inutilizzata) oltre al salvataggio materiale.
 - **Accettazione:** review di 3 carte → 3 righe `FlashcardProgress` (test); scheduler con carta due → notifica candidata.
 
 ### T3.2 — Un solo FSRS — **P1 · M · Opus**
+
 - Due implementazioni divergenti: `packages/education/src/fsrs/core.ts` (documentata, morta a runtime) vs `components/education/flashcards-view/utils/fsrs.ts:17` (`fsrs5Schedule`, viva). Consolida su FSRS-5 in `@/lib/education/fsrs`, elimina la morta, migra i test, aggiorna CLAUDE.md.
 - **Accettazione:** una sola implementazione; grep = 0; test verdi.
 
 ### T3.3 — Renderer completi: timeline live, tool canvas, calculator archive — **P1 · M · Sonnet**
+
 - Timeline → JSON grezzo in chat inline (`tool-content-renderers.tsx:73-141`, manca il case) e nel canvas (`tool-canvas/tool-renderer.tsx:121-131`); il canvas copre solo 5 tipi su 10+ (mancano chart, formula, calculator, demo, timeline); calculator senza renderer archive (`knowledge-hub/renderers/index.tsx:52-84`) né plugin. Aggiungi i case riusando i renderer esistenti; `calculator` in `rendererImports`.
 - **Accettazione:** test per OGNI tipo registrato su chat inline, canvas e archive: nessun JSON grezzo. Matrice tipi×superfici in `docs/UX-STATES.md`.
 
 ### T3.4 — Parità RAG voce/chat — **P1 · M · Opus**
+
 - La chat inietta memoria + RAG maestro-knowledge (`context-builders.ts:7,12-14,219`); la voce solo summary/keyFacts (`memory-utils.ts:36-110`). Aggiungi retrieval nel builder instructions voce (`session-config.ts`, fetch già parallelizzate), con troncamento che dà priorità al safety. Se costo/latenza non valgono: documenta la divergenza in CLAUDE.md e chiudi ACCETTATO.
 - **Accettazione:** KB nel prompt voce (log/test); timing di connessione entro budget (T5.4).
 
 ### T3.5 — Mini-KB coerenti per tutti i maestri — **P2 · S · Sonnet**
+
 - `cassese`, `ippocrate`, `lovelace`, `simone` non interpolano il proprio `*_MINI_KB` (pattern: `curie.ts:7,87`); `mascetti` registrato ma asset KB chiamati `amici-miei-*`. Interpola i 4; riconcilia mascetti.
 - **Accettazione:** `compliance-check --category characters` verde; ogni maestro con mini-kb lo importa (grep).
 
 ### T3.6 — Data-retention: riconciliare cron reale e service stub — **P1 · M · Opus**
+
 - `api/cron/data-retention/route.ts` è reale e multi-fase; `lib/privacy/data-retention-service.ts:13` si autodefinisce stub (mancano migrazioni: UserPrivacyPreferences, `markedForDeletion`, Embedding). Chiarisci il delta, implementalo o elimina lo stub e correggi i claim F-02 (→ Fase C).
 - **Accettazione:** zero moduli che si dichiarano stub in prod; doc coerenti.
 
-### T3.7 — Igiene DB e seeds — **P1 · S · Sonnet** *(nuovo in v2)*
+### T3.7 — Igiene DB e seeds — **P1 · S · Sonnet** _(nuovo in v2)_
+
 - `npx prisma migrate diff` tra schema e migrazioni = pulito; seeds coerenti con D3 (rimozione `maestriLimit` da `tier-fallbacks.ts`, `tier-seed.ts`, tipi — chiudi DEC-06 con mini-ADR); verifica che la migrazione drop-community (daa1268) sia stata applicata in prod (TV.8 aiuta).
 - **Accettazione:** diff vuoto; grep `maestriLimit` = 0; ADR DEC-06 chiuso.
 
 ---
 
 # FASE 4 — Purge totale e igiene del codice
-*In v2 tutto questo è in-scope pre-rilascio (era in parte post-GA). Modello: Sonnet salvo indicato. Ordine consigliato: prima le demolizioni (riducono la superficie di tutto il resto).*
+
+_In v2 tutto questo è in-scope pre-rilascio (era in parte post-GA). Modello: Sonnet salvo indicato. Ordine consigliato: prima le demolizioni (riducono la superficie di tutto il resto)._
 
 ### T4.1 — Eliminare le varianti UI morte (4.102 LOC) — **P1 · S**
+
 - 12 file `maestro-session-*` (v1-v4, proposal1/2) + `header-variants/` (a-e) + `PROPOSALS_README.md`: referenziati solo dal README; il vivo è `maestro-session.tsx`.
 - **Accettazione:** `ci:summary` verde; grep = 0.
 
 ### T4.2 — Archiviare/eliminare gli orfani — **P1 · S**
+
 - `backend/` (FastAPI azure_costs, zero referenze), `testingcase/` (6 script Python), `reports/route-inventory.json` (2026-01-19, stantio), e valuta `terraform/`, `monitoring/`, `grafana/`, `load-tests/` (tutti congelati da PR #348): per ciascuno → voce nel registro con decisione (wire+document / archive / delete; default: `load-tests` si RIATTIVA in Fase R, `grafana`+`monitoring` si verificano con TV.7/T5.x, il resto si archivia).
 - **Accettazione:** root senza directory non contabilizzate; registro aggiornato.
 
 ### T4.3 — Workspace packages: eseguire la decisione D2 — **P1 · L · Opus**
+
 - 7/14 packages mai importati (`maestri, safety, tier, ai-providers, accessibility` + parte di `db`) e duplicano logica viva in `apps/web/src/lib`. Default D2(b): archivia gli shell, dichiara `apps/web/src/lib` la casa, aggiorna CLAUDE.md e le import-map. Attenzione: `packages/db` contiene `pii-middleware.ts` VIVO — verifica import per import cosa è consumato prima di toccare.
 - **Accettazione:** una sola copia per dominio; build+test verdi; CLAUDE.md aggiornato.
 
 ### T4.4 — Route igiene: ritirati, debug, flags — **P1 · S**
+
 - Elimina `api/embeddings/route.ts` (stub "retired"); `debug/`, `debug-cert/`, `debug-env/`, `test/` → env-gated OFF in prod o eliminati; censimento feature flags: ogni flag senza consumer o permanentemente ON/OFF → rimuovi flag e ramo morto (incluso `coming_soon_overlay` post-TJ.3).
 - **Accettazione:** nessuna route debug in prod build; ogni flag ha un consumer vivo (tabella in `docs/ops/FLAGS.md`).
 
 ### T4.5 — Hardening route pubbliche mutanti — **P1 · M · Opus**
+
 - `homework/analyze/route.ts:24`, `search/route.ts:96` (POST con solo `withSentry`), più `contact`, `waitlist/signup`, `realtime/sdp-exchange`: verifica una per una `withRateLimit` + validazione Zod; aggiungi dove manca. Estendi `compliance-check --category api`: ogni route mutante ha auth O (rate-limit+validazione) O firma webhook O cron secret; documenta le esenzioni dei 33 senza CSRF.
 - **Accettazione:** check esteso verde, e fallisce su una route nuda aggiunta ad arte (dimostralo).
 
 ### T4.6 — Config e soppressioni — **P1 · S**
+
 - `engines.node` in package.json; pin pnpm sospetti (`lodash 4.18.1` inesistente upstream, `vite 8.0.16`, `eslint-plugin-react-hooks 7.0.1`) verificati con install pulita; `SENTRY_DSN` in `.env.example`; policy file-line: ratchet in CI (nessun nuovo file oltre soglia, nessun peggioramento dei file toccati); sweep dei 139 `eslint-disable` prod + 24 `@ts-ignore`: fix o commento di giustificazione; `: any` prod → 0; tipizza le fixture/mock condivise dei test (riduce i 1.072 `as any` senza inseguire ogni singolo test).
 - **Accettazione:** install pulita OK; CI con ratchet attivo; grep `@ts-ignore` senza giustificazione = 0; report prima/dopo dei conteggi nel registro.
 
-### T4.7 — Refactor dei top-5 file monstre — **P1 · L · Opus** *(in-scope in v2)*
+### T4.7 — Refactor dei top-5 file monstre — **P1 · L · Opus** _(in-scope in v2)_
+
 - `lib/tier/tier-service.ts` (713), `app/api/chat/route.ts` (711), `lib/admin/user-trash-service.ts` (700), `lib/email/campaign-service.ts` (650), `lib/safety/audit/compliance-audit-service.ts` (630). Split per responsabilità, zero cambi di comportamento; per `chat/route.ts` coordina con T1.3/T1.4 (fai PRIMA il wiring safety, POI il refactor, così i test d'integrazione proteggono lo split).
 - **Accettazione:** test invariati prima/dopo (stessa suite verde); nessun file >400 righe tra i 5.
 
 ---
 
 # FASE C — Contratto delle aspettative (promesse vs realtà)
-*"Match con aspettative perfetto" reso operativo: censire OGNI promessa che il prodotto fa e verificarla. Ogni claim finisce in uno di tre stati: VERO (con prova) · SISTEMATO (codice adeguato) · RIMOSSO (claim corretto). Modello: Opus. Output: `docs/EXPECTATIONS-CONTRACT.md` con la tabella completa.*
+
+_"Match con aspettative perfetto" reso operativo: censire OGNI promessa che il prodotto fa e verificarla. Ogni claim finisce in uno di tre stati: VERO (con prova) · SISTEMATO (codice adeguato) · RIMOSSO (claim corretto). Modello: Opus. Output: `docs/EXPECTATIONS-CONTRACT.md` con la tabella completa._
 
 ### TC.1 — Censimento delle superfici di promessa — **P0 · M**
-- Sorgenti da passare al setaccio: copy UI (messages/*), landing/marketing, `README.md`, `CHANGELOG.md`, `ARCHITECTURE.md`, ADR attivi, `docs/compliance/*` (DPIA, AI-POLICY, MODEL-CARD, PMM), prompt di sistema dei maestri e safety prompts, `store-metadata/`, pagine pubbliche (`/ai-transparency`, `/privacy`, `/terms`, `/accessibility`).
+
+- Sorgenti da passare al setaccio: copy UI (messages/_), landing/marketing, `README.md`, `CHANGELOG.md`, `ARCHITECTURE.md`, ADR attivi, `docs/compliance/_`(DPIA, AI-POLICY, MODEL-CARD, PMM), prompt di sistema dei maestri e safety prompts,`store-metadata/`, pagine pubbliche (`/ai-transparency`, `/privacy`, `/terms`, `/accessibility`).
 - **Accettazione:** tabella claim→stato→prova in `docs/EXPECTATIONS-CONTRACT.md`; zero claim in stato "aperto".
 
 ### TC.2 — Falsi noti da correggere subito (dagli audit) — **P0 · S**
+
 - CHANGELOG: redirect `/coming-soon` mai esistito; ADR 0098 descrive gate morti; PMM: moderazione umana/dashboard realtime (post T1.7); "visibile ai genitori" (post T2.2/D1); F-02 retention (post T3.6); commento CI ignoreCommand (post T0.1); CLAUDE.md: FSRS home sbagliata (post T3.2), "26 Maestri… voice, FSRS" — verifica ogni claim della prima riga.
 - **Accettazione:** ogni falso noto corretto; diff citati nella tabella TC.1.
 
 ### TC.3 — Revisione età-appropriatezza dei 26 maestri — **P1 · M**
+
 - Passa i 26 systemPrompt con lente 8-14 DSA: linguaggio, aneddoti, "intensity dial" coerente, formal address (ADR 0064, `FORMAL_PROFESSORS`), niente contenuto che contraddica i safety prompt. `compliance-check --category characters` + revisione LLM documentata.
 - **Accettazione:** report per maestro (ok/fix) in `docs/EXPECTATIONS-CONTRACT.md`; fix applicati.
 
 ### TC.4 — Stato ADR e documentazione — **P1 · S**
+
 - Ogni ADR riceve header di stato (active/superseded/rejected); `docs-archive/` dichiarato tale nel README; `ARCHITECTURE.md`/`ARCHITECTURE-DIAGRAMS.md` allineati alla realtà post-purge (packages, backend, community rimossa).
 - **Accettazione:** zero ADR senza stato; architettura descritta = architettura reale.
 
@@ -361,18 +432,22 @@ Supabase: backup automatici attivi? Point-in-time recovery? **Fai una prova di r
 # FASE 5 — Observability e performance con i denti
 
 ### T5.1 — Alerting collegato a un canale reale — **P1 · M · Opus**
+
 - `lib/alerting/go-nogo-alerting.ts` calcola e non spedisce (campi canale inutilizzati in `types.ts:75-77`; history in-memory). Implementa notifier (Resend già in stack, o Slack webhook) con dedupe; consumatori: T0.4 (uptime), T1.11 (decrypt-failure), SLO (T5.4). Oppure elimina i campi morti e demanda tutto a Sentry+uptime — decisione nel registro.
 - **Accettazione:** alert di test recapitato; runbook in `docs/ops/`.
 
 ### T5.2 — Budget di performance reali in CI — **P1 · S · Sonnet**
+
 - `bundlewatch.config.json` mai invocato; il job CI fallisce solo su chunk >2MB (`ci.yml:1639-1646`); `lhci autorun || echo` (`ci.yml:1684`) non può fallire. Step bundlewatch reale; rimuovi `|| echo`; se i budget sono già sforati, tara ai valori attuali+10% e stringi dopo.
 - **Accettazione:** PR che gonfia un bundle ad arte fallisce il CI (dimostralo e reverta).
 
 ### T5.3 — Sentry: sampling, DSN, triage — **P1 · S+M · Sonnet (dopo TV.7)**
+
 - `tracesSampleRate: 1.0` client+server e `replaysOnErrorSampleRate: 1.0` → 0.1-0.2 con `tracesSampler` a 1.0 sulle route critiche (voice, chat, checkout); `SENTRY_DSN` in `.env.example`. Col token (TV.7): triage top-20 issue per volume → classifica (bug reale / rumore / già fixato da #449-#452) → issue GitHub per i reali.
 - **Accettazione:** sampling deployato; report triage in `docs/plans/`; issue aperte.
 
-### T5.4 — SLO e budget di latenza voce — **P2 · M · Opus** *(nuovo in v2)*
+### T5.4 — SLO e budget di latenza voce — **P2 · M · Opus** _(nuovo in v2)_
+
 - Definisci SLO misurabili: disponibilità `/api/health`, p75 latenza prima-risposta chat, success-rate connessione voce, p75 connect→greeting (i timing log esistono già in `event-handlers.ts` "Connection timing"). Esponili (metrics-push → Grafana) e collega alert (T5.1).
 - **Accettazione:** dashboard con le 4 serie; alert su violazione simulata.
 
@@ -381,63 +456,73 @@ Supabase: backup automatici attivi? Point-in-time recovery? **Fai una prova di r
 # FASE 6 — Traccia mobile (post-M1)
 
 ### T6.1 — Info.plist: permessi microfono/camera — **P0(M3) · S · Sonnet**
+
 - `ios/App/App/Info.plist` senza `NSMicrophoneUsageDescription`/`NSCameraUsageDescription` → getUserMedia muto in WKWebView + rigetto App Store. Purpose string child-appropriate IT+EN.
 - **Accettazione:** `npm run ios:check` verde.
 
 ### T6.2 — Backend per la shell nativa — **P0(M3) · M · Opus**
+
 - `next.config.mobile.ts:19` è `output:'export'` senza route handler; `capacitor.config.ts:7-11` `server.url` commentato; nessuna base URL assoluta → nell'app nativa tutte le API 404ano. Scegli: shell remota (`server.url` → prod) o base `NEXT_PUBLIC_APP_URL` con `Capacitor.isNativePlatform()`; poi risolvi cookie/CSRF cross-origin (`credentials:'include'` + CORS, o shell remota che li evita).
 - **Accettazione:** simulatore: login, chat, un tool end-to-end.
 
 ### T6.3 — Voce su device reale + submission — **P1(M3) · L · umano+Opus**
+
 - WebRTC in WKWebView da verificare SU DISPOSITIVO. Poi: `ios-release-check.sh:66` fixato (version-check `$(MARKETING_VERSION)` off-macOS), fastlane, store-metadata (passa da Fase C), TestFlight. Android: stessa trafila con `android/fastlane`.
 
 ---
 
 # FASE R — Prova generale di rilascio
-*L'ultima fase non scrive feature: dimostra che tutto il resto è vero. Modello: Opus + maintainer.*
+
+_L'ultima fase non scrive feature: dimostra che tutto il resto è vero. Modello: Opus + maintainer._
 
 ### TR.1 — Clean-room build — **P0 · S**
+
 - Da checkout pulito: `pnpm install --frozen-lockfile` → `npx prisma generate` → `npm run ci:summary` → `npm run test:unit` → suite E2E completa (`./scripts/ci-summary.sh --e2e --a11y`). Zero warning nuovi tollerati senza voce nel registro.
 - **Accettazione:** output incollati; tutto verde al primo colpo.
 
 ### TR.2 — Coverage matrix delle feature visibili — **P0 · M**
+
 - Tabella: ogni feature raggiungibile dalla UI (child e admin) × happy-path E2E esistente. Buchi → o si scrive il test o la feature esce dalla UI (regola Fase 3).
 - **Accettazione:** matrice in `docs/plans/RELEASE-COVERAGE.md` senza buchi non contabilizzati.
 
 ### TR.3 — Deploy rehearsal + rollback — **P0 · M**
+
 - Staging deploy dal gate verde → smoke su staging → `promote-to-production.yml` → health check → **rollback provato** (promote del deployment precedente) → runbook `docs/ops/RUNBOOK-RELEASE.md` con: procedura, rollback, contatti, criteri di abort.
 - **Accettazione:** promote e rollback eseguiti davvero almeno una volta; runbook scritto da chi l'ha fatto.
 
 ### TR.4 — Load smoke — **P1 · M**
+
 - Riattiva `load-tests/` (k6, congelato da PR #348) con uno scenario minimo su staging: 50 utenti concorrenti su home+chat; verifica rate-limit e degradazione pulita (`lib/degradation`).
 - **Accettazione:** report k6 in repo; nessun 5xx non previsto; rate-limit risponde 429 puliti.
 
 ### TR.5 — Security review finale — **P0 · S**
+
 - Esegui la skill `/security-review` del repo sull'intero diff accumulato dal piano + `compliance-check` completo (tutte le categorie) + `weekly-security-audit` run manuale.
 - **Accettazione:** zero finding P0/P1 aperti; il resto nel registro.
 
 ### TR.6 — Go/No-Go firmato — **P0 · S · maintainer**
+
 - Checklist finale: barra di qualità (sopra) tutta spuntata, registro senza righe aperte, verifiche V tutte fatte, contratto aspettative senza claim aperti. Firma del maintainer nel documento.
 
 ---
 
 ## Sequenza consigliata e stima (v2)
 
-| Ordine | Fase | Effort seriale | Parallelizzabile con |
-|---|---|---|---|
-| 1 | V — Validare la realtà | 1-2 giorni (molto umano) | — |
-| 2 | 0 — Deploy/CI | 3-5 giorni | 4 (purge) |
-| 3 | 1 — Safety | 6-9 giorni | 2-J |
-| 4 | 2-J — Funnel | 5-7 giorni | 1 |
-| 5 | 2 (IT) — UX/a11y | 4-5 giorni | 3 |
-| 6 | 3 — Core educativo | 6-8 giorni | 2 (IT) |
-| 7 | 4 — Purge totale | 5-8 giorni (T4.3/T4.7 i grossi) | quasi tutto |
-| 8 | C — Contratto aspettative | 3-4 giorni | dopo 1, 2-J, 3 |
-| 9 | 5 — Observability | 3-4 giorni | C |
-| 10 | R — Prova generale | 3-4 giorni | — (seriale, finale) |
-| | **M1 GA-IT totale** | **~6-9 settimane-agente seriali · ~3-4 settimane con 3-4 worktree** | |
-| 11 | 2 (resto) — Multilingua | ~4 giorni | post-M1 |
-| 12 | 6 — Mobile | 1-2 settimane + device | post-M1 |
+| Ordine | Fase                      | Effort seriale                                                      | Parallelizzabile con |
+| ------ | ------------------------- | ------------------------------------------------------------------- | -------------------- |
+| 1      | V — Validare la realtà    | 1-2 giorni (molto umano)                                            | —                    |
+| 2      | 0 — Deploy/CI             | 3-5 giorni                                                          | 4 (purge)            |
+| 3      | 1 — Safety                | 6-9 giorni                                                          | 2-J                  |
+| 4      | 2-J — Funnel              | 5-7 giorni                                                          | 1                    |
+| 5      | 2 (IT) — UX/a11y          | 4-5 giorni                                                          | 3                    |
+| 6      | 3 — Core educativo        | 6-8 giorni                                                          | 2 (IT)               |
+| 7      | 4 — Purge totale          | 5-8 giorni (T4.3/T4.7 i grossi)                                     | quasi tutto          |
+| 8      | C — Contratto aspettative | 3-4 giorni                                                          | dopo 1, 2-J, 3       |
+| 9      | 5 — Observability         | 3-4 giorni                                                          | C                    |
+| 10     | R — Prova generale        | 3-4 giorni                                                          | — (seriale, finale)  |
+|        | **M1 GA-IT totale**       | **~6-9 settimane-agente seriali · ~3-4 settimane con 3-4 worktree** |                      |
+| 11     | 2 (resto) — Multilingua   | ~4 giorni                                                           | post-M1              |
+| 12     | 6 — Mobile                | 1-2 settimane + device                                              | post-M1              |
 
 ---
 
@@ -455,97 +540,111 @@ Crittografia PII (pii-middleware) · scrubbing RAG (privacy-aware-embedding) · 
 ## Appendice C — Mappa del journey utente attuale (evidenze per la Fase 2-J)
 
 ### Journey A — Bambino trial anonimo
-1. `GET /` → `proxy.ts:328-333` redirect locale → `/it` *(hop invisibile)*
-2. `/it` → route pubblica (`proxy.ts:56`) → home renderizza, ma `page.tsx:50-60`: onboarding non completo → `router.push('/welcome')` *(bounce)*
+
+1. `GET /` → `proxy.ts:328-333` redirect locale → `/it` _(hop invisibile)_
+2. `/it` → route pubblica (`proxy.ts:56`) → home renderizza, ma `page.tsx:50-60`: onboarding non completo → `router.push('/welcome')` _(bounce)_
 3. `/welcome` → `welcome/page.tsx:39,118-122` mostra **LandingPage** (hero + QuickStart: "Beta Access/login" vs "Prova gratis")
 4. "Prova gratis" → `TrialEmailForm` opzionale (`quick-start.tsx:160-174`) → `landing-page.tsx:61-109`: `POST /api/trial/session` + **`POST /api/onboarding {hasCompletedOnboarding:true}`** (salta TUTTO l'onboarding marcandolo completo) → `/`
-   - *Alt:* "Inizia con la voce" → onboarding vocale 5 step (`onboarding-types.ts:26-32`)
+   - _Alt:_ "Inizia con la voce" → onboarding vocale 5 step (`onboarding-types.ts:26-32`)
 5. `/` → **UnifiedConsentWall** (banner bloccante + backdrop, `unified-consent-wall.tsx:105-121`)
 6. Intent chooser (Compiti aperto; Studia/Quiz tier-locked → dialog "chiedi a un grande") → subject picker → sessione maestro. **~5 interazioni al valore (9-10 con onboarding vocale). Il trial può fare una sessione compiti completa senza account (10 chat / 300s voce / 10 tool — `use-trial-status.ts:44-49`).**
 
 ### Journey B — Genitore invitato
+
 1. Acquisizione: `/invite/request` (grown-up gate aritmetico + form PII + autodichiarazione tutore, `invite/request/page.tsx:30-85,127-144`) con approvazione admin manuale, O invito diretto admin (`api/invites/direct` → password random via email)
 2. Email → `/login` (SOLO email+password) → `mustChangePassword` → `/change-password` (`login/page.tsx:47-51`)
 3. → `/` → onboarding non completo → `/welcome` → **onboarding vocale che chiede nome/età/scuola/differenze DEL FIGLIO al GENITORE** senza handoff → consent wall → intent chooser. **~10-11 interazioni + round-trip email.**
 
 ### Journey C — Bambino di ritorno
+
 `/` → intent chooser diretto (~2-3 interazioni). OK, da preservare.
 
-### Anomalie chiave (mappate su TJ.*)
-| # | Anomalia | Evidenza | Task |
-|---|----------|----------|------|
-| 1 | Conflitto route: home E `(marketing)/page.tsx` entrambe su `/[locale]` | route group non cambia il path | TJ.1 |
-| 2 | Tre landing: `(marketing)`, `welcome/LandingPage`, `/landing` (fallback `proxy.ts:453-457`) | — | TJ.2 |
-| 3 | Gate morti: `TosGateProvider`, `TrialConsentGate`, `CookieConsentWall` (zero import non-test; vive solo `UnifiedConsentWall`, `providers.tsx:10,170`); ADR 0098 stantio | — | TJ.3 |
-| 4 | CTA primaria salta l'onboarding marcandolo completo | `landing-page.tsx:88-102` | TJ.4 |
-| 5 | Genitore compila l'identità del figlio senza handoff | Journey B hop 3 | TJ.5 |
-| 6 | Sessione scaduta → downgrade silenzioso a trial (non `/login`) | `proxy.ts:442-446` | TJ.6 |
-| 7 | SSO MS365/Google/OIDC senza entry-point UI; Google OAuth = probabilmente solo Drive | `api/auth/sso/*`; `lib/google/drive-client.ts` | TJ.7 |
-| 8 | Form PII raggiungibile dalla sidebar bambino | `home-sidebar.tsx:230-239` | TJ.8 |
-| 9 | Duplicato `app/invite/request/page.tsx` (stub → `/landing`) | `:11-13` | TJ.3 |
-| 10 | Waitlist/coming-soon vestigiale (flag OFF default, pagina inesistente, CHANGELOG mente) | `feature-flags-service.ts:174-180` | TJ.3 + TC.2 |
+### Anomalie chiave (mappate su TJ.\*)
+
+| #   | Anomalia                                                                                                                                                                | Evidenza                                       | Task        |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ----------- |
+| 1   | Conflitto route: home E `(marketing)/page.tsx` entrambe su `/[locale]`                                                                                                  | route group non cambia il path                 | TJ.1        |
+| 2   | Tre landing: `(marketing)`, `welcome/LandingPage`, `/landing` (fallback `proxy.ts:453-457`)                                                                             | —                                              | TJ.2        |
+| 3   | Gate morti: `TosGateProvider`, `TrialConsentGate`, `CookieConsentWall` (zero import non-test; vive solo `UnifiedConsentWall`, `providers.tsx:10,170`); ADR 0098 stantio | —                                              | TJ.3        |
+| 4   | CTA primaria salta l'onboarding marcandolo completo                                                                                                                     | `landing-page.tsx:88-102`                      | TJ.4        |
+| 5   | Genitore compila l'identità del figlio senza handoff                                                                                                                    | Journey B hop 3                                | TJ.5        |
+| 6   | Sessione scaduta → downgrade silenzioso a trial (non `/login`)                                                                                                          | `proxy.ts:442-446`                             | TJ.6        |
+| 7   | SSO MS365/Google/OIDC senza entry-point UI; Google OAuth = probabilmente solo Drive                                                                                     | `api/auth/sso/*`; `lib/google/drive-client.ts` | TJ.7        |
+| 8   | Form PII raggiungibile dalla sidebar bambino                                                                                                                            | `home-sidebar.tsx:230-239`                     | TJ.8        |
+| 9   | Duplicato `app/invite/request/page.tsx` (stub → `/landing`)                                                                                                             | `:11-13`                                       | TJ.3        |
+| 10  | Waitlist/coming-soon vestigiale (flag OFF default, pagina inesistente, CHANGELOG mente)                                                                                 | `feature-flags-service.ts:174-180`             | TJ.3 + TC.2 |
 
 ## Appendice D — Registro del debito (da tenere aggiornato in OGNI PR)
 
-*Stati: 🔴 aperto · 🟢 RISOLTO (PR#) · 🟡 ACCETTATO (motivazione + firma maintainer). Un item nasce qui per ogni scoperta nuova; niente si chiude fuori da questo registro.*
+_Stati: 🔴 aperto · 🟢 RISOLTO (PR#) · 🟡 ACCETTATO (motivazione + firma maintainer). Un item nasce qui per ogni scoperta nuova; niente si chiude fuori da questo registro._
 
-| ID | Voce | Origine | Task | Stato |
-|----|------|---------|------|-------|
-| D-01 | Safety vocale non collegata (T2-06) | audit safety+edu | T1.1 | 🔴 |
-| D-02 | Crisi non escalata su chat streaming | audit safety | T1.2 | 🔴 |
-| D-03 | Gate deploy decorativo + commento CI falso | audit ops | T0.1 | 🔴 |
-| D-04 | 10 E2E home-intent rossi su main + 2 flaky | sessione | T0.2 | 🔴 |
-| D-05 | Jailbreak detector mai invocato | audit safety | T1.5 | 🔴 |
-| D-06 | Bias detection log-only; streaming senza STEM/bias | audit safety | T1.3, T1.4 | 🔴 |
-| D-07 | Admin safety su buffer volatili | audit safety | T1.7 | 🔴 |
-| D-08 | compliance-check statico con path stantii | audit safety | T1.8 | 🔴 |
-| D-09 | 4 moduli safety in doppia copia (~1.571 LOC morte) | audit arch | T1.9 | 🔴 |
-| D-10 | Age-gating definito e non applicato | audit safety | T1.10 | 🔴 |
-| D-11 | Checkout Stripe raggiungibile da minori (server-side) | audit safety | T1.6 | 🔴 |
-| D-12 | TTS hardcoded it-IT | audit UX | T2.1 | 🔴 |
-| D-13 | Promessa "genitori vedono tutto" falsa | audit UX | T2.2 (D1) | 🔴 |
-| D-14 | errors.json corrotto + de in inglese + copy adulto | audit UX | T2.3 | 🔴 |
-| D-15 | [TRANSLATE] in fr + voice.json parity (it -9 ns) + i18n:check unidirezionale | audit UX | T2.4 | 🔴 |
-| D-16 | Date it-IT hardcoded (2 componenti) | audit UX | T2.5 | 🔴 |
-| D-17 | Profili DSA stacking (switch non azzera) | audit UX | T2.6 | 🔴 |
-| D-18 | syncWithSystem stub | audit UX | T2.9 | 🔴 |
-| D-19 | Conflitto route /[locale] (home vs marketing) | audit journey | TJ.1 | 🔴 |
-| D-20 | Tre landing sovrapposte | audit journey | TJ.2 | 🔴 |
-| D-21 | Tre gate consenso morti + ADR 0098 stantio | audit journey | TJ.3 | 🔴 |
-| D-22 | CTA "Prova gratis" falsifica onboarding completato | audit journey | TJ.4 | 🔴 |
-| D-23 | Nessun handoff genitore→bambino | audit journey | TJ.5 | 🔴 |
-| D-24 | Sessione scaduta → trial anonimo | audit journey | TJ.6 | 🔴 |
-| D-25 | SSO senza UI / Google OAuth ambiguo | audit journey | TJ.7 (D4) | 🔴 |
-| D-26 | Form PII nella sidebar bambino | audit journey | TJ.8 | 🔴 |
-| D-27 | Duplicato invite/request non localizzato | audit journey | TJ.3 | 🔴 |
-| D-28 | Waitlist/coming-soon vestigiale + CHANGELOG falso | audit journey | TJ.3, TC.2 | 🔴 |
-| D-29 | FlashcardProgress mai scritto (reminder+dashboard morti) | audit edu | T3.1 | 🔴 |
-| D-30 | Due FSRS divergenti (quello documentato è morto) | audit edu | T3.2 | 🔴 |
-| D-31 | Timeline JSON grezzo live; canvas 5/10 tipi; calculator senza archive | audit edu | T3.3 | 🔴 |
-| D-32 | Voce senza RAG (parità chat) | audit edu | T3.4 | 🔴 |
-| D-33 | 4 maestri senza mini-KB + mascetti/amici-miei | audit edu | T3.5 | 🔴 |
-| D-34 | data-retention-service stub vs cron reale | audit edu+safety | T3.6 | 🔴 |
-| D-35 | DEC-06 maestriLimit non enforced | repo rules | T3.7 (D3) | 🔴 |
-| D-36 | 4.102 LOC varianti UI morte | audit arch | T4.1 | 🔴 |
-| D-37 | backend/ orfano; testingcase/; reports/ stantio; dirs congelate PR#348 | audit arch | T4.2 | 🔴 |
-| D-38 | 7/14 packages mai importati (logica duplicata) | audit arch | T4.3 (D2) | 🔴 |
-| D-39 | api/embeddings ritirato + route debug in tree | audit arch | T4.4 | 🔴 |
-| D-40 | Route pubbliche mutanti senza rate-limit/validazione verificata | audit arch | T4.5 | 🔴 |
-| D-41 | engines.node assente; pin pnpm sospetti; SENTRY_DSN non documentato | audit arch+ops | T4.6 | 🔴 |
-| D-42 | 139 eslint-disable prod; 24 ts-ignore; 167 :any; 1072 as-any test | audit arch | T4.6 | 🔴 |
-| D-43 | Policy file-line violata da 245 file; top-5 monstre | audit arch | T4.6, T4.7 | 🔴 |
-| D-44 | Alerting senza canale | audit ops | T5.1 | 🔴 |
-| D-45 | bundlewatch mai eseguito; lhci non può fallire | audit ops | T5.2 | 🔴 |
-| D-46 | Sentry sampling 1.0; triage mai fatto | audit ops | T5.3 | 🔴 |
-| D-47 | Nessun uptime monitor continuo | audit ops | T0.4 | 🔴 |
-| D-48 | nightly-benchmark trimestrale; 2 cron orfani | audit ops | T0.5 | 🔴 |
-| D-49 | iOS plist senza permessi mic/camera | audit ops | T6.1 | 🔴 |
-| D-50 | Shell mobile senza backend | audit ops | T6.2 | 🔴 |
-| D-51 | PMM overclaim + classificazione AI Act incoerente | audit safety | T1.12, TC.2 (D6) | 🔴 |
-| D-52 | Stati loading/error/empty child-space non censiti | v2 | T2.7 | 🔴 |
-| D-53 | Funnel non misurato | v2 | TJ.9 | 🔴 |
-| D-54 | SLO/latency voce non definiti | v2 | T5.4 | 🔴 |
-| D-55 | Backup/restore mai provato | v2 | TV.8 | 🔴 |
-| D-56 | load-tests congelato | v2 | TR.4 | 🔴 |
-| D-57 | Nessun report Playwright artifact | sessione | T0.3 | 🔴 |
-| D-58 | Feature flags senza censimento consumer | v2 | T4.4 | 🔴 |
+| ID   | Voce                                                                                                                                                  | Origine                                                | Task                               | Stato                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D-01 | Safety vocale non collegata (T2-06)                                                                                                                   | audit safety+edu                                       | T1.1                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-02 | Crisi non escalata su chat streaming                                                                                                                  | audit safety                                           | T1.2                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-03 | Gate deploy decorativo + commento CI falso                                                                                                            | audit ops                                              | T0.1                               | 🔵 PR #472 aperta — codice pronto (`ci:summary` verde), merge in attesa di verifica umana sul dashboard Vercel (post-merge: confermare che i push su `main` non triggerino più deploy automatico)                                                                                                                                                                                                                                                                                                                                                                                              |
+| D-04 | 10 E2E home-intent rossi su main + 2 flaky                                                                                                            | sessione                                               | T0.2                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-05 | Jailbreak detector mai invocato                                                                                                                       | audit safety                                           | T1.5                               | 🟢 RISOLTO — PR #474 (`454cf19b`): wired in `/api/chat`, `/api/chat/stream`, transcript vocale                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| D-06 | Bias detection log-only; streaming senza STEM/bias                                                                                                    | audit safety                                           | T1.3, T1.4                         | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-07 | Admin safety su buffer volatili                                                                                                                       | audit safety                                           | T1.7                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-08 | compliance-check statico con path stantii                                                                                                             | audit safety                                           | T1.8                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-09 | 4 moduli safety in doppia copia (~1.571 LOC morte)                                                                                                    | audit arch                                             | T1.9                               | 🟢 RISOLTO — PR #479 (`589cf876`): 18 file / 2603 LOC eliminate (content-filter, jailbreak-detector-core, output-sanitizer-core, age-gating/ — verifica per-modulo, non per pattern: in age-gating il vivo era il set flat, non il subdir). Nota di processo: il primo tentativo (agente in background) ha bypassato l'isolamento del worktree e lasciato le cancellazioni staged direttamente su `main`; scoperto con `git status` di routine, messo in sicurezza con `git stash`, agente fermato, lavoro rifatto e riverificato da zero prima del merge. `main` non è mai stato compromesso. |
+| D-10 | Age-gating definito e non applicato                                                                                                                   | audit safety                                           | T1.10                              | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-11 | Checkout Stripe raggiungibile da minori (server-side)                                                                                                 | audit safety                                           | T1.6                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-12 | TTS hardcoded it-IT                                                                                                                                   | audit UX                                               | T2.1                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-13 | Promessa "genitori vedono tutto" falsa                                                                                                                | audit UX                                               | T2.2 (D1)                          | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-14 | errors.json corrotto + de in inglese + copy adulto                                                                                                    | audit UX                                               | T2.3                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-15 | [TRANSLATE] in fr + voice.json parity (it -9 ns) + i18n:check unidirezionale                                                                          | audit UX                                               | T2.4                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-16 | Date it-IT hardcoded (2 componenti)                                                                                                                   | audit UX                                               | T2.5                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-17 | Profili DSA stacking (switch non azzera)                                                                                                              | audit UX                                               | T2.6                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-18 | syncWithSystem stub                                                                                                                                   | audit UX                                               | T2.9                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-19 | Conflitto route /[locale] (home vs marketing)                                                                                                         | audit journey                                          | TJ.1                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-20 | Tre landing sovrapposte                                                                                                                               | audit journey                                          | TJ.2                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-21 | Tre gate consenso morti + ADR 0098 stantio                                                                                                            | audit journey                                          | TJ.3                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-22 | CTA "Prova gratis" falsifica onboarding completato                                                                                                    | audit journey                                          | TJ.4                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-23 | Nessun handoff genitore→bambino                                                                                                                       | audit journey                                          | TJ.5                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-24 | Sessione scaduta → trial anonimo                                                                                                                      | audit journey                                          | TJ.6                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-25 | SSO senza UI / Google OAuth ambiguo                                                                                                                   | audit journey                                          | TJ.7 (D4)                          | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-26 | Form PII nella sidebar bambino                                                                                                                        | audit journey                                          | TJ.8                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-27 | Duplicato invite/request non localizzato                                                                                                              | audit journey                                          | TJ.3                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-28 | Waitlist/coming-soon vestigiale + CHANGELOG falso                                                                                                     | audit journey                                          | TJ.3, TC.2                         | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-29 | FlashcardProgress mai scritto (reminder+dashboard morti)                                                                                              | audit edu                                              | T3.1                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-30 | Due FSRS divergenti (quello documentato è morto)                                                                                                      | audit edu                                              | T3.2                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-31 | Timeline JSON grezzo live; canvas 5/10 tipi; calculator senza archive                                                                                 | audit edu                                              | T3.3                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-32 | Voce senza RAG (parità chat)                                                                                                                          | audit edu                                              | T3.4                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-33 | 4 maestri senza mini-KB + mascetti/amici-miei                                                                                                         | audit edu                                              | T3.5                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-34 | data-retention-service stub vs cron reale                                                                                                             | audit edu+safety                                       | T3.6                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-35 | DEC-06 maestriLimit non enforced                                                                                                                      | repo rules                                             | T3.7 (D3)                          | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-36 | 4.102 LOC varianti UI morte                                                                                                                           | audit arch                                             | T4.1                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-37 | backend/ orfano; testingcase/; reports/ stantio; dirs congelate PR#348                                                                                | audit arch                                             | T4.2                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-38 | 7/14 packages mai importati (logica duplicata)                                                                                                        | audit arch                                             | T4.3 (D2)                          | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-39 | api/embeddings ritirato + route debug in tree                                                                                                         | audit arch                                             | T4.4                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-40 | Route pubbliche mutanti senza rate-limit/validazione verificata                                                                                       | audit arch                                             | T4.5                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-41 | engines.node assente; pin pnpm sospetti; SENTRY_DSN non documentato                                                                                   | audit arch+ops                                         | T4.6                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-42 | 139 eslint-disable prod; 24 ts-ignore; 167 :any; 1072 as-any test                                                                                     | audit arch                                             | T4.6                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-43 | Policy file-line violata da 245 file; top-5 monstre                                                                                                   | audit arch                                             | T4.6, T4.7                         | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-44 | Alerting senza canale                                                                                                                                 | audit ops                                              | T5.1                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-45 | bundlewatch mai eseguito; lhci non può fallire                                                                                                        | audit ops                                              | T5.2                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-46 | Sentry sampling 1.0; triage mai fatto                                                                                                                 | audit ops                                              | T5.3                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-47 | Nessun uptime monitor continuo                                                                                                                        | audit ops                                              | T0.4                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-48 | nightly-benchmark trimestrale; 2 cron orfani                                                                                                          | audit ops                                              | T0.5                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-49 | iOS plist senza permessi mic/camera                                                                                                                   | audit ops                                              | T6.1                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-50 | Shell mobile senza backend                                                                                                                            | audit ops                                              | T6.2                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-51 | PMM overclaim + classificazione AI Act incoerente                                                                                                     | audit safety                                           | T1.12, TC.2 (D6)                   | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-52 | Stati loading/error/empty child-space non censiti                                                                                                     | v2                                                     | T2.7                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-53 | Funnel non misurato                                                                                                                                   | v2                                                     | TJ.9                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-54 | SLO/latency voce non definiti                                                                                                                         | v2                                                     | T5.4                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-55 | Backup/restore mai provato                                                                                                                            | v2                                                     | TV.8                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-56 | load-tests congelato                                                                                                                                  | v2                                                     | TR.4                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-57 | Nessun report Playwright artifact                                                                                                                     | sessione                                               | T0.3                               | 🔵 PR #472 aperta (stesso branch di T0.1) — reporter `html` + upload artifact aggiunti, `ci:summary` verde, merge in attesa della verifica umana del gate deploy (D-03)                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| D-58 | Feature flags senza censimento consumer                                                                                                               | v2                                                     | T4.4                               | 🔴                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D-59 | Voce: audio può già essere riprodotto prima che il blocco scatti; nessun fallback su data channel chiuso                                              | code review PR #456 (issue #469)                       | T1.13                              | 🟡 Parziale — PR #471 (`c7b2f73b`): fallback `pauseAudio` + audit VCE-004 su canale chiuso. Resta aperto il delta-checking incrementale sul transcript (chiude la finestra "audio già suonato prima del `.done`"): richiede verifica su dispositivo/browser reale non disponibile in questa sessione, tracciare su T6.3 prima di implementare alla cieca                                                                                                                                                                                                                                       |
+| D-60 | Bias detection non collegata allo streaming                                                                                                           | code review PR #458 (issue #467)                       | T1.13                              | 🟢 RISOLTO — PR #471 (`c7b2f73b`): check post-hoc sull'output accumulato + messaggio correttivo se rilevato                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| D-61 | Scritture compliance-audit non attese (`void`), rischio perdita su freeze serverless                                                                  | code review PR #462 (issue #468)                       | T1.13                              | 🟢 RISOLTO — PR #471 (`c7b2f73b`): `after()` di `next/server` al posto del fire-and-forget nudo, sia per l'audit sia per gli effetti collaterali della crisi                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| D-62 | Mind map senza navigazione da tastiera; timer pausa ADHD mai collegato al quiz reale                                                                  | focus-group audit (persone Motor/Cerebral Palsy, ADHD) | T2.10                              | 🔵 PR #475 aperta — `applyMindmapKeyboardAccessibility()` (Tab/Enter/frecce/Escape, focus visibile) + `QuizBreakTimer` wired su `settings.adhdMode`; 115 test verdi, i18n 5 locale; merge in attesa di un passaggio reale in browser (tastiera + verifica visiva)                                                                                                                                                                                                                                                                                                                              |
+| D-63 | Trascrizione vocale senza `aria-live`: uno studente sordo/ipoudente che usa il transcript come canale primario non riceve notifica di nuovo contenuto | focus-group audit (persona Sorda, Auditory)            | T2.11                              | 🔵 PR #476 aperta — `role="log" aria-live="polite"` su `SessionTranscript`; verificati e confermati SANI: troncamento (solo nei log, mai nel transcript mostrato), simmetria utente/assistente. Merge in attesa di un passaggio reale con screen reader (VoiceOver/NVDA). Follow-up non ancora affrontato: `conversation.item.input_audio_transcription.failed` cade nel default case, un turno utente può restare senza transcript in silenzio — da verificare contro la versione API pinnata prima di un fix                                                                                 |
+| D-64 | Tier-gate: sospetto redirect 307 silenzioso su feature bloccata                                                                                       | focus-group audit ipotesi (TJ.10)                      | TJ.10                              | 🟢 Verificato NON esistente — già risolto in PR #430 (dialog esplicito "chiedi a un grande", `aria-describedby`, focus restore, TTS, 5 locale). PR #473 (`8141553b`) ha solo aggiunto copertura di regressione (11 test) che mancava. Effetto collaterale: individuato `LockedFeatureOverlay`/`UpgradePromptModal` come dead code separato (D-66)                                                                                                                                                                                                                                              |
+| D-65 | Dipendenze transitive high-severity: `undici` <6.27.0 (DoS WebSocket), `linkify-it` <=5.0.0 (ReDoS quadratico)                                        | weekly pnpm-audit (issue #448, #451)                   | —                                  | 🟢 RISOLTO — PR #477 (`6863571f`): pin via `pnpm.overrides` esistente; `pnpm audit --audit-level=high` 2→0                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| D-66 | `LockedFeatureOverlay`/`UpgradePromptModal` (`components/tier/`) dead code, zero call-site reali                                                      | scoperto durante verifica TJ.10 (PR #473)              | —                                  | 🔴 aperto — pattern "overlay Pro-only" mai collegato; da valutare in un futuro giro di pulizia debito (stesso genere di D-09)                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| D-67 | Buddy avatar non mascherato in-sessione: nome/avatar del Maestro reale ancora visibile durante la sessione                                            | Fase 2 dichiarata in PR #430 (issue #436)              | Phase 2 (non pianificato con ID T) | 🟡 needs-scoping — commento su issue #436: richiede decisione di prodotto su (a) se TTS/voce maschera l'identità o solo la UI visiva, (b) come si comporta l'indirizzo formale ADR 0064 (Lei/Sie/Vous per figure storiche) sotto identità mascherata, (c) comportamento dell'handoff banner. Non delegabile come fix di codice finché queste 3 domande non hanno una risposta del maintainer                                                                                                                                                                                                   |
+| D-68 | Metodo del focus-group simulato non calibrato su utenti reali (VAL-01..07)                                                                            | issue #437, dichiarato dal documento stesso            | — (validazione, non codice)        | 🟡 needs-human-input — richiede esperti di dominio reali (logopedista, insegnante di sostegno, persona Sorda adulta, adulto con CP, adulti dislessici/ADHD) e un protocollo etico per test con minori disabili (DPIA + assenso + reclutamento indipendente). Nessuna azione di codice possibile; resta il caveat "[SIMULATO], non calibrato" su ogni output di questo audit finché non risolto                                                                                                                                                                                                 |


### PR DESCRIPTION
## Summary
Updates the Appendice D debt registry in `docs/plans/PLAN-mirrorbuddy-release.md` to reflect this session's execution:
- D-05 (T1.5), D-09 (T1.9), D-60/D-61 (T1.13 bias+audit gaps) marked RISOLTO with merged PR/commit references.
- D-03/D-57 (T0.1/T0.3) marked as PR open pending human Vercel-dashboard verification.
- New D-59 (T1.13 voice audio race, partial fix, on-device verification needed), D-62 (T2.10 mind-map keyboard nav + ADHD break timer, PR open pending browser verification), D-63 (T2.11 transcript aria-live, PR open pending screen-reader verification), D-64 (TJ.10 verified already-fixed in #430, test coverage added), D-65 (dependency security advisories closed), D-66 (dead LockedFeatureOverlay/UpgradePromptModal, flagged not fixed), D-67 (Buddy avatar masking, needs product scoping per issue #436), D-68 (focus-group method needs expert validation per issue #437).

Also documents, on D-09, the T1.9 background-agent worktree-isolation incident (destructive changes staged directly on `main`, caught via routine `git status`, safely stashed, redone from scratch before merge) — `main` was never compromised, but worth a durable record.

## Test plan
- [x] Docs-only change, no code paths affected
- [x] `npm run i18n:check` — unaffected, PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhQVTk4CazPswSPN1HSEaZ