### PR TITLE
fix(onboarding): returning users go to app home + UI-only accessible onboarding

### DIFF
--- a/apps/web/src/app/[locale]/welcome/hooks/__tests__/use-voice-connection.test.ts
+++ b/apps/web/src/app/[locale]/welcome/hooks/__tests__/use-voice-connection.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression test: onboarding is UI-only (no voice).
+ *
+ * The realtime WebRTC connection can fail after a successful token fetch,
+ * stranding a child on a broken voice step. Onboarding must run through the
+ * accessible form from first paint: useWebSpeechFallback starts true, Azure is
+ * treated as already-checked, and no /api/realtime/token request is made.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useVoiceConnection } from '../use-voice-connection';
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+describe('useVoiceConnection — UI-only onboarding', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to the form path and never fetches a realtime token', () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy as unknown as typeof fetch);
+
+    const { result } = renderHook(() => useVoiceConnection(true));
+
+    // Form is the path from first paint; no Azure wait.
+    expect(result.current.useWebSpeechFallback).toBe(true);
+    expect(result.current.hasCheckedAzure).toBe(true);
+    expect(result.current.connectionInfo).toBeNull();
+    // The voice token endpoint must not be called.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/[locale]/welcome/hooks/use-voice-connection.ts
+++ b/apps/web/src/app/[locale]/welcome/hooks/use-voice-connection.ts
@@ -1,23 +1,34 @@
-import { useState, useEffect } from "react";
-import { logger } from "@/lib/logger";
-import type { VoiceConnectionInfo } from "../types";
+import { useState, useEffect } from 'react';
+import { logger } from '@/lib/logger';
+import type { VoiceConnectionInfo } from '../types';
+
+// Onboarding is UI-only (no voice). The realtime WebRTC connection can fail
+// AFTER a successful token fetch (the token check here only catches config /
+// rate-limit errors, not a failed SDP/ICE negotiation) — which left a child
+// stranded on a broken voice step with no way forward. Every child must be
+// able to complete onboarding via the accessible InfoStepForm / WelcomeStep
+// form path, which collects the same data (name, age, school, learning
+// differences) without a microphone. Flip this to true to restore
+// voice-guided onboarding once realtime reliability is verified on-device
+// (issue #469 / T6.3).
+const ONBOARDING_VOICE_ENABLED = false;
 
 export function useVoiceConnection(enabled = true) {
-  const [connectionInfo, setConnectionInfo] =
-    useState<VoiceConnectionInfo | null>(null);
-  const [hasCheckedAzure, setHasCheckedAzure] = useState(false);
-  const [useWebSpeechFallback, setUseWebSpeechFallback] = useState(false);
+  const [connectionInfo, setConnectionInfo] = useState<VoiceConnectionInfo | null>(null);
+  // When voice onboarding is disabled we've effectively already "decided": no
+  // Azure check is pending (so the page doesn't wait on it) and the UI form is
+  // the path from first paint.
+  const [hasCheckedAzure, setHasCheckedAzure] = useState(!ONBOARDING_VOICE_ENABLED);
+  const [useWebSpeechFallback, setUseWebSpeechFallback] = useState(!ONBOARDING_VOICE_ENABLED);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || !ONBOARDING_VOICE_ENABLED) return;
 
     async function fetchConnectionInfo() {
       try {
         // Check for sessionStorage availability (SSR guard)
         const cached =
-          typeof window !== "undefined"
-            ? sessionStorage.getItem("voice-connection-info")
-            : null;
+          typeof window !== 'undefined' ? sessionStorage.getItem('voice-connection-info') : null;
 
         if (cached) {
           try {
@@ -28,45 +39,38 @@ export function useVoiceConnection(enabled = true) {
               return;
             }
           } catch {
-            if (typeof window !== "undefined") {
-              sessionStorage.removeItem("voice-connection-info");
+            if (typeof window !== 'undefined') {
+              sessionStorage.removeItem('voice-connection-info');
             }
           }
         }
 
-        const response = await fetch("/api/realtime/token");
+        const response = await fetch('/api/realtime/token');
         const data = await response.json();
 
         if (response.status === 429) {
-          logger.warn(
-            "[WelcomePage] Rate limit exceeded, using Web Speech fallback",
-          );
+          logger.warn('[WelcomePage] Rate limit exceeded, using Web Speech fallback');
           setHasCheckedAzure(true);
           setUseWebSpeechFallback(true);
           return;
         }
 
         if (data.error) {
-          logger.warn(
-            "[WelcomePage] Voice API not available, using Web Speech fallback",
-          );
+          logger.warn('[WelcomePage] Voice API not available, using Web Speech fallback');
           setHasCheckedAzure(true);
           setUseWebSpeechFallback(true);
           return;
         }
 
-        if (typeof window !== "undefined") {
-          sessionStorage.setItem("voice-connection-info", JSON.stringify(data));
+        if (typeof window !== 'undefined') {
+          sessionStorage.setItem('voice-connection-info', JSON.stringify(data));
         }
         setConnectionInfo(data as VoiceConnectionInfo);
         setHasCheckedAzure(true);
       } catch (error) {
-        logger.warn(
-          "[WelcomePage] Voice API unavailable, using Web Speech fallback",
-          {
-            error: String(error),
-          },
-        );
+        logger.warn('[WelcomePage] Voice API unavailable, using Web Speech fallback', {
+          error: String(error),
+        });
         setHasCheckedAzure(true);
         setUseWebSpeechFallback(true);
       }

--- a/apps/web/src/app/[locale]/welcome/page.tsx
+++ b/apps/web/src/app/[locale]/welcome/page.tsx
@@ -16,7 +16,6 @@ import { ReadyStep } from './components/ready-step';
 import { LoadingState } from './components/loading-state';
 import { LandingPage } from './components/landing-page';
 import { ProgressIndicator } from './components/progress-indicator';
-import { VoiceFallbackBanner } from './components/voice-fallback-banner';
 import { useExistingUserData } from './hooks/use-existing-user-data';
 import { useVoiceConnection } from './hooks/use-voice-connection';
 import { useWelcomeVoice } from './hooks/use-welcome-voice';
@@ -139,14 +138,7 @@ function WelcomeContent() {
         onReset={handleReset}
       />
 
-      {useWebSpeechFallback && <VoiceFallbackBanner />}
-
-      <div
-        className={cn(
-          'pb-8 px-4 min-h-screen flex items-center justify-center',
-          useWebSpeechFallback ? 'pt-28' : 'pt-20',
-        )}
-      >
+      <div className={cn('pb-8 px-4 min-h-screen flex items-center justify-center', 'pt-20')}>
         <div className="w-full max-w-md">
           <AnimatePresence mode="wait">
             <motion.div

--- a/apps/web/src/lib/stores/__tests__/onboarding-store-hydrate.test.ts
+++ b/apps/web/src/lib/stores/__tests__/onboarding-store-hydrate.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for onboarding completion resolution in hydrateFromApi.
+ *
+ * Bug: a returning logged-in user with a real profile (a name) was bounced to
+ * /welcome forever when their OnboardingState row had an explicit
+ * hasCompletedOnboarding=false (the old `??` let that false win over the
+ * "has existing data" signal). Replay mode must still force onboarding.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useOnboardingStore } from '../onboarding-store';
+
+function mockOnboardingResponse(body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    })) as unknown as typeof fetch,
+  );
+}
+
+describe('onboarding-store hydrateFromApi — completion resolution', () => {
+  beforeEach(() => {
+    // Reset the hydration guard so each test re-runs hydrateFromApi.
+    useOnboardingStore.setState({ isHydrated: false, hasCompletedOnboarding: false });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returning user with a profile name + stale hasCompletedOnboarding=false → completed (no /welcome bounce)', async () => {
+    mockOnboardingResponse({
+      onboardingState: { hasCompletedOnboarding: false, isReplayMode: false },
+      hasExistingData: true,
+      data: { name: 'MarioDan' },
+    });
+
+    await useOnboardingStore.getState().hydrateFromApi();
+
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(true);
+  });
+
+  it('replay mode still forces onboarding even with a profile name', async () => {
+    mockOnboardingResponse({
+      onboardingState: { hasCompletedOnboarding: false, isReplayMode: true },
+      hasExistingData: true,
+      data: { name: 'MarioDan' },
+    });
+
+    await useOnboardingStore.getState().hydrateFromApi();
+
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(false);
+  });
+
+  it('brand-new user with no profile name → not completed (onboarding shown)', async () => {
+    mockOnboardingResponse({
+      onboardingState: null,
+      hasExistingData: false,
+      data: null,
+    });
+
+    await useOnboardingStore.getState().hydrateFromApi();
+
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(false);
+  });
+
+  it('credentialed user with no name yet → not completed (must still onboard)', async () => {
+    // hasExistingData is true for any credentialed account, but without a real
+    // profile name the user still needs to onboard — guarding on the name
+    // (not on hasExistingData) prevents skipping onboarding for fresh accounts.
+    mockOnboardingResponse({
+      onboardingState: { hasCompletedOnboarding: false, isReplayMode: false },
+      hasExistingData: true,
+      data: { name: '' },
+    });
+
+    await useOnboardingStore.getState().hydrateFromApi();
+
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(false);
+  });
+
+  it('explicit hasCompletedOnboarding=true is respected', async () => {
+    mockOnboardingResponse({
+      onboardingState: { hasCompletedOnboarding: true, isReplayMode: false },
+      hasExistingData: true,
+      data: { name: 'MarioDan' },
+    });
+
+    await useOnboardingStore.getState().hydrateFromApi();
+
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(true);
+  });
+});

--- a/apps/web/src/lib/stores/onboarding-store.ts
+++ b/apps/web/src/lib/stores/onboarding-store.ts
@@ -7,18 +7,18 @@
  * - Collected data during onboarding
  */
 
-import { create } from "zustand";
-import { csrfFetch } from "@/lib/auth";
-import { AUTH_COOKIE_NAME } from "@/lib/auth";
+import { create } from 'zustand';
+import { csrfFetch } from '@/lib/auth';
+import { AUTH_COOKIE_NAME } from '@/lib/auth';
 import {
   type OnboardingStep,
   type OnboardingData,
   type VoiceTranscriptEntry,
   STEP_ORDER,
-} from "./onboarding-types";
+} from './onboarding-types';
 
 export type { OnboardingStep, OnboardingData, VoiceTranscriptEntry };
-export { getStepIndex, getTotalSteps } from "./onboarding-types";
+export { getStepIndex, getTotalSteps } from './onboarding-types';
 
 interface OnboardingState {
   // Flow state
@@ -46,7 +46,7 @@ interface OnboardingState {
   setVoiceMuted: (muted: boolean) => void;
   setVoiceSessionActive: (active: boolean) => void;
   setVoiceSessionConnecting: (connecting: boolean) => void;
-  addVoiceTranscript: (role: "user" | "assistant", text: string) => void;
+  addVoiceTranscript: (role: 'user' | 'assistant', text: string) => void;
   clearVoiceTranscript: () => void;
   setAzureAvailable: (available: boolean) => void;
   completeOnboarding: () => void;
@@ -59,7 +59,7 @@ interface OnboardingState {
 export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
   hasCompletedOnboarding: false,
   onboardingCompletedAt: null,
-  currentStep: "welcome",
+  currentStep: 'welcome',
   isReplayMode: false,
   isVoiceMuted: false,
   isHydrated: false,
@@ -71,7 +71,7 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
   azureAvailable: null,
 
   data: {
-    name: "",
+    name: '',
   },
 
   setStep: (step) => set({ currentStep: step }),
@@ -80,15 +80,11 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
 
   setVoiceSessionActive: (active) => set({ voiceSessionActive: active }),
 
-  setVoiceSessionConnecting: (connecting) =>
-    set({ voiceSessionConnecting: connecting }),
+  setVoiceSessionConnecting: (connecting) => set({ voiceSessionConnecting: connecting }),
 
   addVoiceTranscript: (role, text) =>
     set((state) => ({
-      voiceTranscript: [
-        ...state.voiceTranscript,
-        { role, text, timestamp: Date.now() },
-      ],
+      voiceTranscript: [...state.voiceTranscript, { role, text, timestamp: Date.now() }],
     })),
 
   clearVoiceTranscript: () => set({ voiceTranscript: [] }),
@@ -123,7 +119,7 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
 
   startReplay: () =>
     set({
-      currentStep: "welcome",
+      currentStep: 'welcome',
       isReplayMode: true,
     }),
 
@@ -131,7 +127,7 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
     set({
       hasCompletedOnboarding: false,
       onboardingCompletedAt: null,
-      currentStep: "welcome",
+      currentStep: 'welcome',
       isReplayMode: false,
       isVoiceMuted: false,
       isHydrated: false,
@@ -139,29 +135,29 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
       voiceSessionConnecting: false,
       voiceTranscript: [],
       azureAvailable: null,
-      data: { name: "" },
+      data: { name: '' },
     }),
 
   resetAllData: async () => {
     // Delete all user data from database (primary data source)
     try {
-      await csrfFetch("/api/user/data", { method: "DELETE" });
+      await csrfFetch('/api/user/data', { method: 'DELETE' });
     } catch {
       // Continue with local cleanup even if API fails
     }
 
     // Clear any remaining localStorage (legacy/session data)
     const storeKeys = [
-      "mirrorbuddy-settings",
-      "mirrorbuddy-progress",
-      "mirrorbuddy-conversations",
-      "mirrorbuddy-learnings",
-      "mirrorbuddy-html-snippets",
-      "mirrorbuddy-calendar",
-      "mirrorbuddy-onboarding",
-      "mirrorbuddy-accessibility",
-      "mirrorbuddy-notifications",
-      "mirrorbuddy-pomodoro",
+      'mirrorbuddy-settings',
+      'mirrorbuddy-progress',
+      'mirrorbuddy-conversations',
+      'mirrorbuddy-learnings',
+      'mirrorbuddy-html-snippets',
+      'mirrorbuddy-calendar',
+      'mirrorbuddy-onboarding',
+      'mirrorbuddy-accessibility',
+      'mirrorbuddy-notifications',
+      'mirrorbuddy-pomodoro',
       AUTH_COOKIE_NAME,
     ];
 
@@ -170,7 +166,7 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
     });
 
     // Clear IndexedDB (legacy materials storage)
-    const databases = ["mirrorbuddy-materials", "mirrorbuddy-flashcards"];
+    const databases = ['mirrorbuddy-materials', 'mirrorbuddy-flashcards'];
     for (const dbName of databases) {
       try {
         indexedDB.deleteDatabase(dbName);
@@ -183,7 +179,7 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
     set({
       hasCompletedOnboarding: false,
       onboardingCompletedAt: null,
-      currentStep: "welcome",
+      currentStep: 'welcome',
       isReplayMode: false,
       isVoiceMuted: false,
       isHydrated: false,
@@ -191,11 +187,11 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
       voiceSessionConnecting: false,
       voiceTranscript: [],
       azureAvailable: null,
-      data: { name: "" },
+      data: { name: '' },
     });
 
     // Reload the page to reinitialize everything
-    window.location.href = "/welcome";
+    window.location.href = '/welcome';
   },
 
   hydrateFromApi: async () => {
@@ -203,7 +199,7 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
     if (get().isHydrated) return;
 
     try {
-      const response = await fetch("/api/onboarding");
+      const response = await fetch('/api/onboarding');
       if (!response.ok) {
         // API error - mark as hydrated but don't update state
         set({ isHydrated: true });
@@ -212,26 +208,33 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
 
       const data = await response.json();
 
-      // If user has existing data (profile with name), consider them as onboarded
-      // This handles the case where OnboardingState record is missing but user exists
-      const isCompleted =
-        data.onboardingState?.hasCompletedOnboarding ??
-        data.hasExistingData ??
-        false;
+      // Decide whether onboarding is complete.
+      // A returning user who already has a real profile (a name) must go
+      // straight to the app — NOT be re-forced through onboarding by a stale
+      // OnboardingState row with hasCompletedOnboarding=false (e.g. an account
+      // created/seeded without the flag ever being set). The previous `??`
+      // logic let an explicit `false` win over the "has existing data" signal,
+      // which trapped real logged-in users in a /welcome bounce.
+      // Replay mode still intentionally forces onboarding (resetOnboarding /
+      // startReplay set hasCompletedOnboarding=false to redo the flow).
+      const state = data.onboardingState;
+      const hasProfileName = Boolean(data.data?.name);
+      const isCompleted = state?.isReplayMode
+        ? false
+        : Boolean(state?.hasCompletedOnboarding) || hasProfileName;
 
       // Update store with DB state
       set({
         isHydrated: true,
         hasCompletedOnboarding: isCompleted,
-        onboardingCompletedAt:
-          data.onboardingState?.onboardingCompletedAt ?? null,
+        onboardingCompletedAt: data.onboardingState?.onboardingCompletedAt ?? null,
         currentStep:
           (data.onboardingState?.currentStep as OnboardingStep) ??
-          (isCompleted ? "ready" : "welcome"),
+          (isCompleted ? 'ready' : 'welcome'),
         isReplayMode: data.onboardingState?.isReplayMode ?? false,
         ...(data.data && {
           data: {
-            name: data.data.name ?? "",
+            name: data.data.name ?? '',
             age: data.data.age,
             schoolLevel: data.data.schoolLevel,
             learningDifferences: data.data.learningDifferences,


### PR DESCRIPTION
## Due bug di produzione segnalati dall'utente, stessa area (il gate `/welcome`)

### 1. Dopo il login si resta bloccati su `/welcome` invece di entrare nell'app
`onboarding-store.hydrateFromApi` risolveva il completamento con `hasCompletedOnboarding ?? hasExistingData ?? false`. Un `false` esplicito e stantìo sul record `OnboardingState` vinceva sul segnale reale che l'utente ha già un profilo → un utente loggato e configurato (es. "MarioDan") restava intrappolato in un bounce permanente verso `/welcome`. **Fix:** un utente con un nome di profilo reale è considerato onboarded → home. Replay mode continua a forzare l'onboarding; account credenziato senza nome continua l'onboarding (guard sul nome, non su `hasExistingData`).

### 2. L'onboarding richiedeva la voce, che poteva rompersi a metà
`useVoiceConnection` faceva fallback al form solo su fallimento del token, non su fallimento WebRTC/SDP dopo un token valido → bambino bloccato su step vocale rotto. **Fix:** onboarding solo-UI dal primo paint (`ONBOARDING_VOICE_ENABLED=false`); path accessibile WelcomeStep/InfoStepForm (nome, età, scuola, differenze — no microfono). Rimosso VoiceFallbackBanner (i18n placeholder). Costante a `true` per riabilitare voce quando realtime verificato on-device (#469/T6.3).

## Test
- `onboarding-store-hydrate.test.ts` (5 casi incl. replay + account senza nome), `use-voice-connection.test.ts` (form-first, no token fetch). `ci:summary` verde.

## Nota
Logica coperta da unit test; un giro reale in browser (login esistente → home; nuovo utente → onboarding UI senza microfono) è consigliato prima della chiusura end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhQVTk4CazPswSPN1HSEaZ