### PR TITLE
fix(e2e): repair 2 mobile-e2e tests stale since the home redesign (T0.2/D-04)

### DIFF
--- a/apps/web/e2e/mobile/android.spec.ts
+++ b/apps/web/e2e/mobile/android.spec.ts
@@ -78,13 +78,21 @@ test.describe('Android Pixel 7 Mobile UX', () => {
     expect(viewportWidth).toBeLessThan(500);
     expect(viewportHeight).toBeGreaterThan(0);
 
-    // Check that 100vh elements don't cause overflow
-    const hasVerticalScroll = await page.evaluate(() => {
-      return document.body.scrollHeight > window.innerHeight;
+    // The actual 100vh-bug symptom is horizontal overflow (Android Chrome's
+    // dynamic URL bar makes 100vh taller than the visible viewport, which
+    // typically forces wrapped content sideways) — that must never happen.
+    const hasHorizontalOverflow = await page.evaluate(() => {
+      return document.body.scrollWidth > window.innerWidth;
     });
+    expect(hasHorizontalOverflow).toBe(false);
 
-    // Some vertical scroll is expected (page content), but shouldn't be excessive
-    expect(hasVerticalScroll).toBe(true); // Normal page scroll
+    // Vertical overflow is content-dependent, not a bug signal by itself
+    // (the intention-based home, #430, is intentionally short and may fit
+    // a tall viewport like Pixel 7's 915px with zero scroll). Only guard
+    // against a PATHOLOGICAL 100vh miscalculation blowing the page up to
+    // several viewport-heights tall.
+    const scrollHeight = await page.evaluate(() => document.body.scrollHeight);
+    expect(scrollHeight).toBeLessThan(viewportHeight * 3);
   });
 
   test('Android back button should work with sidebar', async ({ page, mobile }) => {
@@ -160,6 +168,14 @@ test.describe('Android Pixel 7 Mobile UX', () => {
   });
 
   test('pull-to-refresh should not interfere with scroll', async ({ page }) => {
+    // This test only means something on a page that actually has scrollable
+    // overflow. The intention-based home (#430) is short by design and may
+    // legitimately fit a tall viewport (e.g. Pixel 7's 915px) with nothing to
+    // scroll — window.scrollTo() is then a no-op and scrollY never moves,
+    // which isn't a pull-to-refresh bug, just nothing to test here.
+    const isScrollable = await page.evaluate(() => document.body.scrollHeight > window.innerHeight);
+    test.skip(!isScrollable, 'Page has no scrollable overflow at this viewport size');
+
     // Scroll down page
     await page.evaluate(() => window.scrollTo(0, 100));
     await page.waitForFunction(() => window.scrollY > 0);


### PR DESCRIPTION
## Perché è urgente
Questi 2 test in `android.spec.ts` (progetto Pixel 7) falliscono su **ogni** run CI di push-to-main, bloccando `deploy-to-staging` (che richiede TUTTI i check obbligatori, incluso `mobile-e2e`) — nessuno dei merge di questa sessione ha effettivamente raggiunto Vercel a causa di questo. Il deploy di produzione è fermo a una build di ~1 giorno fa.

## Causa
Entrambi i test assumono che la home page abbia overflow verticale scrollabile. Era vero prima del redesign intention-based della home (#430, giugno 2026), che l'ha resa intenzionalmente corta (3 card di intento) — su un viewport alto come il Pixel 7 (915px) ora sta correttamente senza scroll. Non è un bug di prodotto: il redesign era corretto, questi test non erano mai stati aggiornati di conseguenza.

- **"Chrome Android viewport units should work correctly"**: asseriva che lo scroll verticale DOVESSE esistere. Il problema reale che il commento originale descriveva è il bug dell'URL-bar dinamica di Chrome Android su `100vh`, che si manifesta come overflow orizzontale o pagina patologicamente alta — non "deve scrollare". Ora verifica `scrollWidth <= innerWidth` e `scrollHeight < 3x altezza viewport`.
- **"pull-to-refresh should not interfere with scroll"**: chiamava `window.scrollTo()` su una pagina senza overflow, quindi `scrollY` non si muoveva mai e l'attesa andava in timeout (120s). Ora salta con grazia quando la pagina non ha contenuto scrollabile — questa interazione non ha semplicemente nulla da testare senza qualcosa da scrollare.

## Test plan
- [x] Verificato localmente contro il vero dev server + DB Postgres di test (progetto pixel-7): 1 passed, 1 skipped (come atteso — nessun contenuto scrollabile a questo viewport), 0 failed
- [x] `npm run ci:summary` verde, 153 warning di baseline invariati

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhQVTk4CazPswSPN1HSEaZ