### PR TITLE
chore: gitignore roberdan-os federated kanban (kanban/ + handoff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,7 @@ feature/
 testingcase/
 study-materials/
 .gstack/
+kanban/todo/
+kanban/doing/
+kanban/done/
+handoff/latest.md


### PR DESCRIPTION
## Summary

Adds the roberdan-os federated kanban/handoff paths to `.gitignore`, mirroring the same preventive change already landed across the other federated repos (roberdan-os, convergio, Fabrica). Keeps operator-local orchestration files (`kanban/todo|doing|done/`, `handoff/latest.md`) out of the MirrorBuddy working tree.

4 lines added to `.gitignore`, no code touched.

## Test plan

- No runtime surface — `.gitignore`-only change.
- Pre-push hook ran full unit suite (11889 passed) before push.
- CI must be green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPLnram2UsajoBpGcLqU5H