### PR TITLE
feat(session): neutral study-coach opener instead of straight-to-Maestro

### DIFF
--- a/apps/web/messages/de/chat.json
+++ b/apps/web/messages/de/chat.json
@@ -577,6 +577,10 @@
       },
       "listen": "Nachricht anhören",
       "dismiss": "Verstanden, schließen"
+    },
+    "coachOpener": {
+      "general": "Hallo! Ich bin {coach}, dein Lerncoach. Bevor wir starten, sag mir: An welchem Fach möchtest du arbeiten, was möchtest du tun und wie viel Zeit hast du? Dann stelle ich dir den richtigen Maestro vor. 😊",
+      "withSubject": "Hallo! Ich bin {coach}, dein Lerncoach. Heute arbeiten wir an {subject} – ich stelle dir gleich den richtigen Maestro vor! 😊"
     }
   }
 }

--- a/apps/web/messages/en/chat.json
+++ b/apps/web/messages/en/chat.json
@@ -577,6 +577,10 @@
       },
       "listen": "Listen to the message",
       "dismiss": "Got it, close"
+    },
+    "coachOpener": {
+      "general": "Hi! I'm {coach}, your study coach. Before we start, tell me: which subject do you want to work on, what do you want to do, and how much time do you have? Then I'll introduce the right Maestro. 😊",
+      "withSubject": "Hi! I'm {coach}, your study coach. Today we're working on {subject} — let me introduce the right Maestro! 😊"
     }
   }
 }

--- a/apps/web/messages/es/chat.json
+++ b/apps/web/messages/es/chat.json
@@ -577,6 +577,10 @@
       },
       "listen": "Escuchar el mensaje",
       "dismiss": "Entendido, cerrar"
+    },
+    "coachOpener": {
+      "general": "¡Hola! Soy {coach}, tu coach de estudio. Antes de empezar, dime: ¿de qué asignatura quieres ocuparte, qué quieres hacer y cuánto tiempo tienes? Luego te presento al Maestro adecuado. 😊",
+      "withSubject": "¡Hola! Soy {coach}, tu coach de estudio. Hoy trabajamos en {subject}: ¡te presento enseguida al Maestro adecuado! 😊"
     }
   }
 }

--- a/apps/web/messages/fr/chat.json
+++ b/apps/web/messages/fr/chat.json
@@ -577,6 +577,10 @@
       },
       "listen": "Écouter le message",
       "dismiss": "Compris, fermer"
+    },
+    "coachOpener": {
+      "general": "Salut ! Je suis {coach}, ton coach d'étude. Avant de commencer, dis-moi : quelle matière veux-tu travailler, que veux-tu faire et combien de temps as-tu ? Ensuite je te présente le bon Maestro. 😊",
+      "withSubject": "Salut ! Je suis {coach}, ton coach d'étude. Aujourd'hui on travaille sur {subject} : je te présente tout de suite le bon Maestro ! 😊"
     }
   }
 }

--- a/apps/web/messages/it/chat.json
+++ b/apps/web/messages/it/chat.json
@@ -577,6 +577,10 @@
     "citazioneMotivazionale": "Citazione motivazionale",
     "quoteIndicators": "Quote indicators",
     "tornaAllaConversazioneCon": "Torna alla conversazione con {name}",
-    "vaiAllaCitazione": "Vai alla citazione {index}"
+    "vaiAllaCitazione": "Vai alla citazione {index}",
+    "coachOpener": {
+      "general": "Ciao! Sono {coach}, il tuo coach di studio. Prima di iniziare dimmi: di quale materia ti vuoi occupare, cosa vuoi fare e quanto tempo hai? Poi ti presento il Maestro giusto. 😊",
+      "withSubject": "Ciao! Sono {coach}, il tuo coach di studio. Oggi lavoriamo su {subject}: ti presento subito il Maestro giusto! 😊"
+    }
   }
 }

--- a/apps/web/src/components/maestros/__tests__/coach-opener.test.ts
+++ b/apps/web/src/components/maestros/__tests__/coach-opener.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveCoachName, buildCoachOpener } from '../coach-opener';
+
+describe('resolveCoachName', () => {
+  it('returns the chosen coach name for a valid preference', () => {
+    // Arrange / Act
+    const name = resolveCoachName('roberto');
+
+    // Assert
+    expect(name).toBe('Roberto');
+  });
+
+  it('falls back to the default coach (Melissa) when preference is undefined', () => {
+    // Arrange / Act
+    const name = resolveCoachName(undefined);
+
+    // Assert
+    expect(name).toBe('Melissa');
+  });
+
+  it('falls back to the default coach when preference is an unknown id', () => {
+    // Arrange / Act
+    const name = resolveCoachName('does-not-exist');
+
+    // Assert
+    expect(name).toBe('Melissa');
+  });
+});
+
+describe('buildCoachOpener', () => {
+  const t = vi.fn(
+    (key: string, values?: Record<string, string>) => `${key}|${JSON.stringify(values ?? {})}`,
+  );
+
+  it('uses the guided-questions general variant when the subject is unknown', () => {
+    // Arrange / Act
+    const opener = buildCoachOpener('chiara', undefined, t);
+
+    // Assert
+    expect(opener).toBe('coachOpener.general|{"coach":"Chiara"}');
+  });
+
+  it('uses the short withSubject variant when the subject is known', () => {
+    // Arrange / Act
+    const opener = buildCoachOpener('chiara', 'Matematica', t);
+
+    // Assert
+    expect(opener).toBe('coachOpener.withSubject|{"coach":"Chiara","subject":"Matematica"}');
+  });
+
+  it('resolves to the default coach name inside the opener when preference missing', () => {
+    // Arrange / Act
+    const opener = buildCoachOpener(null, undefined, t);
+
+    // Assert
+    expect(opener).toContain('"coach":"Melissa"');
+  });
+});

--- a/apps/web/src/components/maestros/coach-opener.ts
+++ b/apps/web/src/components/maestros/coach-opener.ts
@@ -1,0 +1,42 @@
+/**
+ * Neutral study-coach opener helpers.
+ *
+ * A child session must never start by dropping the child straight into a subject
+ * Maestro's persona (e.g. Manzoni). Instead it opens on behalf of the profile's
+ * chosen study coach, who greets the child and — when the subject isn't known yet
+ * — asks the organizing questions before the right Maestro takes over.
+ */
+import {
+  getSupportTeacherById,
+  getDefaultSupportTeacher,
+  type CoachId,
+} from '@/data/support-teachers';
+
+type Translate = (key: string, values?: Record<string, string>) => string;
+
+/**
+ * Resolve the display name of the child's chosen study coach, falling back to the
+ * default coach (Melissa) when the profile has no preference or an unknown id.
+ */
+export function resolveCoachName(preferredCoach: string | null | undefined): string {
+  const coach =
+    (preferredCoach && getSupportTeacherById(preferredCoach as CoachId)) ||
+    getDefaultSupportTeacher();
+  return coach.name;
+}
+
+/**
+ * Build the localized neutral opener. Uses the short `withSubject` variant when the
+ * subject is already known (so it doesn't block the subject Maestro / tool
+ * auto-trigger), otherwise the guided-questions `general` variant.
+ */
+export function buildCoachOpener(
+  preferredCoach: string | null | undefined,
+  subjectLabel: string | undefined,
+  t: Translate,
+): string {
+  const coach = resolveCoachName(preferredCoach);
+  return subjectLabel
+    ? t('coachOpener.withSubject', { coach, subject: subjectLabel })
+    : t('coachOpener.general', { coach });
+}

--- a/apps/web/src/components/maestros/maestro-session.tsx
+++ b/apps/web/src/components/maestros/maestro-session.tsx
@@ -13,11 +13,13 @@
  */
 
 import { useRef, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { AnimatePresence } from 'framer-motion';
 import { ErrorBoundary } from '@/components/error-boundary';
 import { useTTS } from '@/components/accessibility';
 import { ToolResultDisplay } from '@/components/tools';
-import { useUIStore } from '@/lib/stores';
+import { useUIStore, useSettingsStore } from '@/lib/stores';
+import { buildCoachOpener } from './coach-opener';
 import type { Maestro, ToolType } from '@/types';
 import { useMaestroSessionLogic } from './use-maestro-session-logic';
 import { MaestroSessionHandoff } from './maestro-session-handoff';
@@ -68,6 +70,12 @@ export function MaestroSession({
   const { speak, stop: stopTTS, enabled: ttsEnabled } = useTTS();
   const unifiedCharacter = maestroToUnified(maestro);
 
+  const t = useTranslations('chat');
+  const preferredCoach = useSettingsStore((s) => s.studentProfile.preferredCoach);
+  // Neutral opener on behalf of the child's chosen coach (falls back to Melissa)
+  // so a session never starts straight in a subject Maestro's persona.
+  const coachOpener = buildCoachOpener(preferredCoach, subjectLabel, t);
+
   // Prevent screen sleep during active sessions
   useWakeLock(true);
 
@@ -101,7 +109,13 @@ export function MaestroSession({
     requestTool,
     handleRequestPhoto,
     loadConversation,
-  } = useMaestroSessionLogic({ maestro, initialMode, requestedToolType, contextMessage });
+  } = useMaestroSessionLogic({
+    maestro,
+    initialMode,
+    requestedToolType,
+    contextMessage,
+    coachOpener,
+  });
 
   // Build unified voice state and actions
   const voiceState: VoiceState = {

--- a/apps/web/src/components/maestros/maestro-session.tsx
+++ b/apps/web/src/components/maestros/maestro-session.tsx
@@ -277,8 +277,10 @@ export function MaestroSession({
         {/* UX-01/UX-07: child-first handoff banner. Only when arriving via an
             intent (grid entry passes no intent) and before the child has sent
             anything (it explains who they are talking to + the pre-filled
-            question). Lives above the first message; never steals focus. */}
-        {intent && messages.length === 0 && (
+            question). The neutral coach opener seeds an assistant message, so we
+            key off "no user message yet" rather than an empty thread. Tool intents
+            carry their own greeting/auto-trigger and never showed this banner. */}
+        {intent && !requestedToolType && !messages.some((m) => m.role === 'user') && (
           <MaestroSessionHandoff
             maestroName={maestro.displayName ?? maestro.name}
             intent={intent}

--- a/apps/web/src/components/maestros/use-maestro-session-logic.ts
+++ b/apps/web/src/components/maestros/use-maestro-session-logic.ts
@@ -16,6 +16,14 @@ interface UseMaestroSessionLogicProps {
   initialMode: 'voice' | 'chat';
   requestedToolType?: ToolType;
   contextMessage?: string;
+  /**
+   * Neutral study-coach opener shown as the first assistant message so a session
+   * never starts by dropping the child straight into a subject Maestro's persona.
+   * Built (localized) by the caller from the profile's preferred coach. When the
+   * child starts a voice call this message is passed to the realtime model as
+   * conversation context, so voice inherits the same neutral framing.
+   */
+  coachOpener?: string;
 }
 
 export function useMaestroSessionLogic({
@@ -23,6 +31,7 @@ export function useMaestroSessionLogic({
   initialMode,
   requestedToolType,
   contextMessage,
+  coachOpener,
 }: UseMaestroSessionLogicProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -129,6 +138,19 @@ export function useMaestroSessionLogic({
   useEffect(() => {
     const initialMessages: ChatMessage[] = [];
 
+    // Neutral study-coach opener always comes first (when provided): it greets on
+    // behalf of the child's chosen coach and, if the subject isn't known yet,
+    // asks the organizing questions — instead of opening straight into a subject
+    // Maestro (e.g. Manzoni). The subject Maestro takes over on the next turn.
+    if (coachOpener) {
+      initialMessages.push({
+        id: `coach-opener-${Date.now()}`,
+        role: 'assistant',
+        content: coachOpener,
+        timestamp: new Date(),
+      });
+    }
+
     // Add contextual initial message if a tool was requested from the astuccio
     if (requestedToolType) {
       const contextualGreetings: Record<ToolType, string> = {
@@ -187,7 +209,14 @@ export function useMaestroSessionLogic({
     return () => {
       if (timeoutRef) clearTimeout(timeoutRef);
     };
-  }, [maestro.id, requestedToolType, contextMessage, pendingToolRequest, clearPendingToolRequest]);
+  }, [
+    maestro.id,
+    requestedToolType,
+    contextMessage,
+    coachOpener,
+    pendingToolRequest,
+    clearPendingToolRequest,
+  ]);
 
   // Auto-trigger tool request when requestedToolType is present (from URL param)
   useEffect(() => {

--- a/apps/web/src/components/maestros/use-maestro-session-logic.ts
+++ b/apps/web/src/components/maestros/use-maestro-session-logic.ts
@@ -134,6 +134,11 @@ export function useMaestroSessionLogic({
   // Track if we've auto-triggered the requested tool
   const hasAutoTriggeredRef = useRef(false);
 
+  // Tracks which maestro this session was last initialized for, so a settings
+  // hydration (preferredCoach undefined → saved id, which changes coachOpener)
+  // reruns this effect WITHOUT wiping a conversation the child already started.
+  const initializedMaestroRef = useRef<string | null>(null);
+
   // Initialize session with contextual greeting based on requested tool
   useEffect(() => {
     const initialMessages: ChatMessage[] = [];
@@ -184,25 +189,38 @@ export function useMaestroSessionLogic({
       }
     }
 
-    setMessages(initialMessages);
+    // A fresh maestro (or first mount) starts a clean thread; a rerun for the SAME
+    // maestro — e.g. when preferredCoach hydrates and coachOpener changes — must not
+    // clobber messages the child has already exchanged.
+    const isFirstInitForMaestro = initializedMaestroRef.current !== maestro.id;
+    initializedMaestroRef.current = maestro.id;
 
-    // Pre-populate input with context message from URL param (e.g., from Astuccio)
-    if (contextMessage) {
-      setInput(contextMessage);
-    }
+    setMessages((prev) => {
+      if (isFirstInitForMaestro) return initialMessages;
+      return prev.some((m) => m.role === 'user') ? prev : initialMessages;
+    });
 
-    if (pendingToolRequest?.maestroId === maestro.id) {
-      const toolPrompts: Partial<Record<ToolType, string>> = {
-        mindmap: `Crea una mappa mentale sull'argomento di cui stiamo parlando`,
-        quiz: `Crea un quiz per verificare la mia comprensione`,
-        flashcard: `Crea delle flashcard per aiutarmi a memorizzare`,
-        demo: `Crea una demo interattiva per spiegarmi meglio il concetto`,
-      };
-      const pendingPrompt = toolPrompts[pendingToolRequest.tool];
-      if (pendingPrompt) {
-        setInput(pendingPrompt);
+    // Side effects that must run once per session, not on every hydration rerun
+    // (otherwise they'd overwrite what the child is currently typing).
+    if (isFirstInitForMaestro) {
+      // Pre-populate input with context message from URL param (e.g., from Astuccio)
+      if (contextMessage) {
+        setInput(contextMessage);
       }
-      clearPendingToolRequest();
+
+      if (pendingToolRequest?.maestroId === maestro.id) {
+        const toolPrompts: Partial<Record<ToolType, string>> = {
+          mindmap: `Crea una mappa mentale sull'argomento di cui stiamo parlando`,
+          quiz: `Crea un quiz per verificare la mia comprensione`,
+          flashcard: `Crea delle flashcard per aiutarmi a memorizzare`,
+          demo: `Crea una demo interattiva per spiegarmi meglio il concetto`,
+        };
+        const pendingPrompt = toolPrompts[pendingToolRequest.tool];
+        if (pendingPrompt) {
+          setInput(pendingPrompt);
+        }
+        clearPendingToolRequest();
+      }
     }
 
     const timeoutRef = closeTimeoutRef.current;


### PR DESCRIPTION
## Cosa
Le sessioni del bambino non partono più diritte nella persona di un Maestro di materia (es. **Alessandro Manzoni** via il fallback generalista). Il primo messaggio è ora un **opener neutro** pronunciato a nome del **coach scelto nel profilo** (`profile.preferredCoach`, default **Melissa**), che aiuta a organizzare la sessione di studio prima di passare la palla al Maestro giusto.

### Comportamento
- **Materia non ancora scelta** (path "Qualsiasi materia" / compiti): il coach saluta e fa le domande organizzative — quale materia, cosa vuoi fare, quanto tempo hai — poi introduce il Maestro giusto.
- **Materia già nota** (card materia / tool): intro breve del coach, così il Maestro e l'auto-trigger dei tool **non** vengono bloccati.
- **Voce**: eredita lo stesso inquadramento neutro — l'opener fa parte dei messaggi chat passati come contesto al modello realtime all'avvio della chiamata vocale.

### Come sappiamo chi è il bimbo loggato
Cookie di sessione firmato → `validateAuth()` → `userId` → `prisma.user` con `Profile` (`preferredCoach`/`preferredBuddy`). Sul client il coach preferito arriva da `useSettingsStore().studentProfile.preferredCoach`; fallback a Melissa se assente/sconosciuto.

## Modifiche
- `coach-opener.ts` — helper puri e testabili `buildCoachOpener` / `resolveCoachName`.
- `maestro-session.tsx` — costruisce l'opener localizzato dal coach del profilo e lo passa alla hook.
- `use-maestro-session-logic.ts` — nuovo prop `coachOpener`, anteposto come primo messaggio assistant.
- `messages/{it,en,fr,de,es}/chat.json` — nuove chiavi `chat.coachOpener.{general,withSubject}` (5 locali).
- Test: `__tests__/coach-opener.test.ts` (6 test, AAA).

## Scope / note
- Approccio A (lightweight opener dentro l'architettura esistente, sessione modellata sul Maestro). Il ri-routing completo del Maestro dopo le domande resta nel sistema di handoff — **fuori scope** qui; l'opener neutro copre comunque la richiesta perché il bimbo non vede più Manzoni per primo.
- Un opener vocale "first-voice" dedicato via istruzione di sessione è possibile come fast-follow; oggi la voce eredita il contesto chat.

## Validazione
- test:unit — 11899 passed (6 nuovi)
- ci-summary.sh — lint + typecheck + build PASS
- i18n:check — 5/5 locali PASS

Non fare merge senza approvazione (gate umano).
