### PR TITLE
chore(deploy): exclude local-only artifacts from vercel CLI uploads

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,1 +1,15 @@
 feature/
+# --- local-only artifacts (manual CLI deploy) ---
+.git
+node_modules
+**/node_modules
+.next
+**/.next
+.codegraph
+worktrees
+coverage
+playwright-report
+test-results
+blob-report
+*.log
+.turbo


### PR DESCRIPTION
## What
Adds local-only artifact excludes to `.vercelignore`.

## Why
When `.vercelignore` exists, Vercel does **not** fall back to `.gitignore`, so `vercel deploy` (manual CLI) uploads everything not explicitly ignored — including the `.codegraph` unix socket, which triggers a fatal upload `Error -102`. This surfaced while promoting today's production deploy manually (needed because `vercel.json` `ignoreCommand: exit 0` disables git-triggered builds).

## Excludes added
`.git`, `node_modules`, `.next`, `.codegraph`, `worktrees`, `coverage`, `playwright-report`, `test-results`, `blob-report`, `*.log`, `.turbo`.

## Risk
None for production build (Vercel builds from git, not local upload). Only affects manual CLI uploads.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>