### PR TITLE
feat(robot): MirrorBuddy embodiment for Reachy Mini (voice, vision, movement)

### DIFF
--- a/robot/.env.example
+++ b/robot/.env.example
@@ -1,0 +1,22 @@
+# --- Azure OpenAI Realtime (the brain + voice) --------------------------------
+# Required. Copy from the MirrorBuddy .env (same Azure resource).
+AZURE_OPENAI_REALTIME_ENDPOINT=https://<your-resource>.openai.azure.com/
+AZURE_OPENAI_REALTIME_API_KEY=
+AZURE_OPENAI_REALTIME_DEPLOYMENT=gpt-realtime
+# Optional: if set, uses the deprecated Preview WS protocol. Leave empty for GA.
+AZURE_OPENAI_REALTIME_API_VERSION=
+
+# --- MirrorBuddy alignment ----------------------------------------------------
+# Where to fetch the Maestri (personas + voices) from. Public /api/maestri endpoint.
+MIRRORBUDDY_URL=https://mirrorbuddy.org
+MIRRORBUDDY_LOCALE=it
+# Which Maestro to embody. Empty = first Italian tutor. See the settings UI for ids.
+MIRRORBUDDY_MAESTRO_ID=
+# Accessibility profile: cerebral | dyslexia | dyscalculia | adhd | autism | motor | visual | auditory | default
+MIRRORBUDDY_DSA_PROFILE=cerebral
+# Personalise the greeting.
+MIRRORBUDDY_STUDENT_NAME=Mario
+
+# --- feature toggles ----------------------------------------------------------
+MIRRORBUDDY_ENABLE_CAMERA=true
+MIRRORBUDDY_ENABLE_MOVEMENTS=true

--- a/robot/.env.example
+++ b/robot/.env.example
@@ -10,8 +10,14 @@ AZURE_OPENAI_REALTIME_API_VERSION=
 # Where to fetch the Maestri (personas + voices) from. Public /api/maestri endpoint.
 MIRRORBUDDY_URL=https://mirrorbuddy.org
 MIRRORBUDDY_LOCALE=it
-# Which Maestro to embody. Empty = first Italian tutor. See the settings UI for ids.
+# Which Maestro to embody. Empty = start neutrally as "Buddy" (see START_NEUTRAL below).
+# Set to a Maestro id (from the settings UI) to always start as that professor.
 MIRRORBUDDY_MAESTRO_ID=
+# Start neutrally as "Buddy" (helps organise the study session, then calls the right
+# professor) instead of impersonating a historical Maestro. A pinned MAESTRO_ID wins.
+MIRRORBUDDY_START_NEUTRAL=true
+# Voice for the neutral Buddy: alloy | ash | ballad | coral | echo | sage | shimmer | verse
+MIRRORBUDDY_BUDDY_VOICE=coral
 # Accessibility profile: cerebral | dyslexia | dyscalculia | adhd | autism | motor | visual | auditory | default
 MIRRORBUDDY_DSA_PROFILE=cerebral
 # Personalise the greeting.
@@ -24,3 +30,8 @@ MIRRORBUDDY_ENABLE_CAMERA=true
 MIRRORBUDDY_ENABLE_MOVEMENTS=true
 # Face following: the head tracks the student's face while listening (needs the camera).
 MIRRORBUDDY_FOLLOW_FACE=true
+# Calm motion (recommended): no audio head wobbler + gentler amplitudes so the robot does
+# not distract the student while speaking. Set to false for livelier, more theatrical motion.
+MIRRORBUDDY_CALM_MOVEMENT=true
+# Debug: when set to 1, saves the last camera frame to /tmp/mb_frame.jpg (for tuning). Off by default.
+# MIRRORBUDDY_SAVE_FRAMES=1

--- a/robot/.env.example
+++ b/robot/.env.example
@@ -18,5 +18,9 @@ MIRRORBUDDY_DSA_PROFILE=cerebral
 MIRRORBUDDY_STUDENT_NAME=Mario
 
 # --- feature toggles ----------------------------------------------------------
+# Camera (vision): let Buddy take a photo to read homework, on explicit request only.
 MIRRORBUDDY_ENABLE_CAMERA=true
+# Expressive antenna / body / head movement.
 MIRRORBUDDY_ENABLE_MOVEMENTS=true
+# Face following: the head tracks the student's face while listening (needs the camera).
+MIRRORBUDDY_FOLLOW_FACE=true

--- a/robot/.gitignore
+++ b/robot/.gitignore
@@ -1,0 +1,5 @@
+.env
+__pycache__/
+*.pyc
+*.egg-info/
+.venv/

--- a/robot/README.md
+++ b/robot/README.md
@@ -42,11 +42,40 @@ model speech stream over a single Azure Realtime WebSocket (`azure_realtime`).
 | `prompt_builder.py` | Assemble the realtime `instructions` (persona + safety + embodiment) |
 | `safety.py` | Child-safety guardrails (aligned with MirrorBuddy) |
 | `dsa.py` | Accessibility → server-VAD turn-detection tuning |
-| `azure_realtime.py` | Azure OpenAI Realtime WebSocket client |
+| `azure_realtime.py` | Azure OpenAI Realtime WebSocket client (audio + tools + vision) |
+| `rt_messages.py` | Pure builders for the realtime protocol messages |
 | `audio_io.py` | Robot mic ↔ speaker bridge (resampling, playback, barge-in) |
-| `movements.py` | Safe expressive antenna motion driven by speech energy |
+| `movements.py` | Expressive full-body motion + daemon face-follow while listening |
+| `camera.py` | On-demand JPEG capture + daemon head/face tracking helpers |
+| `tools.py` | Voice tool schemas (list/change professor, look at homework) + resolver |
+| `controller.py` | Tool dispatch, live professor switching and vision |
 | `settings_ui.py` | Minimal in-app settings page (creds + Maestro/DSA selection) |
 | `main.py` | App entry point wiring everything together |
+
+## Everything by voice (no screen)
+
+Buddy is voice-only, so the model drives the robot through realtime **tools**:
+
+- **Change professor / subject** — say e.g. *«voglio matematica»* or *«chiama Galileo»*.
+  `call_professor` resolves the Maestro and reconnects the session with the new
+  **persona + voice**; the new professor greets. All 26 MirrorBuddy Maestri are available.
+- **Look at homework** — say e.g. *«guarda questo compito»*. `look_at_homework` captures
+  one camera frame and the model reads the exercise and helps step by step.
+- **Who is here** — `list_professors` enumerates the available Maestri and their subjects.
+
+## Eyes: face-follow & privacy
+
+While listening, the robot **follows the student's face** (daemon head tracking); when
+Buddy speaks, the head hands over to the audio wobbler for lip-sync-like motion.
+
+Privacy by design: the camera **never streams** and captures a frame **only** on an
+explicit `look_at_homework` request, always preceded by a spoken *"I'm going to look…"*.
+Nothing (audio or images) is persisted to disk. Face-follow and the camera can be turned
+off with `MIRRORBUDDY_FOLLOW_FACE=false` / `MIRRORBUDDY_ENABLE_CAMERA=false`.
+
+Identity: the robot is configured **per device** (`MIRRORBUDDY_STUDENT_NAME`,
+`MIRRORBUDDY_DSA_PROFILE`) rather than tied to a MirrorBuddy web login; secure
+device-to-account pairing is on the roadmap.
 
 ## Configuration
 

--- a/robot/README.md
+++ b/robot/README.md
@@ -1,0 +1,86 @@
+# MirrorBuddy on Reachy Mini 🤖
+
+The **physical embodiment of MirrorBuddy**: a Reachy Mini robot that becomes a
+MirrorBuddy Maestro with a body —
+
+- 👁️ **eyes** — the robot camera
+- 👂 **ears** — the robot microphone
+- 👄 **mouth** — the robot speaker
+- 🤸 **movements** — head wobble (speech-synced) + expressive antennas
+
+It reuses **MirrorBuddy's brain** end-to-end, so the robot stays 1:1 aligned with the
+web app at [mirrorbuddy.org](https://mirrorbuddy.org):
+
+- **Personas** — the 26 Maestri are fetched live from MirrorBuddy's public
+  `GET /api/maestri?locale=it` endpoint (same names, voices, system prompts, greetings).
+- **Voice + conversation** — Azure OpenAI **Realtime** (speech-to-speech), the same
+  provider and the same 8 voices (`alloy, ash, ballad, coral, echo, sage, shimmer, verse`).
+- **Child-safety** — the professor-constitution guardrails are prepended to every session.
+- **Accessibility (DSA)** — 8 profiles tune the turn-detection so the robot waits
+  patiently for children who speak more slowly (motor / cerebral palsy, dyslexia…).
+
+## How it works
+
+```
+robot mic ─▶ AudioIO ─▶ Azure Realtime WS ─▶ AudioIO ─▶ robot speaker
+                            ▲     │                          │
+              MirrorBuddy Maestro │ instructions        speech energy
+              (persona + voice)   ▼                          ▼
+                          safety + DSA + embodiment      antenna motion
+```
+
+The Maestro persona (`prompt_builder`) + child-safety (`safety`) + DSA VAD tuning
+(`dsa`) are assembled into the realtime `session.update`, then microphone audio and
+model speech stream over a single Azure Realtime WebSocket (`azure_realtime`).
+
+## Modules
+
+| File | Responsibility |
+| --- | --- |
+| `config.py` | Environment / `.env` configuration + WS URL (GA vs Preview) |
+| `mirrorbuddy_client.py` | Fetch + pick a Maestro from MirrorBuddy's public API |
+| `prompt_builder.py` | Assemble the realtime `instructions` (persona + safety + embodiment) |
+| `safety.py` | Child-safety guardrails (aligned with MirrorBuddy) |
+| `dsa.py` | Accessibility → server-VAD turn-detection tuning |
+| `azure_realtime.py` | Azure OpenAI Realtime WebSocket client |
+| `audio_io.py` | Robot mic ↔ speaker bridge (resampling, playback, barge-in) |
+| `movements.py` | Safe expressive antenna motion driven by speech energy |
+| `settings_ui.py` | Minimal in-app settings page (creds + Maestro/DSA selection) |
+| `main.py` | App entry point wiring everything together |
+
+## Configuration
+
+Copy `.env.example` to the app instance `.env` and fill in the Azure credentials
+(the same Azure resource MirrorBuddy uses). Nothing sensitive is committed. You can
+also enter everything from the in-app settings page.
+
+Required:
+
+- `AZURE_OPENAI_REALTIME_ENDPOINT`
+- `AZURE_OPENAI_REALTIME_API_KEY`
+- `AZURE_OPENAI_REALTIME_DEPLOYMENT` (e.g. `gpt-realtime`)
+
+Useful optional:
+
+- `MIRRORBUDDY_MAESTRO_ID` — which professor to embody (empty = first Italian tutor)
+- `MIRRORBUDDY_DSA_PROFILE` — `cerebral` (default), `dyslexia`, `adhd`, …
+- `MIRRORBUDDY_STUDENT_NAME` — personalises the greeting (e.g. `Mario`)
+
+## Install on the robot
+
+```bash
+# on the Reachy Mini (ssh pollen@<robot-ip>)
+uv pip install --python /path/to/mini_daemon /path/to/robot   # installs this package
+# then set the instance .env and start it from the Reachy Mini dashboard,
+# or run directly:
+python -m reachy_mini_mirrorbuddy.main --debug
+```
+
+The app registers under the `reachy_mini_apps` entry-point group as
+`reachy_mini_mirrorbuddy`, so the Reachy Mini daemon discovers it automatically.
+
+## Roadmap
+
+- **Vision** — the camera hardware is available; sending frames to the realtime model
+  (so Buddy can actually *see* homework you show it) is the next enhancement.
+- **Emotion → richer movement** — map transcript sentiment to head gestures.

--- a/robot/pyproject.toml
+++ b/robot/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "reachy-mini-mirrorbuddy"
+version = "0.1.0"
+description = "MirrorBuddy on Reachy Mini — the physical embodiment of MirrorBuddy (eyes, ears, mouth, movements) powered by Azure OpenAI Realtime and the MirrorBuddy Maestri."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+authors = [{ name = "FightTheStroke / MirrorBuddy" }]
+dependencies = [
+    "websockets>=12.0",
+    "numpy>=1.26",
+    "scipy>=1.11",
+    "httpx>=0.27",
+    "python-dotenv>=1.0",
+]
+
+# reachy_mini, fastapi and uvicorn are provided by the Reachy Mini host runtime.
+
+[project.scripts]
+reachy-mini-mirrorbuddy = "reachy_mini_mirrorbuddy.main:main"
+
+[project.entry-points.reachy_mini_apps]
+reachy_mini_mirrorbuddy = "reachy_mini_mirrorbuddy.main:ReachyMiniMirrorBuddy"
+
+[tool.hatch.build.targets.wheel]
+packages = ["reachy_mini_mirrorbuddy"]

--- a/robot/reachy_mini_mirrorbuddy/__init__.py
+++ b/robot/reachy_mini_mirrorbuddy/__init__.py
@@ -1,0 +1,12 @@
+"""MirrorBuddy on Reachy Mini.
+
+The physical embodiment of MirrorBuddy: the robot becomes a MirrorBuddy Maestro
+with eyes (camera), ears (microphone), mouth (speaker) and expressive movements.
+
+It reuses MirrorBuddy's brain end-to-end:
+- Maestri personas are fetched live from MirrorBuddy's public ``/api/maestri`` endpoint.
+- Voice + conversation run on Azure OpenAI Realtime (the same provider MirrorBuddy uses).
+- Child-safety guardrails and DSA (accessibility) tuning mirror the MirrorBuddy web app.
+"""
+
+__version__ = "0.1.0"

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -14,11 +14,22 @@ import time
 from collections.abc import Callable
 
 import numpy as np
-from scipy.signal import resample
+from math import gcd
+from scipy.signal import resample_poly
 
 from .azure_realtime import SAMPLE_RATE
 
 logger = logging.getLogger(__name__)
+
+
+def _resample(audio: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
+    """Low-latency polyphase resampling (faster + cleaner than FFT resample)."""
+    if src_rate == dst_rate or audio.size == 0:
+        return audio
+    g = gcd(src_rate, dst_rate)
+    up = dst_rate // g
+    down = src_rate // g
+    return resample_poly(audio, up, down)
 
 
 class AudioIO:
@@ -93,8 +104,7 @@ class AudioIO:
 
         out_rate = self._out_rate or SAMPLE_RATE
         if out_rate != SAMPLE_RATE and audio.size:
-            target = max(1, int(audio.size * out_rate / SAMPLE_RATE))
-            audio = resample(audio, target)
+            audio = _resample(audio, SAMPLE_RATE, out_rate)
         audio_f32 = (np.asarray(audio, dtype=np.float32)) / 32768.0
         try:
             self.robot.media.push_audio_sample(audio_f32)
@@ -138,8 +148,7 @@ class AudioIO:
 
                 # Resample microphone -> realtime rate.
                 if needs_resample and audio.size:
-                    target = max(1, int(audio.size * SAMPLE_RATE / in_rate))
-                    audio = resample(audio, target).astype(np.int16)
+                    audio = _resample(audio, in_rate, SAMPLE_RATE).astype(np.int16)
 
                 self.on_input_pcm16(audio.tobytes())
             except Exception as e:

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -113,10 +113,15 @@ class AudioIO:
 
     def interrupt(self) -> None:
         """Stop current playback (barge-in) and reset movement state."""
+        # clear_output_buffer() is deprecated and a no-op on this firmware; clear_player()
+        # actually flushes the queued speaker audio so speech stops immediately.
         try:
-            self.robot.media.audio.clear_output_buffer()
+            self.robot.media.audio.clear_player()
         except Exception:
-            pass
+            try:
+                self.robot.media.audio.clear_output_buffer()
+            except Exception:
+                pass
         if self.movements is not None:
             try:
                 self.movements.reset()

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -1,0 +1,148 @@
+"""Bridge the robot's microphone/speaker to the Azure Realtime client.
+
+- Captures microphone audio, downmixes to mono, resamples to the realtime rate and
+  forwards it to a callback (which sends it to Azure).
+- Plays back the model's speech through the robot speaker, resampling to the robot's
+  output rate, and forwards the same audio to the movement engine for lip-sync.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+
+import numpy as np
+from scipy.signal import resample
+
+from .azure_realtime import SAMPLE_RATE
+
+logger = logging.getLogger(__name__)
+
+
+class AudioIO:
+    """Microphone capture + speaker playback for the realtime session."""
+
+    def __init__(
+        self,
+        robot,
+        on_input_pcm16: Callable[[bytes], None],
+        movements=None,
+    ) -> None:
+        self.robot = robot
+        self.on_input_pcm16 = on_input_pcm16
+        self.movements = movements
+
+        self._recording = False
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._in_rate: int | None = None
+        self._out_rate: int | None = None
+
+    # ------------------------------------------------------------------ lifecycle
+    def start(self) -> None:
+        self.robot.media.start_recording()
+        self.robot.media.start_playing()
+        time.sleep(1.0)  # let the gstreamer pipelines come up
+
+        try:
+            self._in_rate = int(self.robot.media.get_input_audio_samplerate())
+        except Exception:
+            self._in_rate = 16000
+        try:
+            self._out_rate = int(self.robot.media.get_output_audio_samplerate())
+        except Exception:
+            self._out_rate = 16000
+        logger.info("Audio rates — mic: %s Hz, speaker: %s Hz, realtime: %s Hz",
+                    self._in_rate, self._out_rate, SAMPLE_RATE)
+
+        self._recording = True
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._input_loop, name="MirrorBuddyMic", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._recording = False
+        self._stop.set()
+        try:
+            self.robot.media.stop_recording()
+        except Exception:
+            pass
+        try:
+            self.robot.media.stop_playing()
+        except Exception:
+            pass
+        if self._thread:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+    # ------------------------------------------------------------------ playback
+    def play(self, pcm16: bytes) -> None:
+        """Play model speech (PCM16 @ realtime rate) through the robot speaker."""
+        if not pcm16:
+            return
+        audio = np.frombuffer(pcm16, dtype=np.int16)
+
+        # Lip-sync / head movement is driven by the raw speech signal.
+        if self.movements is not None:
+            try:
+                self.movements.feed(audio, SAMPLE_RATE)
+            except Exception as e:
+                logger.debug("movement feed error: %s", e)
+
+        out_rate = self._out_rate or SAMPLE_RATE
+        if out_rate != SAMPLE_RATE and audio.size:
+            target = max(1, int(audio.size * out_rate / SAMPLE_RATE))
+            audio = resample(audio, target)
+        audio_f32 = (np.asarray(audio, dtype=np.float32)) / 32768.0
+        try:
+            self.robot.media.push_audio_sample(audio_f32)
+        except Exception as e:
+            logger.debug("push_audio_sample error: %s", e)
+
+    def interrupt(self) -> None:
+        """Stop current playback (barge-in) and reset movement state."""
+        try:
+            self.robot.media.audio.clear_output_buffer()
+        except Exception:
+            pass
+        if self.movements is not None:
+            try:
+                self.movements.reset()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------ capture
+    def _input_loop(self) -> None:
+        in_rate = self._in_rate or 16000
+        needs_resample = in_rate != SAMPLE_RATE
+        while self._recording and not self._stop.is_set():
+            try:
+                sample = self.robot.media.get_audio_sample()
+                if sample is None:
+                    time.sleep(0.001)
+                    continue
+                audio = sample if isinstance(sample, np.ndarray) else np.frombuffer(sample, dtype=np.int16)
+
+                # Downmix to mono.
+                if audio.ndim == 2:
+                    audio = audio.mean(axis=1)
+
+                # Normalise dtype to int16.
+                if audio.dtype != np.int16:
+                    if np.issubdtype(audio.dtype, np.floating):
+                        audio = (np.clip(audio, -1.0, 1.0) * 32767).astype(np.int16)
+                    else:
+                        audio = audio.astype(np.int16)
+
+                # Resample microphone -> realtime rate.
+                if needs_resample and audio.size:
+                    target = max(1, int(audio.size * SAMPLE_RATE / in_rate))
+                    audio = resample(audio, target).astype(np.int16)
+
+                self.on_input_pcm16(audio.tobytes())
+            except Exception as e:
+                logger.error("mic loop error: %s", e)
+                time.sleep(0.05)
+        logger.info("Microphone loop stopped")

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -1,17 +1,9 @@
 """Azure OpenAI Realtime client over WebSocket.
 
 Runs an asyncio event loop in its own thread and bridges to the (threaded) robot
-audio I/O:
-
-- ``send_audio_pcm16(bytes)``      push microphone audio to the model (thread-safe)
-- ``on_output_audio(bytes)``       callback invoked with model speech (PCM16)
-- ``on_speech_started()``          callback when the user starts talking (barge-in)
-- ``on_transcript(text, final)``   callback with the assistant transcript (for logs/UI)
-
-Audio is exchanged as 16-bit PCM mono at :data:`SAMPLE_RATE` Hz.
-
-The event schema differs slightly between the Azure Realtime GA and Preview
-protocols, so both variants of the relevant event names are handled.
+audio I/O: microphone PCM in, model speech + transcripts + tool calls out. Audio is
+16-bit PCM mono at :data:`SAMPLE_RATE` Hz. Both Realtime GA and Preview event names
+are handled. Message payloads are built in :mod:`rt_messages`.
 """
 
 from __future__ import annotations
@@ -25,9 +17,11 @@ from collections.abc import Callable
 
 import websockets
 
+from . import rt_messages
+
 logger = logging.getLogger(__name__)
 
-SAMPLE_RATE = 24000  # Azure Realtime PCM sample rate (in and out)
+SAMPLE_RATE = rt_messages.SAMPLE_RATE  # Azure Realtime PCM sample rate (in and out)
 
 
 class AzureRealtimeClient:
@@ -42,10 +36,12 @@ class AzureRealtimeClient:
         turn_detection: dict,
         greeting: str | None = None,
         use_ga: bool = True,
+        tools: list[dict] | None = None,
         on_output_audio: Callable[[bytes], None] | None = None,
         on_speech_started: Callable[[], None] | None = None,
         on_transcript: Callable[[str, bool], None] | None = None,
         on_ready: Callable[[], None] | None = None,
+        on_tool_call: Callable[[str, dict, str], None] | None = None,
     ) -> None:
         self.ws_url = ws_url
         self.api_key = api_key
@@ -54,11 +50,14 @@ class AzureRealtimeClient:
         self.turn_detection = turn_detection
         self.greeting = greeting
         self.use_ga = use_ga
+        self.tools = tools or []
 
         self.on_output_audio = on_output_audio
         self.on_speech_started = on_speech_started
         self.on_transcript = on_transcript
         self.on_ready = on_ready
+        self.on_tool_call = on_tool_call
+        self._fc_names: dict[str, str] = {}
 
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
@@ -97,7 +96,25 @@ class AzureRealtimeClient:
         if not pcm16 or self._ws is None or self._loop is None:
             return
         b64 = base64.b64encode(pcm16).decode("ascii")
-        msg = json.dumps({"type": "input_audio_buffer.append", "audio": b64})
+        try:
+            asyncio.run_coroutine_threadsafe(self._safe_send(json.dumps(rt_messages.audio_append(b64))), self._loop)
+        except Exception:
+            pass
+
+    def send_function_result(self, call_id: str, output: str, respond: bool = True) -> None:
+        """Thread-safe: answer a function call, then let the model continue speaking."""
+        self._enqueue(json.dumps(rt_messages.function_call_output(call_id, output)))
+        if respond:
+            self._enqueue(json.dumps({"type": "response.create"}))
+
+    def send_image(self, data_url: str, prompt: str) -> None:
+        """Thread-safe: hand the model a camera frame plus a question about it."""
+        self._enqueue(json.dumps(rt_messages.image_message(data_url, prompt)))
+        self._enqueue(json.dumps({"type": "response.create"}))
+
+    def _enqueue(self, msg: str) -> None:
+        if self._ws is None or self._loop is None:
+            return
         try:
             asyncio.run_coroutine_threadsafe(self._safe_send(msg), self._loop)
         except Exception:
@@ -135,7 +152,10 @@ class AzureRealtimeClient:
         ) as ws:
             self._ws = ws
             logger.info("WebSocket connected; configuring session")
-            await ws.send(json.dumps(self._session_update_payload()))
+            payload = rt_messages.session_update(
+                self.instructions, self.voice, self.turn_detection, self.tools, self.use_ga
+            )
+            await ws.send(json.dumps(payload))
 
             async for raw in ws:
                 if self._stop.is_set():
@@ -148,39 +168,6 @@ class AzureRealtimeClient:
 
         self._ws = None
         logger.info("WebSocket closed")
-
-    def _session_update_payload(self) -> dict:
-        """Build the ``session.update`` message (GA nested-audio shape)."""
-        if self.use_ga:
-            session = {
-                "type": "realtime",
-                "instructions": self.instructions,
-                "output_modalities": ["audio"],
-                "audio": {
-                    "input": {
-                        "format": {"type": "audio/pcm", "rate": SAMPLE_RATE},
-                        "turn_detection": self.turn_detection,
-                        "transcription": {"model": "whisper-1"},
-                        "noise_reduction": {"type": "near_field"},
-                    },
-                    "output": {
-                        "format": {"type": "audio/pcm", "rate": SAMPLE_RATE},
-                        "voice": self.voice,
-                    },
-                },
-            }
-        else:
-            # Preview (deprecated) flat shape.
-            session = {
-                "modalities": ["audio", "text"],
-                "instructions": self.instructions,
-                "voice": self.voice,
-                "input_audio_format": "pcm16",
-                "output_audio_format": "pcm16",
-                "input_audio_transcription": {"model": "whisper-1"},
-                "turn_detection": self.turn_detection,
-            }
-        return {"type": "session.update", "session": session}
 
     async def _greet(self) -> None:
         """Have the Maestro speak first."""
@@ -205,34 +192,48 @@ class AzureRealtimeClient:
         if etype in ("response.output_audio.delta", "response.audio.delta"):
             b64 = event.get("delta") or event.get("audio")
             if b64 and self.on_output_audio:
-                try:
-                    _safe_cb(self.on_output_audio, base64.b64decode(b64))
-                except Exception:
-                    pass
+                _safe_cb(self.on_output_audio, base64.b64decode(b64))
             return
 
         # User started speaking -> barge-in / interrupt current playback.
-        if etype == "input_audio_buffer.speech_started":
-            if self.on_speech_started:
-                _safe_cb(self.on_speech_started)
+        if etype == "input_audio_buffer.speech_started" and self.on_speech_started:
+            _safe_cb(self.on_speech_started)
             return
 
         # Assistant transcript (for logs / captions).
-        if etype in (
-            "response.output_audio_transcript.delta",
-            "response.audio_transcript.delta",
-        ):
+        if etype in ("response.output_audio_transcript.delta", "response.audio_transcript.delta"):
             delta = event.get("delta") or ""
             if delta and self.on_transcript:
                 _safe_cb(self.on_transcript, delta, False)
             return
-        if etype in (
-            "response.output_audio_transcript.done",
-            "response.audio_transcript.done",
-        ):
+        if etype in ("response.output_audio_transcript.done", "response.audio_transcript.done"):
             text = event.get("transcript") or ""
             if text and self.on_transcript:
                 _safe_cb(self.on_transcript, text, True)
+            return
+
+        # Function call: capture the tool name when the item is announced.
+        if etype == "response.output_item.added":
+            item = event.get("item") or {}
+            if item.get("type") == "function_call":
+                cid = item.get("call_id") or item.get("id") or ""
+                if cid:
+                    self._fc_names[cid] = item.get("name") or ""
+            return
+
+        # Function call arguments complete -> dispatch to the controller.
+        if etype == "response.function_call_arguments.done":
+            call_id = event.get("call_id") or ""
+            name = event.get("name") or self._fc_names.get(call_id, "")
+            raw_args = event.get("arguments") or "{}"
+            try:
+                args = json.loads(raw_args) if isinstance(raw_args, str) else dict(raw_args)
+            except (ValueError, TypeError):
+                args = {}
+            self._fc_names.pop(call_id, None)
+            logger.info("Tool call: %s(%s) call_id=%s", name, args, call_id)
+            if name and self.on_tool_call:
+                _safe_cb(self.on_tool_call, name, args, call_id)
             return
 
         if etype == "error":

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -1,8 +1,6 @@
-"""Azure OpenAI Realtime client over WebSocket.
+"""Azure OpenAI Realtime client over WebSocket (asyncio loop in its own thread).
 
-Runs an asyncio loop in its own thread and bridges the (threaded) robot audio I/O:
-microphone PCM in, model speech + transcripts + tool calls out. Audio is 16-bit PCM
-mono at :data:`SAMPLE_RATE` Hz. Payloads are built in :mod:`rt_messages`.
+Bridges robot audio I/O: mic PCM in, model speech + transcripts + tool calls out.
 """
 
 from __future__ import annotations
@@ -24,8 +22,6 @@ SAMPLE_RATE = rt_messages.SAMPLE_RATE  # Azure Realtime PCM sample rate (in and 
 
 
 class AzureRealtimeClient:
-    """Minimal, resilient Azure OpenAI Realtime WebSocket client."""
-
     def __init__(
         self,
         ws_url: str,
@@ -50,14 +46,12 @@ class AzureRealtimeClient:
         self.greeting = greeting
         self.use_ga = use_ga
         self.tools = tools or []
-
         self.on_output_audio = on_output_audio
         self.on_speech_started = on_speech_started
         self.on_transcript = on_transcript
         self.on_ready = on_ready
         self.on_tool_call = on_tool_call
         self._fc_names: dict[str, str] = {}
-
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
         self._ws: websockets.WebSocketClientProtocol | None = None
@@ -65,6 +59,7 @@ class AzureRealtimeClient:
         self._ready = threading.Event()
         self._responding = False  # a model response is currently streaming
         self._suppress = False  # drop in-flight audio after a barge-in cancel
+        self._quiet = False  # student asked for silence: keep model muted
 
     def start(self) -> None:
         self._thread = threading.Thread(target=self._run, name="AzureRealtime", daemon=True)
@@ -75,8 +70,7 @@ class AzureRealtimeClient:
 
     def stop(self) -> None:
         self._stop.set()
-        loop = self._loop
-        ws = self._ws
+        loop, ws = self._loop, self._ws
         if loop and ws:
             try:
                 asyncio.run_coroutine_threadsafe(ws.close(), loop)
@@ -88,22 +82,15 @@ class AzureRealtimeClient:
             self._thread.join(timeout)
 
     def send_audio_pcm16(self, pcm16: bytes) -> None:
-        if not pcm16 or self._ws is None or self._loop is None:
-            return
-        b64 = base64.b64encode(pcm16).decode("ascii")
-        try:
-            asyncio.run_coroutine_threadsafe(self._safe_send(json.dumps(rt_messages.audio_append(b64))), self._loop)
-        except Exception:
-            pass
+        if pcm16:
+            self._enqueue(json.dumps(rt_messages.audio_append(base64.b64encode(pcm16).decode("ascii"))))
 
     def send_function_result(self, call_id: str, output: str, respond: bool = True) -> None:
-        """Answer a function call, then let the model continue speaking."""
         self._enqueue(json.dumps(rt_messages.function_call_output(call_id, output)))
         if respond:
             self._enqueue(json.dumps({"type": "response.create"}))
 
     def send_image(self, data_url: str, prompt: str) -> None:
-        """Hand the model a camera frame plus a question about it."""
         self._enqueue(json.dumps(rt_messages.image_message(data_url, prompt)))
         self._enqueue(json.dumps({"type": "response.create"}))
 
@@ -137,11 +124,8 @@ class AzureRealtimeClient:
         headers = {"api-key": self.api_key}
         logger.info("Connecting to Azure Realtime: %s", self.ws_url.split("?")[0])
         async with websockets.connect(
-            self.ws_url,
-            additional_headers=headers,
-            max_size=None,
-            ping_interval=20,
-            ping_timeout=20,
+            self.ws_url, additional_headers=headers, max_size=None,
+            ping_interval=20, ping_timeout=20,
         ) as ws:
             self._ws = ws
             logger.info("WebSocket connected; configuring session")
@@ -163,7 +147,6 @@ class AzureRealtimeClient:
         logger.info("WebSocket closed")
 
     async def _greet(self) -> None:
-        """Have the Maestro speak first."""
         instructions = (
             f"Di' esattamente, con calore: «{self.greeting}»" if self.greeting
             else "Saluta calorosamente e presentati brevemente, poi chiedi da cosa vuole partire."
@@ -190,6 +173,10 @@ class AzureRealtimeClient:
             return
 
         if etype == "response.created":
+            if self._quiet:
+                await self._safe_send(rt_messages.CANCEL)
+                self._suppress = True
+                return
             self._responding = True
             self._suppress = False
             return
@@ -197,12 +184,26 @@ class AzureRealtimeClient:
             self._responding = False
             return
 
-        # User started speaking -> barge-in: cancel the model's turn server-side and
-        # suppress any audio still in flight, then stop local playback.
+        # Student's speech transcribed: honour stop-intent deterministically.
+        if etype.endswith("input_audio_transcription.completed"):
+            text = (event.get("transcript") or "").strip()
+            if not text:
+                return
+            self._quiet = rt_messages.is_stop(text)
+            if self._quiet:
+                self._suppress = True
+                if self._responding:
+                    await self._safe_send(rt_messages.CANCEL)
+                if self.on_speech_started:
+                    _safe_cb(self.on_speech_started)  # flush local playback now
+            return
+
+        # Barge-in: cancel the turn, drop in-flight audio; each new turn starts un-muted.
         if etype == "input_audio_buffer.speech_started":
             self._suppress = True
+            self._quiet = False
             if self._responding:
-                await self._safe_send(json.dumps({"type": "response.cancel"}))
+                await self._safe_send(rt_messages.CANCEL)
             if self.on_speech_started:
                 _safe_cb(self.on_speech_started)
             return
@@ -221,7 +222,6 @@ class AzureRealtimeClient:
                     self._fc_names[cid] = item.get("name") or ""
             return
 
-        # Function call arguments complete -> dispatch to the controller.
         if etype == "response.function_call_arguments.done":
             call_id = event.get("call_id") or ""
             name = event.get("name") or self._fc_names.get(call_id, "")

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -21,6 +21,14 @@ logger = logging.getLogger(__name__)
 SAMPLE_RATE = rt_messages.SAMPLE_RATE  # Azure Realtime PCM sample rate (in and out)
 
 
+def _ws_major() -> int:
+    """Major version of the installed ``websockets`` package (0 if unknown)."""
+    try:
+        return int(str(websockets.__version__).split(".", 1)[0])
+    except (ValueError, AttributeError):  # pragma: no cover - defensive
+        return 0
+
+
 class AzureRealtimeClient:
     def __init__(
         self,
@@ -123,9 +131,13 @@ class AzureRealtimeClient:
     async def _connect_and_listen(self) -> None:
         headers = {"api-key": self.api_key}
         logger.info("Connecting to Azure Realtime: %s", self.ws_url.split("?")[0])
+        # websockets>=13 names custom handshake headers ``additional_headers``; the
+        # 12.x asyncio client calls the same argument ``extra_headers``. Pick the one
+        # the installed version accepts so we work across both.
+        hdr_kw = "additional_headers" if _ws_major() >= 13 else "extra_headers"
         async with websockets.connect(
-            self.ws_url, additional_headers=headers, max_size=None,
-            ping_interval=20, ping_timeout=20,
+            self.ws_url, max_size=None, ping_interval=20, ping_timeout=20,
+            **{hdr_kw: headers},
         ) as ws:
             self._ws = ws
             logger.info("WebSocket connected; configuring session")

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -1,0 +1,249 @@
+"""Azure OpenAI Realtime client over WebSocket.
+
+Runs an asyncio event loop in its own thread and bridges to the (threaded) robot
+audio I/O:
+
+- ``send_audio_pcm16(bytes)``      push microphone audio to the model (thread-safe)
+- ``on_output_audio(bytes)``       callback invoked with model speech (PCM16)
+- ``on_speech_started()``          callback when the user starts talking (barge-in)
+- ``on_transcript(text, final)``   callback with the assistant transcript (for logs/UI)
+
+Audio is exchanged as 16-bit PCM mono at :data:`SAMPLE_RATE` Hz.
+
+The event schema differs slightly between the Azure Realtime GA and Preview
+protocols, so both variants of the relevant event names are handled.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import threading
+from collections.abc import Callable
+
+import websockets
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_RATE = 24000  # Azure Realtime PCM sample rate (in and out)
+
+
+class AzureRealtimeClient:
+    """Minimal, resilient Azure OpenAI Realtime WebSocket client."""
+
+    def __init__(
+        self,
+        ws_url: str,
+        api_key: str,
+        instructions: str,
+        voice: str,
+        turn_detection: dict,
+        greeting: str | None = None,
+        use_ga: bool = True,
+        on_output_audio: Callable[[bytes], None] | None = None,
+        on_speech_started: Callable[[], None] | None = None,
+        on_transcript: Callable[[str, bool], None] | None = None,
+        on_ready: Callable[[], None] | None = None,
+    ) -> None:
+        self.ws_url = ws_url
+        self.api_key = api_key
+        self.instructions = instructions
+        self.voice = voice
+        self.turn_detection = turn_detection
+        self.greeting = greeting
+        self.use_ga = use_ga
+
+        self.on_output_audio = on_output_audio
+        self.on_speech_started = on_speech_started
+        self.on_transcript = on_transcript
+        self.on_ready = on_ready
+
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._ws: websockets.WebSocketClientProtocol | None = None
+        self._stop = threading.Event()
+        self._ready = threading.Event()
+
+    # ------------------------------------------------------------------ lifecycle
+    def start(self) -> None:
+        """Start the client (connects in a background thread)."""
+        self._thread = threading.Thread(target=self._run, name="AzureRealtime", daemon=True)
+        self._thread.start()
+
+    def wait_ready(self, timeout: float = 20.0) -> bool:
+        """Block until the session is configured (or timeout)."""
+        return self._ready.wait(timeout)
+
+    def stop(self) -> None:
+        """Signal shutdown and close the socket."""
+        self._stop.set()
+        loop = self._loop
+        ws = self._ws
+        if loop and ws:
+            try:
+                asyncio.run_coroutine_threadsafe(ws.close(), loop)
+            except Exception:
+                pass
+
+    def join(self, timeout: float = 5.0) -> None:
+        if self._thread:
+            self._thread.join(timeout)
+
+    # ------------------------------------------------------------------ send API
+    def send_audio_pcm16(self, pcm16: bytes) -> None:
+        """Thread-safe: append a chunk of microphone PCM16 audio."""
+        if not pcm16 or self._ws is None or self._loop is None:
+            return
+        b64 = base64.b64encode(pcm16).decode("ascii")
+        msg = json.dumps({"type": "input_audio_buffer.append", "audio": b64})
+        try:
+            asyncio.run_coroutine_threadsafe(self._safe_send(msg), self._loop)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------ internals
+    def _run(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        try:
+            self._loop.run_until_complete(self._connect_and_listen())
+        except Exception as e:  # pragma: no cover - network runtime
+            logger.error("Azure Realtime loop crashed: %s", e, exc_info=True)
+        finally:
+            self._loop.close()
+
+    async def _safe_send(self, msg: str) -> None:
+        ws = self._ws
+        if ws is not None:
+            try:
+                await ws.send(msg)
+            except Exception as e:
+                logger.debug("send failed: %s", e)
+
+    async def _connect_and_listen(self) -> None:
+        # GA uses the api-key header; keep the same header for Preview too.
+        headers = {"api-key": self.api_key}
+        logger.info("Connecting to Azure Realtime: %s", self.ws_url.split("?")[0])
+        async with websockets.connect(
+            self.ws_url,
+            additional_headers=headers,
+            max_size=None,
+            ping_interval=20,
+            ping_timeout=20,
+        ) as ws:
+            self._ws = ws
+            logger.info("WebSocket connected; configuring session")
+            await ws.send(json.dumps(self._session_update_payload()))
+
+            async for raw in ws:
+                if self._stop.is_set():
+                    break
+                try:
+                    event = json.loads(raw)
+                except (ValueError, TypeError):
+                    continue
+                await self._handle_event(event)
+
+        self._ws = None
+        logger.info("WebSocket closed")
+
+    def _session_update_payload(self) -> dict:
+        """Build the ``session.update`` message (GA nested-audio shape)."""
+        if self.use_ga:
+            session = {
+                "type": "realtime",
+                "instructions": self.instructions,
+                "output_modalities": ["audio"],
+                "audio": {
+                    "input": {
+                        "format": {"type": "audio/pcm", "rate": SAMPLE_RATE},
+                        "turn_detection": self.turn_detection,
+                        "transcription": {"model": "whisper-1"},
+                        "noise_reduction": {"type": "near_field"},
+                    },
+                    "output": {
+                        "format": {"type": "audio/pcm", "rate": SAMPLE_RATE},
+                        "voice": self.voice,
+                    },
+                },
+            }
+        else:
+            # Preview (deprecated) flat shape.
+            session = {
+                "modalities": ["audio", "text"],
+                "instructions": self.instructions,
+                "voice": self.voice,
+                "input_audio_format": "pcm16",
+                "output_audio_format": "pcm16",
+                "input_audio_transcription": {"model": "whisper-1"},
+                "turn_detection": self.turn_detection,
+            }
+        return {"type": "session.update", "session": session}
+
+    async def _greet(self) -> None:
+        """Have the Maestro speak first."""
+        if not self.greeting:
+            instructions = "Saluta calorosamente e presentati brevemente, poi chiedi da cosa vuole partire."
+        else:
+            instructions = f"Di' esattamente, con calore: «{self.greeting}»"
+        await self._safe_send(json.dumps({"type": "response.create", "response": {"instructions": instructions}}))
+
+    async def _handle_event(self, event: dict) -> None:
+        etype = event.get("type", "")
+
+        if etype in ("session.created", "session.updated"):
+            if not self._ready.is_set():
+                self._ready.set()
+                if self.on_ready:
+                    _safe_cb(self.on_ready)
+                await self._greet()
+            return
+
+        # Assistant speech audio (GA + Preview event names).
+        if etype in ("response.output_audio.delta", "response.audio.delta"):
+            b64 = event.get("delta") or event.get("audio")
+            if b64 and self.on_output_audio:
+                try:
+                    _safe_cb(self.on_output_audio, base64.b64decode(b64))
+                except Exception:
+                    pass
+            return
+
+        # User started speaking -> barge-in / interrupt current playback.
+        if etype == "input_audio_buffer.speech_started":
+            if self.on_speech_started:
+                _safe_cb(self.on_speech_started)
+            return
+
+        # Assistant transcript (for logs / captions).
+        if etype in (
+            "response.output_audio_transcript.delta",
+            "response.audio_transcript.delta",
+        ):
+            delta = event.get("delta") or ""
+            if delta and self.on_transcript:
+                _safe_cb(self.on_transcript, delta, False)
+            return
+        if etype in (
+            "response.output_audio_transcript.done",
+            "response.audio_transcript.done",
+        ):
+            text = event.get("transcript") or ""
+            if text and self.on_transcript:
+                _safe_cb(self.on_transcript, text, True)
+            return
+
+        if etype == "error":
+            logger.error("Azure Realtime error event: %s", json.dumps(event.get("error", event)))
+            return
+
+        logger.debug("Unhandled event: %s", etype)
+
+
+def _safe_cb(cb: Callable, *args) -> None:
+    try:
+        cb(*args)
+    except Exception as e:  # pragma: no cover
+        logger.debug("callback error: %s", e)

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -1,9 +1,8 @@
 """Azure OpenAI Realtime client over WebSocket.
 
-Runs an asyncio event loop in its own thread and bridges to the (threaded) robot
-audio I/O: microphone PCM in, model speech + transcripts + tool calls out. Audio is
-16-bit PCM mono at :data:`SAMPLE_RATE` Hz. Both Realtime GA and Preview event names
-are handled. Message payloads are built in :mod:`rt_messages`.
+Runs an asyncio loop in its own thread and bridges the (threaded) robot audio I/O:
+microphone PCM in, model speech + transcripts + tool calls out. Audio is 16-bit PCM
+mono at :data:`SAMPLE_RATE` Hz. Payloads are built in :mod:`rt_messages`.
 """
 
 from __future__ import annotations
@@ -64,19 +63,17 @@ class AzureRealtimeClient:
         self._ws: websockets.WebSocketClientProtocol | None = None
         self._stop = threading.Event()
         self._ready = threading.Event()
+        self._responding = False  # a model response is currently streaming
+        self._suppress = False  # drop in-flight audio after a barge-in cancel
 
-    # ------------------------------------------------------------------ lifecycle
     def start(self) -> None:
-        """Start the client (connects in a background thread)."""
         self._thread = threading.Thread(target=self._run, name="AzureRealtime", daemon=True)
         self._thread.start()
 
     def wait_ready(self, timeout: float = 20.0) -> bool:
-        """Block until the session is configured (or timeout)."""
         return self._ready.wait(timeout)
 
     def stop(self) -> None:
-        """Signal shutdown and close the socket."""
         self._stop.set()
         loop = self._loop
         ws = self._ws
@@ -90,9 +87,7 @@ class AzureRealtimeClient:
         if self._thread:
             self._thread.join(timeout)
 
-    # ------------------------------------------------------------------ send API
     def send_audio_pcm16(self, pcm16: bytes) -> None:
-        """Thread-safe: append a chunk of microphone PCM16 audio."""
         if not pcm16 or self._ws is None or self._loop is None:
             return
         b64 = base64.b64encode(pcm16).decode("ascii")
@@ -102,13 +97,13 @@ class AzureRealtimeClient:
             pass
 
     def send_function_result(self, call_id: str, output: str, respond: bool = True) -> None:
-        """Thread-safe: answer a function call, then let the model continue speaking."""
+        """Answer a function call, then let the model continue speaking."""
         self._enqueue(json.dumps(rt_messages.function_call_output(call_id, output)))
         if respond:
             self._enqueue(json.dumps({"type": "response.create"}))
 
     def send_image(self, data_url: str, prompt: str) -> None:
-        """Thread-safe: hand the model a camera frame plus a question about it."""
+        """Hand the model a camera frame plus a question about it."""
         self._enqueue(json.dumps(rt_messages.image_message(data_url, prompt)))
         self._enqueue(json.dumps({"type": "response.create"}))
 
@@ -120,7 +115,6 @@ class AzureRealtimeClient:
         except Exception:
             pass
 
-    # ------------------------------------------------------------------ internals
     def _run(self) -> None:
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
@@ -140,7 +134,6 @@ class AzureRealtimeClient:
                 logger.debug("send failed: %s", e)
 
     async def _connect_and_listen(self) -> None:
-        # GA uses the api-key header; keep the same header for Preview too.
         headers = {"api-key": self.api_key}
         logger.info("Connecting to Azure Realtime: %s", self.ws_url.split("?")[0])
         async with websockets.connect(
@@ -171,10 +164,10 @@ class AzureRealtimeClient:
 
     async def _greet(self) -> None:
         """Have the Maestro speak first."""
-        if not self.greeting:
-            instructions = "Saluta calorosamente e presentati brevemente, poi chiedi da cosa vuole partire."
-        else:
-            instructions = f"Di' esattamente, con calore: «{self.greeting}»"
+        instructions = (
+            f"Di' esattamente, con calore: «{self.greeting}»" if self.greeting
+            else "Saluta calorosamente e presentati brevemente, poi chiedi da cosa vuole partire."
+        )
         await self._safe_send(json.dumps({"type": "response.create", "response": {"instructions": instructions}}))
 
     async def _handle_event(self, event: dict) -> None:
@@ -188,31 +181,38 @@ class AzureRealtimeClient:
                 await self._greet()
             return
 
-        # Assistant speech audio (GA + Preview event names).
         if etype in ("response.output_audio.delta", "response.audio.delta"):
+            if self._suppress:
+                return  # dropped: user barged in, this response is being cancelled
             b64 = event.get("delta") or event.get("audio")
             if b64 and self.on_output_audio:
                 _safe_cb(self.on_output_audio, base64.b64decode(b64))
             return
 
-        # User started speaking -> barge-in / interrupt current playback.
-        if etype == "input_audio_buffer.speech_started" and self.on_speech_started:
-            _safe_cb(self.on_speech_started)
+        if etype == "response.created":
+            self._responding = True
+            self._suppress = False
+            return
+        if etype == "response.done":
+            self._responding = False
             return
 
-        # Assistant transcript (for logs / captions).
-        if etype in ("response.output_audio_transcript.delta", "response.audio_transcript.delta"):
-            delta = event.get("delta") or ""
-            if delta and self.on_transcript:
-                _safe_cb(self.on_transcript, delta, False)
+        # User started speaking -> barge-in: cancel the model's turn server-side and
+        # suppress any audio still in flight, then stop local playback.
+        if etype == "input_audio_buffer.speech_started":
+            self._suppress = True
+            if self._responding:
+                await self._safe_send(json.dumps({"type": "response.cancel"}))
+            if self.on_speech_started:
+                _safe_cb(self.on_speech_started)
             return
+
         if etype in ("response.output_audio_transcript.done", "response.audio_transcript.done"):
             text = event.get("transcript") or ""
             if text and self.on_transcript:
                 _safe_cb(self.on_transcript, text, True)
             return
 
-        # Function call: capture the tool name when the item is announced.
         if etype == "response.output_item.added":
             item = event.get("item") or {}
             if item.get("type") == "function_call":

--- a/robot/reachy_mini_mirrorbuddy/camera.py
+++ b/robot/reachy_mini_mirrorbuddy/camera.py
@@ -1,0 +1,62 @@
+"""Camera helpers: capture a frame and query face detection.
+
+The robot exposes a JPEG frame via ``robot.media.get_frame_jpeg()`` and daemon-side
+face tracking via ``robot.get_tracked_face()`` / ``robot.start_head_tracking()``.
+
+Privacy: a frame is only ever captured on an explicit request (the ``look_at_homework``
+tool), never continuously, and nothing is persisted to disk.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def capture_data_url(robot) -> str | None:
+    """Capture one JPEG frame and return it as a ``data:`` URL (or None)."""
+    try:
+        jpeg = robot.media.get_frame_jpeg()
+    except Exception as e:
+        logger.warning("get_frame_jpeg failed: %s", e)
+        return None
+    if not jpeg:
+        logger.warning("camera returned no frame")
+        return None
+    b64 = base64.b64encode(jpeg).decode("ascii")
+    return f"data:image/jpeg;base64,{b64}"
+
+
+def face_detected(robot) -> bool:
+    """Return True if the daemon currently tracks a face."""
+    try:
+        face = robot.get_tracked_face(wait=False)
+        return bool(getattr(face, "detected", False))
+    except Exception:
+        return False
+
+
+def start_tracking(robot, weight: float = 1.0) -> None:
+    """Enable daemon-side head tracking so the robot follows the student's face."""
+    try:
+        robot.start_head_tracking(weight=weight)
+        logger.info("Head tracking enabled (weight=%s)", weight)
+    except Exception as e:
+        logger.warning("start_head_tracking failed: %s", e)
+
+
+def set_tracking_weight(robot, weight: float) -> None:
+    """Adjust tracking influence (0 = paused, 1 = full follow)."""
+    try:
+        robot.start_head_tracking(weight=weight)
+    except Exception as e:
+        logger.debug("set tracking weight failed: %s", e)
+
+
+def stop_tracking(robot) -> None:
+    try:
+        robot.stop_head_tracking()
+    except Exception:
+        pass

--- a/robot/reachy_mini_mirrorbuddy/camera.py
+++ b/robot/reachy_mini_mirrorbuddy/camera.py
@@ -11,8 +11,29 @@ from __future__ import annotations
 
 import base64
 import logging
+import os
 
 logger = logging.getLogger(__name__)
+
+
+def _jpeg_size(data: bytes) -> tuple[int, int] | None:
+    """Read (width, height) from a JPEG's SOF marker without any image library."""
+    try:
+        i, n = 2, len(data)
+        while i + 9 < n:
+            if data[i] != 0xFF:
+                i += 1
+                continue
+            marker = data[i + 1]
+            if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+                h = (data[i + 5] << 8) | data[i + 6]
+                w = (data[i + 7] << 8) | data[i + 8]
+                return w, h
+            seg = (data[i + 2] << 8) | data[i + 3]
+            i += 2 + seg
+    except Exception:
+        return None
+    return None
 
 
 def capture_data_url(robot) -> str | None:
@@ -25,6 +46,14 @@ def capture_data_url(robot) -> str | None:
     if not jpeg:
         logger.warning("camera returned no frame")
         return None
+    size = _jpeg_size(jpeg)
+    logger.info("Camera frame: %s bytes, resolution=%s", len(jpeg), size)
+    if os.getenv("MIRRORBUDDY_SAVE_FRAMES"):
+        try:
+            with open("/tmp/mb_frame.jpg", "wb") as fh:
+                fh.write(jpeg)
+        except Exception as e:
+            logger.debug("save frame failed: %s", e)
     b64 = base64.b64encode(jpeg).decode("ascii")
     return f"data:image/jpeg;base64,{b64}"
 

--- a/robot/reachy_mini_mirrorbuddy/config.py
+++ b/robot/reachy_mini_mirrorbuddy/config.py
@@ -1,0 +1,97 @@
+"""Configuration for the MirrorBuddy Reachy Mini app.
+
+All configuration is read from environment variables (optionally from an instance
+``.env`` file loaded by the host). Nothing sensitive is hard-coded.
+
+Required:
+    AZURE_OPENAI_REALTIME_ENDPOINT   e.g. https://<resource>.openai.azure.com/
+    AZURE_OPENAI_REALTIME_API_KEY    Azure OpenAI key (kept only in the robot .env)
+    AZURE_OPENAI_REALTIME_DEPLOYMENT realtime deployment name, e.g. gpt-realtime
+
+Optional:
+    AZURE_OPENAI_REALTIME_API_VERSION  if set -> use the Preview WS protocol; else GA
+    MIRRORBUDDY_URL                    default https://mirrorbuddy.org
+    MIRRORBUDDY_LOCALE                 default "it"
+    MIRRORBUDDY_MAESTRO_ID             which Maestro to embody (default: first Italian tutor)
+    MIRRORBUDDY_DSA_PROFILE            one of the DSA profiles (see dsa.py); default "cerebral"
+    MIRRORBUDDY_STUDENT_NAME           personalise the greeting (e.g. "Mario")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
+
+
+class Config:
+    """Runtime configuration loaded from environment / .env."""
+
+    def __init__(self) -> None:
+        load_dotenv()
+        self.reload()
+
+    def reload(self) -> None:
+        """(Re)read all values from the environment."""
+        load_dotenv(override=True)
+
+        # --- Azure OpenAI Realtime (the brain + voice) ---
+        endpoint = (os.getenv("AZURE_OPENAI_REALTIME_ENDPOINT") or "").strip()
+        self.AZURE_ENDPOINT: str = endpoint.rstrip("/")
+        self.AZURE_API_KEY: str | None = (os.getenv("AZURE_OPENAI_REALTIME_API_KEY") or "").strip() or None
+        self.AZURE_DEPLOYMENT: str = (os.getenv("AZURE_OPENAI_REALTIME_DEPLOYMENT") or "gpt-realtime").strip()
+        # When set, we speak the deprecated Preview protocol; otherwise the GA protocol.
+        self.AZURE_API_VERSION: str | None = (os.getenv("AZURE_OPENAI_REALTIME_API_VERSION") or "").strip() or None
+
+        # --- MirrorBuddy alignment ---
+        self.MIRRORBUDDY_URL: str = (os.getenv("MIRRORBUDDY_URL") or "https://mirrorbuddy.org").strip().rstrip("/")
+        self.LOCALE: str = (os.getenv("MIRRORBUDDY_LOCALE") or "it").strip()
+        self.MAESTRO_ID: str | None = (os.getenv("MIRRORBUDDY_MAESTRO_ID") or "").strip() or None
+        self.DSA_PROFILE: str = (os.getenv("MIRRORBUDDY_DSA_PROFILE") or "cerebral").strip()
+        self.STUDENT_NAME: str | None = (os.getenv("MIRRORBUDDY_STUDENT_NAME") or "").strip() or None
+
+        # --- feature toggles ---
+        self.ENABLE_CAMERA: bool = _flag("MIRRORBUDDY_ENABLE_CAMERA", True)
+        self.ENABLE_MOVEMENTS: bool = _flag("MIRRORBUDDY_ENABLE_MOVEMENTS", True)
+
+    def missing(self) -> list[str]:
+        """Return the list of required config values that are absent."""
+        errors: list[str] = []
+        if not self.AZURE_ENDPOINT:
+            errors.append("AZURE_OPENAI_REALTIME_ENDPOINT")
+        if not self.AZURE_API_KEY:
+            errors.append("AZURE_OPENAI_REALTIME_API_KEY")
+        if not self.AZURE_DEPLOYMENT:
+            errors.append("AZURE_OPENAI_REALTIME_DEPLOYMENT")
+        return errors
+
+    @property
+    def use_ga_protocol(self) -> bool:
+        """GA when no api-version is configured."""
+        return self.AZURE_API_VERSION is None
+
+    def realtime_ws_url(self) -> str:
+        """Build the Azure OpenAI Realtime WebSocket URL (GA or Preview)."""
+        host = self.AZURE_ENDPOINT.replace("https://", "").replace("http://", "").rstrip("/")
+        if self.use_ga_protocol:
+            # GA: resource endpoint directly, model = deployment name.
+            return f"wss://{host}/openai/v1/realtime?model={self.AZURE_DEPLOYMENT}"
+        # Preview (deprecated): api-version + deployment.
+        return (
+            f"wss://{host}/openai/realtime"
+            f"?api-version={self.AZURE_API_VERSION}&deployment={self.AZURE_DEPLOYMENT}"
+        )
+
+
+def _flag(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+# Global singleton, mirrors the pattern used by the other Reachy Mini apps.
+config = Config()

--- a/robot/reachy_mini_mirrorbuddy/config.py
+++ b/robot/reachy_mini_mirrorbuddy/config.py
@@ -31,12 +31,13 @@ class Config:
     """Runtime configuration loaded from environment / .env."""
 
     def __init__(self) -> None:
+        self.env_path: str | None = None
         load_dotenv()
         self.reload()
 
     def reload(self) -> None:
         """(Re)read all values from the environment."""
-        load_dotenv(override=True)
+        load_dotenv(self.env_path or None, override=True)
 
         # --- Azure OpenAI Realtime (the brain + voice) ---
         endpoint = (os.getenv("AZURE_OPENAI_REALTIME_ENDPOINT") or "").strip()

--- a/robot/reachy_mini_mirrorbuddy/config.py
+++ b/robot/reachy_mini_mirrorbuddy/config.py
@@ -52,11 +52,18 @@ class Config:
         self.MAESTRO_ID: str | None = (os.getenv("MIRRORBUDDY_MAESTRO_ID") or "").strip() or None
         self.DSA_PROFILE: str = (os.getenv("MIRRORBUDDY_DSA_PROFILE") or "cerebral").strip()
         self.STUDENT_NAME: str | None = (os.getenv("MIRRORBUDDY_STUDENT_NAME") or "").strip() or None
+        # Start neutrally as "Buddy" (organise the study session) instead of impersonating a
+        # historical Maestro. A pinned MIRRORBUDDY_MAESTRO_ID always takes precedence.
+        self.START_NEUTRAL: bool = _flag("MIRRORBUDDY_START_NEUTRAL", True)
+        self.BUDDY_VOICE: str = (os.getenv("MIRRORBUDDY_BUDDY_VOICE") or "coral").strip().lower()
 
         # --- feature toggles ---
         self.ENABLE_CAMERA: bool = _flag("MIRRORBUDDY_ENABLE_CAMERA", True)
         self.ENABLE_MOVEMENTS: bool = _flag("MIRRORBUDDY_ENABLE_MOVEMENTS", True)
         self.FOLLOW_FACE: bool = _flag("MIRRORBUDDY_FOLLOW_FACE", True)
+        # Calm motion (default): no audio head wobbler + gentler amplitudes, so the robot
+        # does not distract the student while speaking. Set to false for livelier motion.
+        self.CALM_MOVEMENT: bool = _flag("MIRRORBUDDY_CALM_MOVEMENT", True)
 
     def missing(self) -> list[str]:
         """Return the list of required config values that are absent."""

--- a/robot/reachy_mini_mirrorbuddy/config.py
+++ b/robot/reachy_mini_mirrorbuddy/config.py
@@ -56,6 +56,7 @@ class Config:
         # --- feature toggles ---
         self.ENABLE_CAMERA: bool = _flag("MIRRORBUDDY_ENABLE_CAMERA", True)
         self.ENABLE_MOVEMENTS: bool = _flag("MIRRORBUDDY_ENABLE_MOVEMENTS", True)
+        self.FOLLOW_FACE: bool = _flag("MIRRORBUDDY_FOLLOW_FACE", True)
 
     def missing(self) -> list[str]:
         """Return the list of required config values that are absent."""

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -1,0 +1,168 @@
+"""Orchestrates the live session: tool dispatch, professor switching and vision.
+
+The controller owns the current :class:`AzureRealtimeClient` and swaps it out when the
+student asks for another professor (a new voice + persona needs a fresh realtime
+session). It keeps ``main.py`` thin and holds all the voice-driven behaviour:
+
+- ``list_professors``   → speak the available Maestri.
+- ``call_professor``    → switch persona + voice live.
+- ``look_at_homework``  → capture one camera frame and let Buddy read it.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from . import camera, tools
+from .audio_io import AudioIO
+from .azure_realtime import AzureRealtimeClient
+from .config import Config
+from .dsa import turn_detection_config
+from .mirrorbuddy_client import Maestro
+from .movements import Movements, temperament_for
+from .prompt_builder import build_instructions
+
+logger = logging.getLogger(__name__)
+
+
+class Controller:
+    """Owns the realtime client and reacts to the model's tool calls."""
+
+    def __init__(
+        self,
+        robot,
+        cfg: Config,
+        maestri: list[Maestro],
+        maestro: Maestro,
+        audio: AudioIO,
+        movements: Movements,
+    ) -> None:
+        self.robot = robot
+        self.cfg = cfg
+        self.maestri = maestri
+        self.maestro = maestro
+        self.audio = audio
+        self.movements = movements
+        self._client: AzureRealtimeClient | None = None
+        self._switch_lock = threading.Lock()
+
+    # ------------------------------------------------------------------ lifecycle
+    def start(self) -> bool:
+        """Connect the first Maestro. Returns True once the session is ready."""
+        self._client = self._build_client(self.maestro)
+        self.audio.on_input_pcm16 = self._client.send_audio_pcm16
+        self._client.start()
+        ready = self._client.wait_ready(timeout=25.0)
+        if not ready:
+            logger.warning("Realtime session not confirmed ready; continuing anyway")
+        return ready
+
+    def is_alive(self) -> bool:
+        c = self._client
+        return bool(c and c._thread and c._thread.is_alive())
+
+    def stop(self) -> None:
+        c = self._client
+        if c:
+            c.stop()
+            c.join()
+
+    # ------------------------------------------------------------------ building
+    def _build_client(self, maestro: Maestro) -> AzureRealtimeClient:
+        instructions = build_instructions(
+            maestro,
+            locale=self.cfg.LOCALE,
+            dsa_profile=self.cfg.DSA_PROFILE,
+            student_name=self.cfg.STUDENT_NAME,
+        )
+        return AzureRealtimeClient(
+            ws_url=self.cfg.realtime_ws_url(),
+            api_key=self.cfg.AZURE_API_KEY or "",
+            instructions=instructions,
+            voice=maestro.voice,
+            turn_detection=turn_detection_config(self.cfg.DSA_PROFILE),
+            greeting=maestro.greeting or None,
+            use_ga=self.cfg.use_ga_protocol,
+            tools=tools.TOOL_SCHEMAS,
+            on_output_audio=self.audio.play,
+            on_speech_started=self.audio.interrupt,
+            on_transcript=_log_transcript,
+            on_tool_call=self._on_tool_call,
+        )
+
+    # ------------------------------------------------------------------ tools
+    def _on_tool_call(self, name: str, args: dict, call_id: str) -> None:
+        """Runs in the realtime client's thread — keep it quick; offload the switch."""
+        client = self._client
+        if client is None:
+            return
+        try:
+            if name == "list_professors":
+                client.send_function_result(call_id, tools.professors_summary(self.maestri))
+            elif name == "call_professor":
+                self._handle_call_professor(client, args, call_id)
+            elif name == "look_at_homework":
+                self._handle_look_at_homework(client, args, call_id)
+            else:
+                client.send_function_result(call_id, "Ok.")
+        except Exception as e:  # pragma: no cover - runtime robustness
+            logger.warning("tool %s failed: %s", name, e)
+            client.send_function_result(call_id, "Scusa, non ci sono riuscito.")
+
+    def _handle_call_professor(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
+        target = tools.resolve_maestro(self.maestri, str(args.get("query") or ""))
+        if target is None:
+            client.send_function_result(call_id, "Non ho trovato quel professore, puoi ripetere il nome o la materia?")
+            return
+        if target.id == self.maestro.id:
+            client.send_function_result(call_id, f"Sono gia' io, {self.maestro.display_name}. Andiamo avanti.")
+            return
+        # Acknowledge without a spoken reply here; the new Maestro will greet.
+        client.send_function_result(call_id, f"Passo la parola a {target.display_name}.", respond=False)
+        threading.Thread(target=self._switch_to, args=(target,), name="MaestroSwitch", daemon=True).start()
+
+    def _handle_look_at_homework(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
+        if not self.cfg.ENABLE_CAMERA:
+            client.send_function_result(call_id, "La telecamera e' spenta nelle impostazioni, non posso guardare.")
+            return
+        data_url = camera.capture_data_url(self.robot)
+        if not data_url:
+            client.send_function_result(call_id, "Non riesco a vedere bene, avvicina il foglio e riproviamo.")
+            return
+        question = str(args.get("question") or "").strip() or (
+            "Guarda la foto del compito dello studente, leggi cosa c'e' scritto e aiutalo passo passo, "
+            "senza dare la risposta pronta."
+        )
+        # Privacy: announce we are looking, then hand the frame to the model.
+        client.send_function_result(call_id, "Sto guardando il tuo compito un momento.", respond=False)
+        client.send_image(data_url, question)
+
+    # ------------------------------------------------------------------ switching
+    def _switch_to(self, target: Maestro) -> None:
+        """Reconnect the realtime session with a new persona and voice."""
+        with self._switch_lock:
+            old = self._client
+            self.audio.interrupt()
+            self.movements.set_temperament(
+                temperament_for(target.subject, target.teaching_style, target.voice_instructions)
+            )
+            new = self._build_client(target)
+            new.start()
+            if not new.wait_ready(timeout=25.0):
+                logger.warning("New Maestro session not ready; keeping the previous one")
+                new.stop()
+                new.join()
+                return
+            self.audio.on_input_pcm16 = new.send_audio_pcm16
+            self._client = new
+            self.maestro = target
+            if old:
+                old.stop()
+                old.join()
+            logger.info("Switched to Maestro %s (%s), voice=%s", target.display_name, target.id, target.voice)
+
+
+def _log_transcript(text: str, final: bool) -> None:
+    if final:
+        logger.info("Buddy: %s", text)

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -126,7 +126,15 @@ class Controller:
         if not self.cfg.ENABLE_CAMERA:
             client.send_function_result(call_id, "La telecamera e' spenta nelle impostazioni, non posso guardare.")
             return
-        data_url = camera.capture_data_url(self.robot)
+        # Offload: freezing the head to get a sharp frame takes ~1s; never block the ws loop.
+        threading.Thread(target=self._capture_homework, args=(client, args, call_id), daemon=True).start()
+
+    def _capture_homework(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
+        self.movements.hold_still()
+        try:
+            data_url = camera.capture_data_url(self.robot)
+        finally:
+            self.movements.release_hold()
         if not data_url:
             client.send_function_result(call_id, "Non riesco a vedere bene, avvicina il foglio e riproviamo.")
             return
@@ -134,8 +142,8 @@ class Controller:
             "Guarda la foto del compito dello studente, leggi cosa c'e' scritto e aiutalo passo passo, "
             "senza dare la risposta pronta."
         )
-        # Privacy: announce we are looking, then hand the frame to the model.
-        client.send_function_result(call_id, "Sto guardando il tuo compito un momento.", respond=False)
+        # Privacy: we already announced verbally; hand the still frame to the model.
+        client.send_function_result(call_id, "Ho guardato il tuo compito.", respond=False)
         client.send_image(data_url, question)
 
     # ------------------------------------------------------------------ switching

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -139,8 +139,9 @@ class Controller:
             client.send_function_result(call_id, "Non riesco a vedere bene, avvicina il foglio e riproviamo.")
             return
         question = str(args.get("question") or "").strip() or (
-            "Guarda la foto del compito dello studente, leggi cosa c'e' scritto e aiutalo passo passo, "
-            "senza dare la risposta pronta."
+            "Guarda la foto: puo' essere un compito, la pagina di un quaderno o di un libro, "
+            "o lo schermo. Leggi cosa c'e' scritto e aiuta lo studente passo passo, senza dare "
+            "la risposta pronta."
         )
         # Privacy: we already announced verbally; hand the still frame to the model.
         client.send_function_result(call_id, "Ho guardato il tuo compito.", respond=False)

--- a/robot/reachy_mini_mirrorbuddy/dsa.py
+++ b/robot/reachy_mini_mirrorbuddy/dsa.py
@@ -1,0 +1,57 @@
+"""DSA / accessibility tuning for the realtime turn-detection (VAD).
+
+Mirrors MirrorBuddy's adaptive-VAD idea: different learners need the robot to wait
+differently before it decides the child has finished speaking. Students with slower
+or less regular speech (motor / cerebral palsy, dyslexia) need a longer silence
+window so the robot does not interrupt them.
+
+These values feed the Azure OpenAI Realtime ``turn_detection`` (server VAD) config.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class VadProfile:
+    """server_vad parameters for a given accessibility profile."""
+
+    threshold: float
+    prefix_padding_ms: int
+    silence_duration_ms: int
+    # Azure noise reduction: "near_field" | "far_field" | None
+    noise_reduction: str | None = "near_field"
+
+
+# Longer silence windows = more patient robot (won't cut the child off).
+_PROFILES: dict[str, VadProfile] = {
+    "default": VadProfile(0.5, 300, 700),
+    "dyslexia": VadProfile(0.45, 400, 1100),
+    "adhd": VadProfile(0.55, 250, 600),
+    "autism": VadProfile(0.5, 400, 1200),
+    "motor": VadProfile(0.4, 500, 1500),
+    "cerebral": VadProfile(0.4, 500, 1600),
+    "visual": VadProfile(0.5, 300, 900),
+    "auditory": VadProfile(0.5, 300, 900),
+}
+
+
+def get_vad_profile(name: str | None) -> VadProfile:
+    """Return the VAD profile for ``name`` (falls back to a patient default)."""
+    if not name:
+        return _PROFILES["default"]
+    return _PROFILES.get(name.strip().lower(), _PROFILES["default"])
+
+
+def turn_detection_config(name: str | None) -> dict:
+    """Build the realtime ``turn_detection`` object for the given profile."""
+    p = get_vad_profile(name)
+    return {
+        "type": "server_vad",
+        "threshold": p.threshold,
+        "prefix_padding_ms": p.prefix_padding_ms,
+        "silence_duration_ms": p.silence_duration_ms,
+        "create_response": True,
+        "interrupt_response": True,
+    }

--- a/robot/reachy_mini_mirrorbuddy/dsa.py
+++ b/robot/reachy_mini_mirrorbuddy/dsa.py
@@ -24,16 +24,18 @@ class VadProfile:
     noise_reduction: str | None = "near_field"
 
 
-# Longer silence windows = more patient robot (won't cut the child off).
+# Snappier turn-taking (Roberto: "più veloce, in tempo reale") while still giving
+# slower/less-regular speakers enough room not to be cut off. Silence windows are
+# roughly half the earlier, very-patient values.
 _PROFILES: dict[str, VadProfile] = {
-    "default": VadProfile(0.5, 300, 700),
-    "dyslexia": VadProfile(0.45, 400, 1100),
-    "adhd": VadProfile(0.55, 250, 600),
-    "autism": VadProfile(0.5, 400, 1200),
-    "motor": VadProfile(0.4, 500, 1500),
-    "cerebral": VadProfile(0.4, 500, 1600),
-    "visual": VadProfile(0.5, 300, 900),
-    "auditory": VadProfile(0.5, 300, 900),
+    "default": VadProfile(0.5, 200, 450),
+    "dyslexia": VadProfile(0.45, 250, 650),
+    "adhd": VadProfile(0.55, 150, 400),
+    "autism": VadProfile(0.5, 250, 700),
+    "motor": VadProfile(0.4, 300, 800),
+    "cerebral": VadProfile(0.4, 300, 800),
+    "visual": VadProfile(0.5, 200, 550),
+    "auditory": VadProfile(0.5, 200, 550),
 }
 
 

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -22,7 +22,7 @@ from .audio_io import AudioIO
 from .config import config
 from .dsa import turn_detection_config
 from .mirrorbuddy_client import MirrorBuddyClient
-from .movements import Movements
+from .movements import Movements, temperament_for
 from .prompt_builder import build_instructions
 
 logger = logging.getLogger(__name__)
@@ -109,7 +109,8 @@ def run(
         robot = ReachyMini(**({"robot_name": args.robot_name} if args.robot_name else {}))
 
     # --- assemble the pipeline -------------------------------------------------
-    movements = Movements(robot, enabled=config.ENABLE_MOVEMENTS)
+    temperament = temperament_for(maestro.subject, maestro.teaching_style, maestro.voice_instructions)
+    movements = Movements(robot, enabled=config.ENABLE_MOVEMENTS, temperament=temperament)
 
     audio = AudioIO(robot, on_input_pcm16=lambda b: None, movements=movements)
 

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -1,0 +1,203 @@
+"""Entry point for the MirrorBuddy Reachy Mini app.
+
+Wires together:
+    MirrorBuddy Maestro (persona)  ->  instructions
+    Azure OpenAI Realtime          <->  robot microphone / speaker
+    speech energy                  ->  expressive antenna movement
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import threading
+import time
+from pathlib import Path
+
+from reachy_mini import ReachyMini, ReachyMiniApp
+
+from .azure_realtime import AzureRealtimeClient
+from .audio_io import AudioIO
+from .config import config
+from .dsa import turn_detection_config
+from .mirrorbuddy_client import MirrorBuddyClient
+from .movements import Movements
+from .prompt_builder import build_instructions
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="MirrorBuddy on Reachy Mini")
+    parser.add_argument("--debug", action="store_true", help="Verbose logging")
+    parser.add_argument("--no-camera", action="store_true", help="Disable the camera")
+    parser.add_argument("--robot-name", default=None, help="Robot name for the SDK")
+    args, _ = parser.parse_known_args()
+    return args
+
+
+def _setup_logging(debug: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if debug else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s | %(message)s",
+    )
+
+
+def run(
+    args: argparse.Namespace,
+    robot: ReachyMini | None = None,
+    app_stop_event: threading.Event | None = None,
+    settings_app=None,
+    instance_path: str | None = None,
+) -> None:
+    _setup_logging(args.debug)
+    logger.info("Starting MirrorBuddy Reachy Mini app")
+
+    # Load instance .env (Azure creds + MirrorBuddy config live here on the robot).
+    if instance_path:
+        env_path = Path(instance_path) / ".env"
+        if env_path.exists():
+            from dotenv import load_dotenv
+
+            load_dotenv(dotenv_path=str(env_path), override=True)
+            config.reload()
+
+    # Optional in-app settings UI (lets you pick the Maestro / enter creds).
+    if settings_app is not None:
+        try:
+            from .settings_ui import mount_settings_routes
+
+            mount_settings_routes(settings_app, instance_path)
+        except Exception as e:
+            logger.warning("Failed to mount settings UI: %s", e)
+
+    # Wait for required configuration (Azure creds) if a settings UI is available.
+    missing = config.missing()
+    if missing:
+        if settings_app is not None:
+            logger.info("Waiting for configuration via settings UI: %s", ", ".join(missing))
+            while config.missing():
+                time.sleep(0.5)
+                config.reload()
+        else:
+            logger.error("Missing required configuration: %s", ", ".join(missing))
+            sys.exit(1)
+
+    # Fetch the Maestro persona live from MirrorBuddy.
+    mb = MirrorBuddyClient(config.MIRRORBUDDY_URL, locale=config.LOCALE)
+    try:
+        maestri = mb.fetch_maestri()
+        maestro = mb.pick(maestri, config.MAESTRO_ID)
+    except Exception as e:
+        logger.error("Could not load Maestri from MirrorBuddy (%s): %s", config.MIRRORBUDDY_URL, e)
+        sys.exit(1)
+    logger.info("Embodying Maestro: %s (%s), voice=%s", maestro.display_name, maestro.id, maestro.voice)
+
+    instructions = build_instructions(
+        maestro,
+        locale=config.LOCALE,
+        dsa_profile=config.DSA_PROFILE,
+        student_name=config.STUDENT_NAME,
+    )
+
+    # Initialize the robot if the host didn't hand us one.
+    if robot is None:
+        robot = ReachyMini(**({"robot_name": args.robot_name} if args.robot_name else {}))
+
+    # --- assemble the pipeline -------------------------------------------------
+    movements = Movements(robot, enabled=config.ENABLE_MOVEMENTS)
+
+    audio = AudioIO(robot, on_input_pcm16=lambda b: None, movements=movements)
+
+    client = AzureRealtimeClient(
+        ws_url=config.realtime_ws_url(),
+        api_key=config.AZURE_API_KEY or "",
+        instructions=instructions,
+        voice=maestro.voice,
+        turn_detection=turn_detection_config(config.DSA_PROFILE),
+        greeting=maestro.greeting or None,
+        use_ga=config.use_ga_protocol,
+        on_output_audio=audio.play,
+        on_speech_started=audio.interrupt,
+        on_transcript=_log_transcript,
+    )
+    # Now that the client exists, route microphone audio into it.
+    audio.on_input_pcm16 = client.send_audio_pcm16
+
+    # Graceful shutdown on the host stop event.
+    def _watch_stop() -> None:
+        if app_stop_event is not None:
+            app_stop_event.wait()
+            logger.info("Stop event received; shutting down")
+            client.stop()
+
+    if app_stop_event is not None:
+        threading.Thread(target=_watch_stop, daemon=True).start()
+
+    movements.start()
+    client.start()
+    if not client.wait_ready(timeout=25.0):
+        logger.warning("Realtime session not confirmed ready; continuing anyway")
+    audio.start()
+    logger.info("MirrorBuddy is live 🎙️  — say something!")
+
+    try:
+        # Block until the realtime client thread ends (stop or disconnect).
+        while client._thread and client._thread.is_alive():
+            if app_stop_event is not None and app_stop_event.is_set():
+                break
+            time.sleep(0.2)
+    except KeyboardInterrupt:
+        logger.info("Interrupted")
+    finally:
+        logger.info("Cleaning up...")
+        audio.stop()
+        client.stop()
+        client.join()
+        movements.stop()
+        try:
+            robot.media.close()
+        except Exception:
+            pass
+        try:
+            robot.client.disconnect()
+        except Exception:
+            pass
+        logger.info("Shutdown complete")
+
+
+def _log_transcript(text: str, final: bool) -> None:
+    if final:
+        logger.info("Buddy: %s", text)
+
+
+def main() -> None:
+    """Console-script entry point."""
+    run(parse_args())
+
+
+class ReachyMiniMirrorBuddy(ReachyMiniApp):  # type: ignore[misc]
+    """Reachy Mini app: MirrorBuddy with a body."""
+
+    description = "MirrorBuddy on Reachy Mini — a MirrorBuddy Maestro with eyes, ears, mouth and movements."
+    custom_app_url = "http://0.0.0.0:7862/"
+    dont_start_webserver = False
+
+    def run(self, reachy_mini: ReachyMini, stop_event: threading.Event) -> None:
+        instance_path = self._get_instance_path().parent
+        run(
+            parse_args(),
+            robot=reachy_mini,
+            app_stop_event=stop_event,
+            settings_app=self.settings_app,
+            instance_path=str(instance_path),
+        )
+
+
+if __name__ == "__main__":
+    app = ReachyMiniMirrorBuddy()
+    try:
+        app.wrapped_run()
+    except KeyboardInterrupt:
+        app.stop()

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -17,13 +17,11 @@ from pathlib import Path
 
 from reachy_mini import ReachyMini, ReachyMiniApp
 
-from .azure_realtime import AzureRealtimeClient
 from .audio_io import AudioIO
 from .config import config
-from .dsa import turn_detection_config
+from .controller import Controller
 from .mirrorbuddy_client import MirrorBuddyClient
 from .movements import Movements, temperament_for
-from .prompt_builder import build_instructions
 
 logger = logging.getLogger(__name__)
 
@@ -94,13 +92,6 @@ def run(
         sys.exit(1)
     logger.info("Embodying Maestro: %s (%s), voice=%s", maestro.display_name, maestro.id, maestro.voice)
 
-    instructions = build_instructions(
-        maestro,
-        locale=config.LOCALE,
-        dsa_profile=config.DSA_PROFILE,
-        student_name=config.STUDENT_NAME,
-    )
-
     # Initialize the robot if the host didn't hand us one. When the Reachy Mini host
     # launches the app it opens (and will close) the robot for us, so only tear it
     # down here if we created it.
@@ -109,47 +100,33 @@ def run(
         robot = ReachyMini(**({"robot_name": args.robot_name} if args.robot_name else {}))
 
     # --- assemble the pipeline -------------------------------------------------
+    follow_face = config.FOLLOW_FACE and config.ENABLE_CAMERA and not args.no_camera
     temperament = temperament_for(maestro.subject, maestro.teaching_style, maestro.voice_instructions)
-    movements = Movements(robot, enabled=config.ENABLE_MOVEMENTS, temperament=temperament)
+    movements = Movements(robot, enabled=config.ENABLE_MOVEMENTS, temperament=temperament, follow_face=follow_face)
 
     audio = AudioIO(robot, on_input_pcm16=lambda b: None, movements=movements)
 
-    client = AzureRealtimeClient(
-        ws_url=config.realtime_ws_url(),
-        api_key=config.AZURE_API_KEY or "",
-        instructions=instructions,
-        voice=maestro.voice,
-        turn_detection=turn_detection_config(config.DSA_PROFILE),
-        greeting=maestro.greeting or None,
-        use_ga=config.use_ga_protocol,
-        on_output_audio=audio.play,
-        on_speech_started=audio.interrupt,
-        on_transcript=_log_transcript,
-    )
-    # Now that the client exists, route microphone audio into it.
-    audio.on_input_pcm16 = client.send_audio_pcm16
+    controller = Controller(robot, config, maestri, maestro, audio, movements)
 
     # Graceful shutdown on the host stop event.
     def _watch_stop() -> None:
         if app_stop_event is not None:
             app_stop_event.wait()
             logger.info("Stop event received; shutting down")
-            client.stop()
+            controller.stop()
 
     if app_stop_event is not None:
         threading.Thread(target=_watch_stop, daemon=True).start()
 
     movements.start()
     movements.wake()
-    client.start()
-    if not client.wait_ready(timeout=25.0):
-        logger.warning("Realtime session not confirmed ready; continuing anyway")
+    controller.start()
     audio.start()
     logger.info("MirrorBuddy is live 🎙️  — say something!")
 
     try:
         # Block until the realtime client thread ends (stop or disconnect).
-        while client._thread and client._thread.is_alive():
+        while controller.is_alive():
             if app_stop_event is not None and app_stop_event.is_set():
                 break
             time.sleep(0.2)
@@ -158,8 +135,7 @@ def run(
     finally:
         logger.info("Cleaning up...")
         audio.stop()
-        client.stop()
-        client.join()
+        controller.stop()
         movements.stop()
         if owns_robot:
             try:
@@ -171,11 +147,6 @@ def run(
             except Exception:
                 pass
         logger.info("Shutdown complete")
-
-
-def _log_transcript(text: str, final: bool) -> None:
-    if final:
-        logger.info("Buddy: %s", text)
 
 
 def main() -> None:

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -20,7 +20,7 @@ from reachy_mini import ReachyMini, ReachyMiniApp
 from .audio_io import AudioIO
 from .config import config
 from .controller import Controller
-from .mirrorbuddy_client import MirrorBuddyClient
+from .mirrorbuddy_client import MirrorBuddyClient, neutral_buddy
 from .movements import Movements, temperament_for
 
 logger = logging.getLogger(__name__)
@@ -86,7 +86,12 @@ def run(
     mb = MirrorBuddyClient(config.MIRRORBUDDY_URL, locale=config.LOCALE)
     try:
         maestri = mb.fetch_maestri()
-        maestro = mb.pick(maestri, config.MAESTRO_ID)
+        if config.MAESTRO_ID:
+            maestro = mb.pick(maestri, config.MAESTRO_ID)  # profile pinned this Maestro
+        elif config.START_NEUTRAL:
+            maestro = neutral_buddy(config.STUDENT_NAME, config.BUDDY_VOICE)  # neutral organiser
+        else:
+            maestro = mb.pick(maestri, None)
     except Exception as e:
         logger.error("Could not load Maestri from MirrorBuddy (%s): %s", config.MIRRORBUDDY_URL, e)
         sys.exit(1)
@@ -102,7 +107,8 @@ def run(
     # --- assemble the pipeline -------------------------------------------------
     follow_face = config.FOLLOW_FACE and config.ENABLE_CAMERA and not args.no_camera
     temperament = temperament_for(maestro.subject, maestro.teaching_style, maestro.voice_instructions)
-    movements = Movements(robot, enabled=config.ENABLE_MOVEMENTS, temperament=temperament, follow_face=follow_face)
+    movements = Movements(robot, enabled=config.ENABLE_MOVEMENTS, temperament=temperament,
+                          follow_face=follow_face, calm=config.CALM_MOVEMENT)
 
     audio = AudioIO(robot, on_input_pcm16=lambda b: None, movements=movements)
 

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -140,6 +140,7 @@ def run(
         threading.Thread(target=_watch_stop, daemon=True).start()
 
     movements.start()
+    movements.wake()
     client.start()
     if not client.wait_ready(timeout=25.0):
         logger.warning("Realtime session not confirmed ready; continuing anyway")

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -101,7 +101,10 @@ def run(
         student_name=config.STUDENT_NAME,
     )
 
-    # Initialize the robot if the host didn't hand us one.
+    # Initialize the robot if the host didn't hand us one. When the Reachy Mini host
+    # launches the app it opens (and will close) the robot for us, so only tear it
+    # down here if we created it.
+    owns_robot = robot is None
     if robot is None:
         robot = ReachyMini(**({"robot_name": args.robot_name} if args.robot_name else {}))
 
@@ -156,14 +159,15 @@ def run(
         client.stop()
         client.join()
         movements.stop()
-        try:
-            robot.media.close()
-        except Exception:
-            pass
-        try:
-            robot.client.disconnect()
-        except Exception:
-            pass
+        if owns_robot:
+            try:
+                robot.media.close()
+            except Exception:
+                pass
+            try:
+                robot.client.disconnect()
+            except Exception:
+                pass
         logger.info("Shutdown complete")
 
 

--- a/robot/reachy_mini_mirrorbuddy/mirrorbuddy_client.py
+++ b/robot/reachy_mini_mirrorbuddy/mirrorbuddy_client.py
@@ -1,0 +1,101 @@
+"""Fetch MirrorBuddy Maestri (personas) live from the MirrorBuddy backend.
+
+MirrorBuddy exposes an unauthenticated JSON endpoint ``GET /api/maestri?locale=it``
+that returns the same Maestro data the web app uses. By fetching it here we keep the
+robot fully aligned with MirrorBuddy: the exact same 26 professors, voices, system
+prompts and greetings, with zero duplication.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# The 8 Azure OpenAI Realtime voices MirrorBuddy uses.
+VALID_VOICES = {"alloy", "ash", "ballad", "coral", "echo", "sage", "shimmer", "verse"}
+DEFAULT_VOICE = "coral"
+
+
+@dataclass
+class Maestro:
+    """A MirrorBuddy professor persona (subset of fields we need on the robot)."""
+
+    id: str
+    name: str
+    display_name: str
+    subject: str
+    specialty: str
+    voice: str
+    voice_instructions: str
+    teaching_style: str
+    system_prompt: str
+    greeting: str
+
+    @classmethod
+    def from_json(cls, d: dict[str, Any]) -> "Maestro":
+        voice = str(d.get("voice") or "").strip().lower()
+        if voice not in VALID_VOICES:
+            logger.warning("Maestro %s has unknown voice %r; falling back to %s", d.get("id"), voice, DEFAULT_VOICE)
+            voice = DEFAULT_VOICE
+        return cls(
+            id=str(d.get("id") or ""),
+            name=str(d.get("name") or ""),
+            display_name=str(d.get("displayName") or d.get("name") or ""),
+            subject=str(d.get("subject") or ""),
+            specialty=str(d.get("specialty") or ""),
+            voice=voice,
+            voice_instructions=str(d.get("voiceInstructions") or ""),
+            teaching_style=str(d.get("teachingStyle") or ""),
+            system_prompt=str(d.get("systemPrompt") or ""),
+            greeting=str(d.get("greeting") or ""),
+        )
+
+
+class MirrorBuddyClient:
+    """Thin client over the MirrorBuddy public API."""
+
+    def __init__(self, base_url: str, locale: str = "it", timeout: float = 15.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.locale = locale
+        self.timeout = timeout
+
+    def fetch_maestri(self) -> list[Maestro]:
+        """Return all Maestri for the configured locale."""
+        url = f"{self.base_url}/api/maestri?locale={self.locale}"
+        logger.info("Fetching Maestri from %s", url)
+        resp = httpx.get(url, timeout=self.timeout, headers={"accept": "application/json"})
+        resp.raise_for_status()
+        data = resp.json()
+        # The endpoint may return a bare list or an object wrapping it.
+        items = data if isinstance(data, list) else data.get("maestri") or data.get("data") or []
+        maestri = [Maestro.from_json(it) for it in items if isinstance(it, dict)]
+        logger.info("Fetched %d Maestri", len(maestri))
+        return maestri
+
+    def pick(self, maestri: list[Maestro], maestro_id: str | None) -> Maestro:
+        """Choose the Maestro to embody.
+
+        Preference order:
+        1. Explicit ``maestro_id`` if it matches.
+        2. An Italian-language / literature tutor (good calm default for homework).
+        3. The first Maestro returned.
+        """
+        if not maestri:
+            raise RuntimeError("MirrorBuddy returned no Maestri")
+
+        if maestro_id:
+            for m in maestri:
+                if m.id == maestro_id:
+                    return m
+            logger.warning("Maestro id %r not found; using a sensible default", maestro_id)
+
+        for m in maestri:
+            if m.subject.lower() in ("italian", "italiano", "storytelling"):
+                return m
+
+        return maestri[0]

--- a/robot/reachy_mini_mirrorbuddy/mirrorbuddy_client.py
+++ b/robot/reachy_mini_mirrorbuddy/mirrorbuddy_client.py
@@ -99,3 +99,43 @@ class MirrorBuddyClient:
                 return m
 
         return maestri[0]
+
+
+def neutral_buddy(student_name: str | None = None, voice: str = DEFAULT_VOICE) -> Maestro:
+    """A neutral MirrorBuddy tutor used at start-up.
+
+    It does not impersonate a historical figure: it greets warmly, helps the student
+    plan the study session, then hands over to the right subject professor via the
+    ``call_professor`` tool. This is the default entry point on the child's device.
+    """
+    v = voice.strip().lower() if voice else DEFAULT_VOICE
+    if v not in VALID_VOICES:
+        v = DEFAULT_VOICE
+    name = (student_name or "").strip()
+    hello = f"Ciao {name}! " if name else "Ciao! "
+    greeting = (
+        f"{hello}Sono Buddy, il tuo tutor. Da cosa vuoi partire oggi? "
+        "Dimmi che compiti o materie hai e organizziamo insieme lo studio, un passo alla volta."
+    )
+    system_prompt = (
+        "Sei Buddy, il tutor personale di MirrorBuddy. NON sei un personaggio storico e non "
+        "interpreti nessuno: sei semplicemente Buddy, caldo, semplice e incoraggiante. "
+        "Il tuo primo compito e' aiutare lo studente a ORGANIZZARE la sessione di studio: "
+        "chiedi con calma cosa deve fare oggi, quali materie e quali compiti, e proponi un "
+        "piccolo piano concreto (una cosa alla volta, senza fretta). Quando si entra davvero "
+        "in una materia o lo studente chiede un professore, usa lo strumento 'call_professor' "
+        "per chiamare il Maestro giusto. Resta neutro e rassicurante, non fare lezione tu stesso "
+        "all'inizio: prima si organizza, poi si studia."
+    )
+    return Maestro(
+        id="buddy",
+        name="Buddy",
+        display_name="Buddy",
+        subject="",
+        specialty="organizzazione dello studio",
+        voice=v,
+        voice_instructions="Voce calda, calma e incoraggiante; ritmo tranquillo.",
+        teaching_style="organizzatore, paziente, incoraggiante",
+        system_prompt=system_prompt,
+        greeting=greeting,
+    )

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -1,10 +1,9 @@
 """Expressive full-body movement for MirrorBuddy.
 
-Layers (from the proven Reachy Mini conversation app): the daemon audio wobbler moves
-the head while Buddy talks; a living idle drives antennas + body (and head when not
-face-following); and while listening the head tracks the student's face. Intensity is
-scaled by a per-Maestro **temperament**. ``hold_still`` freezes everything so the camera
-can grab a sharp homework frame.
+A living idle drives antennas + body (and head when not face-following); while listening
+the head tracks the student's face. In *calm* mode the audio wobbler stays off and
+amplitudes are gentle. Intensity is scaled by a per-Maestro **temperament**.
+``hold_still`` freezes everything so the camera can grab a sharp homework frame.
 """
 
 from __future__ import annotations
@@ -55,11 +54,13 @@ def temperament_for(subject: str = "", teaching_style: str = "", voice_instructi
 class Movements:
     """Background full-body animation driven by speech energy + idle liveliness."""
 
-    def __init__(self, robot, enabled: bool = True, temperament: Temperament = NEUTRAL, follow_face: bool = True) -> None:
+    def __init__(self, robot, enabled: bool = True, temperament: Temperament = NEUTRAL,
+                 follow_face: bool = True, calm: bool = True) -> None:
         self.robot = robot
         self.enabled = enabled
         self.temp = temperament
         self.follow_face = follow_face
+        self.calm = calm  # calm: no audio wobbler, gentler amplitudes, softer face-follow
         self._energy = 0.0
         self._lock = threading.Lock()
         self._stop = threading.Event()
@@ -87,10 +88,11 @@ class Movements:
         """Resume normal motion after a camera capture."""
         if not self._hold.is_set():
             return
-        try:
-            self.robot.enable_wobbling()
-        except Exception:
-            pass
+        if not self.calm:
+            try:
+                self.robot.enable_wobbling()
+            except Exception:
+                pass
         if self.follow_face:
             camera.set_tracking_weight(self.robot, 1.0)
             self._track_weight = 1.0
@@ -114,13 +116,14 @@ class Movements:
             self.robot.enable_motors()
         except Exception as e:
             logger.debug("enable_motors not available/failed: %s", e)
-        # Daemon-driven, speech-reactive head motion (real-time lip-sync).
-        try:
-            self.robot.enable_wobbling()
-            logger.info("Audio wobbler enabled (speech-reactive head motion)")
-        except Exception as e:
-            logger.warning("enable_wobbling failed: %s", e)
-        # Daemon-driven face tracking: the head follows the student's face.
+        # Speech-reactive head wobbler. In calm mode we keep it OFF so the head does not
+        # jitter while talking (less distracting for the student).
+        if not self.calm:
+            try:
+                self.robot.enable_wobbling()
+                logger.info("Audio wobbler enabled (speech-reactive head motion)")
+            except Exception as e:
+                logger.warning("enable_wobbling failed: %s", e)
         if self.follow_face:
             camera.start_tracking(self.robot, 1.0)
             self._track_weight = 1.0
@@ -181,20 +184,19 @@ class Movements:
             with self._lock:
                 energy = self._energy
                 self._energy *= 0.9
-                s = self.temp.scale
+                s = self.temp.scale * (0.55 if self.calm else 1.0)
                 w = self.temp.speed
 
             speaking = energy > 0.06
 
-            # Face-follow handoff: hand the head to the wobbler while speaking (weight 0),
-            # track the student while listening (weight 1).
+            # Face-follow: while speaking keep a gentle track (calm) or hand off to the
+            # wobbler (0); while listening, full tracking (1).
             if self.follow_face:
-                target_weight = 0.0 if speaking else 1.0
+                target_weight = (0.5 if self.calm else 0.0) if speaking else 1.0
                 if target_weight != self._track_weight:
                     camera.set_tracking_weight(self.robot, target_weight)
                     self._track_weight = target_weight
 
-            # Base head pose: breathing + idle drift (amplitudes deliberately visible).
             z = 0.010 * s * math.sin(2 * math.pi * 0.12 * w * t)  # gentle breathing (m)
             pitch = 5.0 * s * math.sin(2 * math.pi * 0.09 * w * t)  # deg
             yaw_head = 8.0 * s * math.sin(2 * math.pi * 0.06 * w * t)  # deg
@@ -202,7 +204,6 @@ class Movements:
                 pitch += 6.0 * s * energy * math.sin(2 * math.pi * 1.1 * t)
                 yaw_head += 5.0 * s * energy * math.sin(2 * math.pi * 0.5 * t)
 
-            # Body: slow sway, engages more while speaking.
             body_yaw = math.radians(12.0 * s * math.sin(2 * math.pi * 0.05 * w * t))
             if speaking:
                 body_yaw += math.radians(8.0 * s * energy * math.sin(2 * math.pi * 0.6 * t))

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -1,19 +1,10 @@
 """Expressive full-body movement for MirrorBuddy.
 
-Layers, from the proven Reachy Mini conversation app:
-
-1. **Speech-reactive head** — the daemon's audio wobbler (``enable_wobbling``) moves the
-   head in real time while Buddy talks. This is the primary "lip-sync" and needs no
-   timing work from us.
-2. **Living idle** — a gentle base pose we set continuously: breathing (head z),
-   slow head drift, body rotation (``body_yaw``) and antenna sway. The wobbler overlays
-   speech motion on top of this base.
-3. **Speech energy -> antennas / body** — antennas perk up and the body engages slightly
-   while Buddy speaks, proportional to loudness.
-
-The intensity/speed of the idle + speech motion is scaled by a per-Maestro
-**temperament**, so a lively teacher moves more than a calm one (alignment with the
-MirrorBuddy persona).
+Layers (from the proven Reachy Mini conversation app): the daemon audio wobbler moves
+the head while Buddy talks; a living idle drives antennas + body (and head when not
+face-following); and while listening the head tracks the student's face. Intensity is
+scaled by a per-Maestro **temperament**. ``hold_still`` freezes everything so the camera
+can grab a sharp homework frame.
 """
 
 from __future__ import annotations
@@ -75,6 +66,35 @@ class Movements:
         self._thread: threading.Thread | None = None
         self._create_head_pose = None
         self._track_weight = -1.0  # unset; managed on speaking transitions
+        self._hold = threading.Event()  # when set, freeze all motion (e.g. camera capture)
+
+    def hold_still(self) -> None:
+        """Freeze head/body and pause tracking + wobbler so the camera gets a sharp frame."""
+        self._hold.set()
+        camera.set_tracking_weight(self.robot, 0.0)
+        try:
+            self.robot.disable_wobbling()
+        except Exception:
+            pass
+        try:
+            head = self._create_head_pose(0, 0, 0, 0, 0, 0, degrees=True) if self._create_head_pose else None
+            self.robot.goto_target(head=head, antennas=[_ANTENNA_NEUTRAL, _ANTENNA_NEUTRAL], body_yaw=0.0, duration=0.5)
+        except Exception as e:
+            logger.debug("hold_still goto failed: %s", e)
+        time.sleep(0.8)  # let the head settle and the camera pipeline produce a fresh frame
+
+    def release_hold(self) -> None:
+        """Resume normal motion after a camera capture."""
+        if not self._hold.is_set():
+            return
+        try:
+            self.robot.enable_wobbling()
+        except Exception:
+            pass
+        if self.follow_face:
+            camera.set_tracking_weight(self.robot, 1.0)
+            self._track_weight = 1.0
+        self._hold.clear()
 
     def set_temperament(self, temperament: Temperament) -> None:
         """Update liveliness when the Maestro changes (kept in sync with the persona)."""
@@ -151,10 +171,12 @@ class Movements:
         with self._lock:
             self._energy = 0.6 * self._energy + 0.4 * min(1.0, rms * 4.0)
 
-    # ------------------------------------------------------------------ internals
     def _loop(self) -> None:
         t0 = time.monotonic()
         while not self._stop.is_set():
+            if self._hold.is_set():
+                time.sleep(0.05)  # frozen for camera capture; drive nothing
+                continue
             t = time.monotonic() - t0
             with self._lock:
                 energy = self._energy
@@ -164,30 +186,28 @@ class Movements:
 
             speaking = energy > 0.06
 
-            # Face-follow handoff: while Buddy speaks, hand the head to the wobbler
-            # (weight 0); when idle/listening, let the head track the student (weight 1).
+            # Face-follow handoff: hand the head to the wobbler while speaking (weight 0),
+            # track the student while listening (weight 1).
             if self.follow_face:
                 target_weight = 0.0 if speaking else 1.0
                 if target_weight != self._track_weight:
                     camera.set_tracking_weight(self.robot, target_weight)
                     self._track_weight = target_weight
 
-            # --- base head pose: breathing + slow idle drift -----------------
-            # Amplitudes are intentionally clearly visible (a still robot reads as broken).
+            # Base head pose: breathing + idle drift (amplitudes deliberately visible).
             z = 0.010 * s * math.sin(2 * math.pi * 0.12 * w * t)  # gentle breathing (m)
             pitch = 5.0 * s * math.sin(2 * math.pi * 0.09 * w * t)  # deg
             yaw_head = 8.0 * s * math.sin(2 * math.pi * 0.06 * w * t)  # deg
             if speaking:
-                # Extra nod while talking (wobbler adds the fast motion on top).
                 pitch += 6.0 * s * energy * math.sin(2 * math.pi * 1.1 * t)
                 yaw_head += 5.0 * s * energy * math.sin(2 * math.pi * 0.5 * t)
 
-            # --- body rotation: slow sway, engages more while speaking -------
+            # Body: slow sway, engages more while speaking.
             body_yaw = math.radians(12.0 * s * math.sin(2 * math.pi * 0.05 * w * t))
             if speaking:
                 body_yaw += math.radians(8.0 * s * energy * math.sin(2 * math.pi * 0.6 * t))
 
-            # --- antennas: idle sway + perk up while speaking ----------------
+            # Antennas: idle sway + perk up while speaking.
             sway = math.radians(18.0 * s) * math.sin(2 * math.pi * 0.5 * w * t)
             if speaking:
                 perk = _ANTENNA_MAX * min(1.0, 0.4 + energy)
@@ -212,9 +232,7 @@ class Movements:
                 logger.debug("create_head_pose failed: %s", e)
         try:
             self.robot.set_target(
-                head=head,
-                antennas=[float(antennas[0]), float(antennas[1])],
-                body_yaw=float(body_yaw),
+                head=head, antennas=[float(antennas[0]), float(antennas[1])], body_yaw=float(body_yaw)
             )
         except Exception as e:
             logger.debug("set_target failed: %s", e)

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from . import camera
+
 logger = logging.getLogger(__name__)
 
 # Antennas are in radians. Neutral is a small offset to reduce servo shaking
@@ -62,15 +64,22 @@ def temperament_for(subject: str = "", teaching_style: str = "", voice_instructi
 class Movements:
     """Background full-body animation driven by speech energy + idle liveliness."""
 
-    def __init__(self, robot, enabled: bool = True, temperament: Temperament = NEUTRAL) -> None:
+    def __init__(self, robot, enabled: bool = True, temperament: Temperament = NEUTRAL, follow_face: bool = True) -> None:
         self.robot = robot
         self.enabled = enabled
         self.temp = temperament
+        self.follow_face = follow_face
         self._energy = 0.0
         self._lock = threading.Lock()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._create_head_pose = None
+        self._track_weight = -1.0  # unset; managed on speaking transitions
+
+    def set_temperament(self, temperament: Temperament) -> None:
+        """Update liveliness when the Maestro changes (kept in sync with the persona)."""
+        with self._lock:
+            self.temp = temperament
 
     def start(self) -> None:
         if not self.enabled:
@@ -91,6 +100,10 @@ class Movements:
             logger.info("Audio wobbler enabled (speech-reactive head motion)")
         except Exception as e:
             logger.warning("enable_wobbling failed: %s", e)
+        # Daemon-driven face tracking: the head follows the student's face.
+        if self.follow_face:
+            camera.start_tracking(self.robot, 1.0)
+            self._track_weight = 1.0
         self._stop.clear()
         self._thread = threading.Thread(target=self._loop, name="MirrorBuddyMoves", daemon=True)
         self._thread.start()
@@ -122,6 +135,8 @@ class Movements:
             self.robot.disable_wobbling()
         except Exception:
             pass
+        if self.follow_face:
+            camera.stop_tracking(self.robot)
         self._neutral()
 
     def reset(self) -> None:
@@ -139,15 +154,23 @@ class Movements:
     # ------------------------------------------------------------------ internals
     def _loop(self) -> None:
         t0 = time.monotonic()
-        s = self.temp.scale
-        w = self.temp.speed
         while not self._stop.is_set():
             t = time.monotonic() - t0
             with self._lock:
                 energy = self._energy
                 self._energy *= 0.9
+                s = self.temp.scale
+                w = self.temp.speed
 
             speaking = energy > 0.06
+
+            # Face-follow handoff: while Buddy speaks, hand the head to the wobbler
+            # (weight 0); when idle/listening, let the head track the student (weight 1).
+            if self.follow_face:
+                target_weight = 0.0 if speaking else 1.0
+                if target_weight != self._track_weight:
+                    camera.set_tracking_weight(self.robot, target_weight)
+                    self._track_weight = target_weight
 
             # --- base head pose: breathing + slow idle drift -----------------
             # Amplitudes are intentionally clearly visible (a still robot reads as broken).
@@ -180,7 +203,9 @@ class Movements:
 
     def _apply(self, z: float, pitch: float, yaw: float, body_yaw: float, antennas: tuple[float, float]) -> None:
         head = None
-        if self._create_head_pose is not None:
+        # When face-follow is on, the daemon owns the head (track + wobble); we only
+        # animate antennas and body so we never fight the tracker.
+        if not self.follow_face and self._create_head_pose is not None:
             try:
                 head = self._create_head_pose(x=0, y=0, z=z, roll=0, pitch=pitch, yaw=yaw, degrees=True)
             except Exception as e:

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -95,6 +95,24 @@ class Movements:
         self._thread = threading.Thread(target=self._loop, name="MirrorBuddyMoves", daemon=True)
         self._thread.start()
 
+    def wake(self) -> None:
+        """A short, clearly visible greeting gesture (look around + nod + antennas up)."""
+        if not self.enabled or self._create_head_pose is None:
+            return
+        cp = self._create_head_pose
+        seq = [
+            (cp(yaw=22, degrees=True), [0.5, -0.5], 0.28),
+            (cp(yaw=-22, degrees=True), [-0.5, 0.5], -0.28),
+            (cp(pitch=16, degrees=True), [0.45, 0.45], 0.0),
+            (cp(0, 0, 0, 0, 0, 0, degrees=True), [_ANTENNA_NEUTRAL, _ANTENNA_NEUTRAL], 0.0),
+        ]
+        for pose, ant, byaw in seq:
+            try:
+                self.robot.goto_target(head=pose, antennas=ant, body_yaw=byaw, duration=0.55)
+            except Exception as e:
+                logger.debug("wake goto failed: %s", e)
+            time.sleep(0.6)
+
     def stop(self) -> None:
         self._stop.set()
         if self._thread:
@@ -132,25 +150,27 @@ class Movements:
             speaking = energy > 0.06
 
             # --- base head pose: breathing + slow idle drift -----------------
-            z = 0.006 * s * math.sin(2 * math.pi * 0.1 * w * t)  # gentle breathing (m)
-            pitch = 2.5 * s * math.sin(2 * math.pi * 0.07 * w * t)  # deg
-            yaw_head = 3.0 * s * math.sin(2 * math.pi * 0.05 * w * t)  # deg
+            # Amplitudes are intentionally clearly visible (a still robot reads as broken).
+            z = 0.010 * s * math.sin(2 * math.pi * 0.12 * w * t)  # gentle breathing (m)
+            pitch = 5.0 * s * math.sin(2 * math.pi * 0.09 * w * t)  # deg
+            yaw_head = 8.0 * s * math.sin(2 * math.pi * 0.06 * w * t)  # deg
             if speaking:
-                # Small extra nod while talking (wobbler adds the fast motion on top).
-                pitch += 3.0 * s * energy * math.sin(2 * math.pi * 1.1 * t)
+                # Extra nod while talking (wobbler adds the fast motion on top).
+                pitch += 6.0 * s * energy * math.sin(2 * math.pi * 1.1 * t)
+                yaw_head += 5.0 * s * energy * math.sin(2 * math.pi * 0.5 * t)
 
-            # --- body rotation: slow sway, engages a bit while speaking ------
-            body_yaw = math.radians(6.0 * s * math.sin(2 * math.pi * 0.04 * w * t))
+            # --- body rotation: slow sway, engages more while speaking -------
+            body_yaw = math.radians(12.0 * s * math.sin(2 * math.pi * 0.05 * w * t))
             if speaking:
-                body_yaw += math.radians(4.0 * s * energy * math.sin(2 * math.pi * 0.6 * t))
+                body_yaw += math.radians(8.0 * s * energy * math.sin(2 * math.pi * 0.6 * t))
 
             # --- antennas: idle sway + perk up while speaking ----------------
-            sway = math.radians(12.0 * s) * math.sin(2 * math.pi * 0.5 * w * t)
+            sway = math.radians(18.0 * s) * math.sin(2 * math.pi * 0.5 * w * t)
             if speaking:
-                perk = _ANTENNA_MAX * min(1.0, 0.3 + energy)
-                flutter = math.radians(9.0) * math.sin(2 * math.pi * 6.0 * t)
-                right = _clamp(_ANTENNA_NEUTRAL + perk * 0.5 + flutter)
-                left = _clamp(_ANTENNA_NEUTRAL + perk * 0.5 - flutter)
+                perk = _ANTENNA_MAX * min(1.0, 0.4 + energy)
+                flutter = math.radians(12.0) * math.sin(2 * math.pi * 6.0 * t)
+                right = _clamp(_ANTENNA_NEUTRAL + perk * 0.6 + flutter)
+                left = _clamp(_ANTENNA_NEUTRAL + perk * 0.6 - flutter)
             else:
                 right = _clamp(_ANTENNA_NEUTRAL + sway)
                 left = _clamp(_ANTENNA_NEUTRAL - sway)

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -1,11 +1,19 @@
-"""Lightweight, safe expressive movement for MirrorBuddy.
+"""Expressive full-body movement for MirrorBuddy.
 
-The robot's media pipeline already wobbles the head in sync with played speech.
-On top of that we add gentle **antenna** motion (bounded, low-risk) so Buddy feels
-alive: antennas perk up while speaking and sway slowly while idle.
+Layers, from the proven Reachy Mini conversation app:
 
-Head-pose control is intentionally avoided in v1 to keep motion safe and predictable;
-antennas are expressive enough and cannot send the head to an odd absolute pose.
+1. **Speech-reactive head** — the daemon's audio wobbler (``enable_wobbling``) moves the
+   head in real time while Buddy talks. This is the primary "lip-sync" and needs no
+   timing work from us.
+2. **Living idle** — a gentle base pose we set continuously: breathing (head z),
+   slow head drift, body rotation (``body_yaw``) and antenna sway. The wobbler overlays
+   speech motion on top of this base.
+3. **Speech energy -> antennas / body** — antennas perk up and the body engages slightly
+   while Buddy speaks, proportional to loudness.
+
+The intensity/speed of the idle + speech motion is scaled by a per-Maestro
+**temperament**, so a lively teacher moves more than a calm one (alignment with the
+MirrorBuddy persona).
 """
 
 from __future__ import annotations
@@ -14,32 +22,75 @@ import logging
 import math
 import threading
 import time
+from dataclasses import dataclass
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
 
-_ANTENNA_MAX = 0.5  # radians, bounded so motion always stays gentle
+# Antennas are in radians. Neutral is a small offset to reduce servo shaking
+# (matches the conversation app's ~10deg rest).
+_ANTENNA_NEUTRAL = 0.1745  # ~10 deg
+_ANTENNA_MAX = 0.6
+
+
+@dataclass(frozen=True)
+class Temperament:
+    """How lively the Maestro moves. ``scale`` = amplitude, ``speed`` = frequency."""
+
+    scale: float = 1.0
+    speed: float = 1.0
+
+
+CALM = Temperament(scale=0.7, speed=0.8)
+NEUTRAL = Temperament(scale=1.0, speed=1.0)
+LIVELY = Temperament(scale=1.35, speed=1.25)
+
+
+def temperament_for(subject: str = "", teaching_style: str = "", voice_instructions: str = "") -> Temperament:
+    """Derive a movement temperament from a Maestro's persona (best-effort keywords)."""
+    text = f"{subject} {teaching_style} {voice_instructions}".lower()
+    lively_kw = ("energe", "vivac", "entusias", "playful", "dynamic", "passion", "espressiv", "teatral", "lively")
+    calm_kw = ("calm", "tranquil", "gentle", "paz", "serio", "riflessiv", "pacato", "soft", "measured", "sober")
+    if any(k in text for k in lively_kw):
+        return LIVELY
+    if any(k in text for k in calm_kw):
+        return CALM
+    return NEUTRAL
 
 
 class Movements:
-    """Background antenna animation driven by speech energy."""
+    """Background full-body animation driven by speech energy + idle liveliness."""
 
-    def __init__(self, robot, enabled: bool = True) -> None:
+    def __init__(self, robot, enabled: bool = True, temperament: Temperament = NEUTRAL) -> None:
         self.robot = robot
         self.enabled = enabled
+        self.temp = temperament
         self._energy = 0.0
         self._lock = threading.Lock()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
+        self._create_head_pose = None
 
     def start(self) -> None:
         if not self.enabled:
             return
         try:
+            from reachy_mini.utils import create_head_pose
+
+            self._create_head_pose = create_head_pose
+        except Exception as e:
+            logger.warning("create_head_pose unavailable, head motion disabled: %s", e)
+        try:
             self.robot.enable_motors()
         except Exception as e:
             logger.debug("enable_motors not available/failed: %s", e)
+        # Daemon-driven, speech-reactive head motion (real-time lip-sync).
+        try:
+            self.robot.enable_wobbling()
+            logger.info("Audio wobbler enabled (speech-reactive head motion)")
+        except Exception as e:
+            logger.warning("enable_wobbling failed: %s", e)
         self._stop.clear()
         self._thread = threading.Thread(target=self._loop, name="MirrorBuddyMoves", daemon=True)
         self._thread.start()
@@ -49,7 +100,11 @@ class Movements:
         if self._thread:
             self._thread.join(timeout=1.5)
             self._thread = None
-        self._set_antennas(0.0, 0.0)
+        try:
+            self.robot.disable_wobbling()
+        except Exception:
+            pass
+        self._neutral()
 
     def reset(self) -> None:
         with self._lock:
@@ -61,39 +116,70 @@ class Movements:
             return
         rms = float(np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2)))
         with self._lock:
-            # Smooth so antennas don't jitter.
             self._energy = 0.6 * self._energy + 0.4 * min(1.0, rms * 4.0)
 
     # ------------------------------------------------------------------ internals
     def _loop(self) -> None:
         t0 = time.monotonic()
+        s = self.temp.scale
+        w = self.temp.speed
         while not self._stop.is_set():
             t = time.monotonic() - t0
             with self._lock:
                 energy = self._energy
-                # Natural decay when no fresh audio arrives.
                 self._energy *= 0.9
 
-            if energy > 0.05:
-                # Speaking: perk up + subtle flutter proportional to loudness.
-                base = _ANTENNA_MAX * min(1.0, 0.3 + energy)
-                flutter = 0.15 * math.sin(t * 12.0)
-                right = _clamp(base + flutter)
-                left = _clamp(base - flutter)
+            speaking = energy > 0.06
+
+            # --- base head pose: breathing + slow idle drift -----------------
+            z = 0.006 * s * math.sin(2 * math.pi * 0.1 * w * t)  # gentle breathing (m)
+            pitch = 2.5 * s * math.sin(2 * math.pi * 0.07 * w * t)  # deg
+            yaw_head = 3.0 * s * math.sin(2 * math.pi * 0.05 * w * t)  # deg
+            if speaking:
+                # Small extra nod while talking (wobbler adds the fast motion on top).
+                pitch += 3.0 * s * energy * math.sin(2 * math.pi * 1.1 * t)
+
+            # --- body rotation: slow sway, engages a bit while speaking ------
+            body_yaw = math.radians(6.0 * s * math.sin(2 * math.pi * 0.04 * w * t))
+            if speaking:
+                body_yaw += math.radians(4.0 * s * energy * math.sin(2 * math.pi * 0.6 * t))
+
+            # --- antennas: idle sway + perk up while speaking ----------------
+            sway = math.radians(12.0 * s) * math.sin(2 * math.pi * 0.5 * w * t)
+            if speaking:
+                perk = _ANTENNA_MAX * min(1.0, 0.3 + energy)
+                flutter = math.radians(9.0) * math.sin(2 * math.pi * 6.0 * t)
+                right = _clamp(_ANTENNA_NEUTRAL + perk * 0.5 + flutter)
+                left = _clamp(_ANTENNA_NEUTRAL + perk * 0.5 - flutter)
             else:
-                # Idle: slow, gentle, breathing-like sway.
-                sway = 0.12 * math.sin(t * 1.2)
-                right = _clamp(sway)
-                left = _clamp(-sway)
+                right = _clamp(_ANTENNA_NEUTRAL + sway)
+                left = _clamp(_ANTENNA_NEUTRAL - sway)
 
-            self._set_antennas(right, left)
-            time.sleep(0.05)
+            self._apply(z=z, pitch=pitch, yaw=yaw_head, body_yaw=body_yaw, antennas=(right, left))
+            time.sleep(0.033)  # ~30 Hz
 
-    def _set_antennas(self, right: float, left: float) -> None:
+    def _apply(self, z: float, pitch: float, yaw: float, body_yaw: float, antennas: tuple[float, float]) -> None:
+        head = None
+        if self._create_head_pose is not None:
+            try:
+                head = self._create_head_pose(x=0, y=0, z=z, roll=0, pitch=pitch, yaw=yaw, degrees=True)
+            except Exception as e:
+                logger.debug("create_head_pose failed: %s", e)
         try:
-            self.robot.set_target(antennas=[float(right), float(left)])
+            self.robot.set_target(
+                head=head,
+                antennas=[float(antennas[0]), float(antennas[1])],
+                body_yaw=float(body_yaw),
+            )
         except Exception as e:
-            logger.debug("set antennas failed: %s", e)
+            logger.debug("set_target failed: %s", e)
+
+    def _neutral(self) -> None:
+        try:
+            head = self._create_head_pose(0, 0, 0, 0, 0, 0, degrees=True) if self._create_head_pose else None
+            self.robot.set_target(head=head, antennas=[_ANTENNA_NEUTRAL, _ANTENNA_NEUTRAL], body_yaw=0.0)
+        except Exception:
+            pass
 
 
 def _clamp(v: float) -> float:

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -1,0 +1,100 @@
+"""Lightweight, safe expressive movement for MirrorBuddy.
+
+The robot's media pipeline already wobbles the head in sync with played speech.
+On top of that we add gentle **antenna** motion (bounded, low-risk) so Buddy feels
+alive: antennas perk up while speaking and sway slowly while idle.
+
+Head-pose control is intentionally avoided in v1 to keep motion safe and predictable;
+antennas are expressive enough and cannot send the head to an odd absolute pose.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+import time
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_ANTENNA_MAX = 0.5  # radians, bounded so motion always stays gentle
+
+
+class Movements:
+    """Background antenna animation driven by speech energy."""
+
+    def __init__(self, robot, enabled: bool = True) -> None:
+        self.robot = robot
+        self.enabled = enabled
+        self._energy = 0.0
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if not self.enabled:
+            return
+        try:
+            self.robot.enable_motors()
+        except Exception as e:
+            logger.debug("enable_motors not available/failed: %s", e)
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._loop, name="MirrorBuddyMoves", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=1.5)
+            self._thread = None
+        self._set_antennas(0.0, 0.0)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._energy = 0.0
+
+    def feed(self, audio: np.ndarray, sample_rate: int) -> None:
+        """Update the current speech energy from a chunk of PCM16 audio."""
+        if audio is None or audio.size == 0:
+            return
+        rms = float(np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2)))
+        with self._lock:
+            # Smooth so antennas don't jitter.
+            self._energy = 0.6 * self._energy + 0.4 * min(1.0, rms * 4.0)
+
+    # ------------------------------------------------------------------ internals
+    def _loop(self) -> None:
+        t0 = time.monotonic()
+        while not self._stop.is_set():
+            t = time.monotonic() - t0
+            with self._lock:
+                energy = self._energy
+                # Natural decay when no fresh audio arrives.
+                self._energy *= 0.9
+
+            if energy > 0.05:
+                # Speaking: perk up + subtle flutter proportional to loudness.
+                base = _ANTENNA_MAX * min(1.0, 0.3 + energy)
+                flutter = 0.15 * math.sin(t * 12.0)
+                right = _clamp(base + flutter)
+                left = _clamp(base - flutter)
+            else:
+                # Idle: slow, gentle, breathing-like sway.
+                sway = 0.12 * math.sin(t * 1.2)
+                right = _clamp(sway)
+                left = _clamp(-sway)
+
+            self._set_antennas(right, left)
+            time.sleep(0.05)
+
+    def _set_antennas(self, right: float, left: float) -> None:
+        try:
+            self.robot.set_target(antennas=[float(right), float(left)])
+        except Exception as e:
+            logger.debug("set antennas failed: %s", e)
+
+
+def _clamp(v: float) -> float:
+    return max(-_ANTENNA_MAX, min(_ANTENNA_MAX, v))

--- a/robot/reachy_mini_mirrorbuddy/prompt_builder.py
+++ b/robot/reachy_mini_mirrorbuddy/prompt_builder.py
@@ -24,6 +24,17 @@ _EMBODIMENT_IT = (
     "ma resta sempre un tutor: il tuo scopo è aiutare a studiare e capire."
 )
 
+_TOOLS_IT = (
+    "Puoi fare tre cose con gli strumenti, quando serve, senza che nessuno tocchi uno schermo:\n"
+    "- Se lo studente chiede chi c'è o con chi può parlare, usa 'list_professors'.\n"
+    "- Se chiede un altro professore o un'altra materia (es. «voglio matematica», «chiama "
+    "Galileo»), usa 'call_professor': cambierai persona e voce e il nuovo professore saluterà.\n"
+    "- Se ti mostra un compito, un esercizio o un foglio da leggere, usa 'look_at_homework' "
+    "per guardarlo con la telecamera. Prima di usarlo, dì sempre a voce che stai per guardare "
+    "(es. «fammi dare un'occhiata al tuo compito»). Non spiare mai: usa la telecamera solo su "
+    "richiesta, per aiutare con lo studio, e non descrivere le persone."
+)
+
 
 def build_instructions(
     maestro: Maestro,
@@ -53,8 +64,9 @@ def build_instructions(
     if persona:
         parts.append("\n".join(persona))
 
-    # 4. Robot embodiment.
+    # 4. Robot embodiment + voice-driven tools.
     parts.append(_EMBODIMENT_IT)
+    parts.append(_TOOLS_IT)
 
     # 5. Student personalisation + DSA sensitivity.
     student_bits: list[str] = []

--- a/robot/reachy_mini_mirrorbuddy/prompt_builder.py
+++ b/robot/reachy_mini_mirrorbuddy/prompt_builder.py
@@ -27,12 +27,14 @@ _EMBODIMENT_IT = (
 _TOOLS_IT = (
     "Puoi fare tre cose con gli strumenti, quando serve, senza che nessuno tocchi uno schermo:\n"
     "- Se lo studente chiede chi c'è o con chi può parlare, usa 'list_professors'.\n"
-    "- Se chiede un altro professore o un'altra materia (es. «voglio matematica», «chiama "
-    "Galileo»), usa 'call_professor': cambierai persona e voce e il nuovo professore saluterà.\n"
-    "- Se ti mostra un compito, un esercizio o un foglio da leggere, usa 'look_at_homework' "
-    "per guardarlo con la telecamera. Prima di usarlo, dì sempre a voce che stai per guardare "
-    "(es. «fammi dare un'occhiata al tuo compito»). Non spiare mai: usa la telecamera solo su "
-    "richiesta, per aiutare con lo studio, e non descrivere le persone."
+    "- IMPORTANTE: se lo studente chiede un altro professore o un'altra materia (es. «voglio "
+    "matematica», «chiama Galileo», «parliamo di storia»), DEVI usare SUBITO lo strumento "
+    "'call_professor' con quel nome o materia. Non limitarti a rispondere a parole né a fingere "
+    "di cambiare: chiama davvero lo strumento, sarà lui a cambiare persona e voce.\n"
+    "- Se ti mostra un compito, un esercizio o un foglio, usa 'look_at_homework'. Prima dì a voce "
+    "che stai per guardare (es. «fammi dare un'occhiata»); poi resta fermo, non muovere la testa, "
+    "perché il robot si ferma da solo per scattare una foto nitida. Non spiare mai: usa la "
+    "telecamera solo su richiesta, per aiutare con lo studio, e non descrivere le persone."
 )
 
 

--- a/robot/reachy_mini_mirrorbuddy/prompt_builder.py
+++ b/robot/reachy_mini_mirrorbuddy/prompt_builder.py
@@ -31,10 +31,19 @@ _TOOLS_IT = (
     "matematica», «chiama Galileo», «parliamo di storia»), DEVI usare SUBITO lo strumento "
     "'call_professor' con quel nome o materia. Non limitarti a rispondere a parole né a fingere "
     "di cambiare: chiama davvero lo strumento, sarà lui a cambiare persona e voce.\n"
-    "- Se ti mostra un compito, un esercizio o un foglio, usa 'look_at_homework'. Prima dì a voce "
-    "che stai per guardare (es. «fammi dare un'occhiata»); poi resta fermo, non muovere la testa, "
-    "perché il robot si ferma da solo per scattare una foto nitida. Non spiare mai: usa la "
-    "telecamera solo su richiesta, per aiutare con lo studio, e non descrivere le persone."
+    "- Se ti mostra qualcosa da guardare — un compito, un esercizio, un foglio, la pagina di un "
+    "quaderno o di un libro sul tavolo, oppure lo schermo del computer — usa 'look_at_homework'. "
+    "Prima dì a voce che stai per guardare (es. «fammi dare un'occhiata»); poi resta fermo, non "
+    "muovere la testa, perché il robot si ferma da solo per scattare una foto nitida. Non spiare "
+    "mai: usa la telecamera solo su richiesta, per aiutare con lo studio, e non descrivere le persone."
+)
+
+_CONTROL_IT = (
+    "Regole di conversazione: tieni ogni risposta corta e poi lascia parlare lo studente. "
+    "Lo studente può interromperti in qualsiasi momento: se inizia a parlare, fermati subito e "
+    "ascolta. Se dice «basta», «aspetta», «pausa», «fermati», «zitto» o «un momento», smetti "
+    "immediatamente di parlare, resta in silenzio e aspetta con calma che riprenda lui. "
+    "Non riprendere finché non te lo chiede."
 )
 
 
@@ -66,9 +75,10 @@ def build_instructions(
     if persona:
         parts.append("\n".join(persona))
 
-    # 4. Robot embodiment + voice-driven tools.
+    # 4. Robot embodiment + voice-driven tools + conversation control.
     parts.append(_EMBODIMENT_IT)
     parts.append(_TOOLS_IT)
+    parts.append(_CONTROL_IT)
 
     # 5. Student personalisation + DSA sensitivity.
     student_bits: list[str] = []

--- a/robot/reachy_mini_mirrorbuddy/prompt_builder.py
+++ b/robot/reachy_mini_mirrorbuddy/prompt_builder.py
@@ -1,0 +1,88 @@
+"""Assemble the realtime ``instructions`` string for a Maestro.
+
+This mirrors MirrorBuddy's web assembly (``session-config.ts``): safety guardrails +
+language instruction + character/persona + voice style, plus a robot-embodiment note
+so the Maestro knows it now has a physical body (eyes, ears, mouth, movements).
+"""
+
+from __future__ import annotations
+
+from .mirrorbuddy_client import Maestro
+from .safety import get_safety_preamble
+
+_LANGUAGE_IT = (
+    "Parla SEMPRE in italiano, con frasi brevi e parole semplici. "
+    "Le tue risposte verranno pronunciate ad alta voce: sii naturale, caldo e conciso, "
+    "evita elenchi lunghi, simboli, formule scritte o emoji. Una cosa alla volta."
+)
+
+_EMBODIMENT_IT = (
+    "Ora hai un corpo fisico: sei un piccolo robot da tavolo, Reachy Mini. "
+    "Hai occhi (una telecamera con cui puoi vedere chi ti parla e ciò che ti mostra), "
+    "orecchie (un microfono), una voce (un altoparlante) e puoi muovere la testa e "
+    "le antenne per esprimere emozioni. Muoviti e reagisci in modo vivo e amichevole, "
+    "ma resta sempre un tutor: il tuo scopo è aiutare a studiare e capire."
+)
+
+
+def build_instructions(
+    maestro: Maestro,
+    locale: str = "it",
+    dsa_profile: str | None = None,
+    student_name: str | None = None,
+) -> str:
+    """Compose the full system instructions for the realtime session."""
+    parts: list[str] = []
+
+    # 1. Safety first — highest priority, non-negotiable.
+    parts.append(get_safety_preamble(locale))
+
+    # 2. Language + spoken-output style.
+    parts.append(_LANGUAGE_IT if locale.startswith("it") else _LANGUAGE_IT)
+
+    # 3. Character / persona (straight from MirrorBuddy).
+    persona: list[str] = []
+    if maestro.display_name:
+        persona.append(f"Interpreti {maestro.display_name}.")
+    if maestro.system_prompt:
+        persona.append(maestro.system_prompt)
+    if maestro.voice_instructions:
+        persona.append(f"Stile di voce e personalità: {maestro.voice_instructions}")
+    if maestro.teaching_style:
+        persona.append(f"Stile di insegnamento: {maestro.teaching_style}")
+    if persona:
+        parts.append("\n".join(persona))
+
+    # 4. Robot embodiment.
+    parts.append(_EMBODIMENT_IT)
+
+    # 5. Student personalisation + DSA sensitivity.
+    student_bits: list[str] = []
+    if student_name:
+        student_bits.append(
+            f"Stai facendo da tutor a {student_name}. Chiamalo per nome, con affetto."
+        )
+    if dsa_profile:
+        student_bits.append(_dsa_note(dsa_profile))
+    if student_bits:
+        parts.append(" ".join(student_bits))
+
+    return "\n\n".join(p.strip() for p in parts if p and p.strip())
+
+
+def _dsa_note(profile: str) -> str:
+    p = profile.strip().lower()
+    notes = {
+        "dyslexia": "Ha dislessia: non chiedergli di leggere testi lunghi, leggi tu ad alta voce e vai piano.",
+        "dyscalculia": "Ha discalculia: spezza la matematica in micro-passi, uno alla volta, senza fretta.",
+        "cerebral": (
+            "Ha una paralisi cerebrale e può parlare o rispondere più lentamente: "
+            "aspettalo sempre con pazienza, non interromperlo, va benissimo ripetere."
+        ),
+        "motor": "Può avere tempi motori e di risposta più lunghi: aspetta con pazienza, non incalzare.",
+        "adhd": "Può distrarsi: riporta con dolcezza al compito e tieni gli scambi brevi e vivaci.",
+        "autism": "Preferisce chiarezza e prevedibilità: sii esplicito, calmo e coerente, evita ironia ambigua.",
+        "visual": "Descrivi a voce ciò che serve, senza dare per scontato che veda bene lo schermo.",
+        "auditory": "Scandisci bene le parole e ripeti volentieri se non ha sentito.",
+    }
+    return notes.get(p, "")

--- a/robot/reachy_mini_mirrorbuddy/rt_messages.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_messages.py
@@ -7,7 +7,27 @@ The event schema differs between the Realtime GA and Preview protocols, so
 
 from __future__ import annotations
 
+import json
+import re
+
 SAMPLE_RATE = 24000  # PCM sample rate (in and out)
+
+# Pre-serialised cancel of the model's current response (used on barge-in / stop).
+CANCEL = json.dumps({"type": "response.cancel"})
+
+# Stop-intent words. When the student says any of these the robot must go silent
+# immediately, deterministically — never relying on the model to choose to yield.
+# This is an accessibility requirement: insistence stresses the student.
+_STOP_RE = re.compile(
+    r"\b(basta|ferma(?:ti|te|lo)?|zitt[oaie]|silenzio|silence|aspetta|"
+    r"pausa|stop|taci|smettila|smetti|shh+|sh+t?)\b",
+    re.IGNORECASE,
+)
+
+
+def is_stop(text: str | None) -> bool:
+    """True if the user utterance is a command to stop / be quiet."""
+    return bool(text and _STOP_RE.search(text))
 
 
 def session_update(

--- a/robot/reachy_mini_mirrorbuddy/rt_messages.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_messages.py
@@ -1,0 +1,77 @@
+"""Pure builders for Azure Realtime protocol messages.
+
+Keeping these here keeps :mod:`azure_realtime` focused on the socket lifecycle.
+The event schema differs between the Realtime GA and Preview protocols, so
+:func:`session_update` emits the right shape for each.
+"""
+
+from __future__ import annotations
+
+SAMPLE_RATE = 24000  # PCM sample rate (in and out)
+
+
+def session_update(
+    instructions: str,
+    voice: str,
+    turn_detection: dict,
+    tools: list[dict] | None,
+    use_ga: bool,
+) -> dict:
+    """Build the ``session.update`` message for the active protocol."""
+    if use_ga:
+        session: dict = {
+            "type": "realtime",
+            "instructions": instructions,
+            "output_modalities": ["audio"],
+            "audio": {
+                "input": {
+                    "format": {"type": "audio/pcm", "rate": SAMPLE_RATE},
+                    "turn_detection": turn_detection,
+                    "transcription": {"model": "whisper-1"},
+                    "noise_reduction": {"type": "near_field"},
+                },
+                "output": {
+                    "format": {"type": "audio/pcm", "rate": SAMPLE_RATE},
+                    "voice": voice,
+                },
+            },
+        }
+    else:
+        session = {
+            "modalities": ["audio", "text"],
+            "instructions": instructions,
+            "voice": voice,
+            "input_audio_format": "pcm16",
+            "output_audio_format": "pcm16",
+            "input_audio_transcription": {"model": "whisper-1"},
+            "turn_detection": turn_detection,
+        }
+    if tools:
+        session["tools"] = tools
+        session["tool_choice"] = "auto"
+    return {"type": "session.update", "session": session}
+
+
+def audio_append(b64: str) -> dict:
+    return {"type": "input_audio_buffer.append", "audio": b64}
+
+
+def function_call_output(call_id: str, output: str) -> dict:
+    return {
+        "type": "conversation.item.create",
+        "item": {"type": "function_call_output", "call_id": call_id, "output": output},
+    }
+
+
+def image_message(data_url: str, prompt: str) -> dict:
+    return {
+        "type": "conversation.item.create",
+        "item": {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": prompt},
+                {"type": "input_image", "image_url": data_url},
+            ],
+        },
+    }

--- a/robot/reachy_mini_mirrorbuddy/safety.py
+++ b/robot/reachy_mini_mirrorbuddy/safety.py
@@ -1,0 +1,37 @@
+"""Child-safety guardrails, aligned with MirrorBuddy's professor constitution.
+
+This is a compact, faithful restatement of the non-negotiable safety rules that
+MirrorBuddy injects into every voice session. It is prepended to the Maestro's own
+system prompt so the robot behaves like a MirrorBuddy professor even though the
+conversation runs directly against Azure OpenAI Realtime.
+
+The robot is used by a minor (in the reference deployment, a 15-year-old with DSA
+and cerebral palsy), so these rules take precedence over everything else.
+"""
+
+from __future__ import annotations
+
+SAFETY_GUARDRAILS_IT = """\
+[REGOLE DI SICUREZZA — PRIORITÀ ASSOLUTA, NON DEROGABILI]
+Stai parlando con un minore. La sua sicurezza e il suo benessere vengono prima di tutto.
+
+1. Sei un tutor educativo gentile. Non sei un medico, uno psicologo, né un amico adulto:
+   non sostituirti a genitori, insegnanti o professionisti.
+2. Non chiedere e non registrare dati personali (indirizzo, scuola, password, posizione,
+   numeri di telefono, foto). Se emergono, non ripeterli e riporta gentilmente al compito.
+3. Linguaggio sempre adatto ai minori. Mai contenuti violenti, sessuali, d'odio,
+   autolesionismo, droghe, gioco d'azzardo o attività pericolose o illegali.
+4. Non dare consigli medici, legali o finanziari. Non diagnosticare.
+5. Se il ragazzo esprime disagio, paura, tristezza forte, o accenna a pericolo o
+   maltrattamento: resta calmo, rassicuralo, non indagare morbosamente e invitalo con
+   dolcezza a parlarne subito con un adulto di fiducia (un genitore o un insegnante).
+6. Non spaventare, non colpevolizzare, non deridere mai. Mai sarcasmo verso di lui.
+7. Non fingere di essere umano se te lo chiede: sei Buddy, un piccolo robot amico.
+8. In caso di dubbio tra utilità e sicurezza, scegli sempre la sicurezza.
+"""
+
+
+def get_safety_preamble(locale: str = "it") -> str:
+    """Return the safety preamble for the given locale (Italian by default)."""
+    # Only Italian is provided for now; extend here when other locales are needed.
+    return SAFETY_GUARDRAILS_IT

--- a/robot/reachy_mini_mirrorbuddy/settings_ui.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_ui.py
@@ -1,0 +1,183 @@
+"""Minimal in-app settings UI (FastAPI routes).
+
+Mounted on the Reachy Mini app's built-in settings web server. It lets you:
+- see whether the required configuration is present,
+- pick which Maestro to embody, the DSA profile and the student name,
+- enter the Azure Realtime credentials (written to the instance ``.env``).
+
+The page is deliberately tiny and dependency-free (inline HTML + fetch).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from .config import config
+
+logger = logging.getLogger(__name__)
+
+# Keys we allow the UI to persist into the instance .env file.
+_EDITABLE_KEYS = (
+    "AZURE_OPENAI_REALTIME_ENDPOINT",
+    "AZURE_OPENAI_REALTIME_API_KEY",
+    "AZURE_OPENAI_REALTIME_DEPLOYMENT",
+    "AZURE_OPENAI_REALTIME_API_VERSION",
+    "MIRRORBUDDY_URL",
+    "MIRRORBUDDY_LOCALE",
+    "MIRRORBUDDY_MAESTRO_ID",
+    "MIRRORBUDDY_DSA_PROFILE",
+    "MIRRORBUDDY_STUDENT_NAME",
+)
+
+
+def mount_settings_routes(app, instance_path: str | None) -> None:
+    """Attach the settings routes to the app's FastAPI ``settings_app``."""
+    from fastapi import Request
+    from fastapi.responses import HTMLResponse, JSONResponse
+
+    env_path = Path(instance_path) / ".env" if instance_path else Path(".env")
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index() -> str:  # noqa: D401 - route
+        return _PAGE
+
+    @app.get("/api/status")
+    async def status() -> JSONResponse:
+        config.reload()
+        return JSONResponse(
+            {
+                "ready": not config.missing(),
+                "missing": config.missing(),
+                "maestroId": config.MAESTRO_ID,
+                "dsaProfile": config.DSA_PROFILE,
+                "studentName": config.STUDENT_NAME,
+                "mirrorbuddyUrl": config.MIRRORBUDDY_URL,
+                "locale": config.LOCALE,
+            }
+        )
+
+    @app.get("/api/maestri")
+    async def maestri() -> JSONResponse:
+        from .mirrorbuddy_client import MirrorBuddyClient
+
+        try:
+            client = MirrorBuddyClient(config.MIRRORBUDDY_URL, locale=config.LOCALE)
+            items = [
+                {"id": m.id, "name": m.display_name, "subject": m.subject, "voice": m.voice}
+                for m in client.fetch_maestri()
+            ]
+            return JSONResponse({"maestri": items})
+        except Exception as e:
+            logger.warning("maestri fetch failed: %s", e)
+            return JSONResponse({"maestri": [], "error": str(e)}, status_code=502)
+
+    @app.post("/api/config")
+    async def save_config(request: Request) -> JSONResponse:
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"ok": False, "error": "invalid JSON"}, status_code=400)
+        if not isinstance(body, dict):
+            return JSONResponse({"ok": False, "error": "expected object"}, status_code=400)
+
+        updates = {k: str(v) for k, v in body.items() if k in _EDITABLE_KEYS and v is not None}
+        try:
+            _write_env(env_path, updates)
+        except Exception as e:
+            logger.error("failed to write .env: %s", e)
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+        config.reload()
+        return JSONResponse({"ok": True, "ready": not config.missing(), "missing": config.missing()})
+
+
+def _write_env(env_path: Path, updates: dict[str, str]) -> None:
+    """Merge ``updates`` into the .env file, preserving existing keys."""
+    if not updates:
+        return
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    existing: dict[str, str] = {}
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            existing[k.strip()] = v
+    existing.update(updates)
+    body = "\n".join(f"{k}={v}" for k, v in existing.items()) + "\n"
+    env_path.write_text(body, encoding="utf-8")
+
+
+_PAGE = """<!doctype html>
+<html lang="it">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MirrorBuddy Robot — Impostazioni</title>
+<style>
+ body{font-family:system-ui,sans-serif;max-width:640px;margin:2rem auto;padding:0 1rem;color:#1a1a2e}
+ h1{font-size:1.4rem} label{display:block;margin:.6rem 0 .2rem;font-weight:600;font-size:.9rem}
+ input,select{width:100%;padding:.5rem;border:1px solid #ccc;border-radius:8px;font-size:1rem}
+ button{margin-top:1rem;padding:.6rem 1.2rem;border:0;border-radius:8px;background:#5b47e0;color:#fff;font-size:1rem;cursor:pointer}
+ .status{padding:.6rem;border-radius:8px;margin:.5rem 0;font-size:.9rem}
+ .ok{background:#e4f8ec;color:#0a7a3d} .warn{background:#fff3e0;color:#a35b00}
+ small{color:#666}
+</style>
+</head>
+<body>
+<h1>🤖 MirrorBuddy Robot</h1>
+<div id="status" class="status warn">Carico…</div>
+<label>Endpoint Azure Realtime</label>
+<input id="AZURE_OPENAI_REALTIME_ENDPOINT" placeholder="https://<risorsa>.openai.azure.com/"/>
+<label>Azure API key</label>
+<input id="AZURE_OPENAI_REALTIME_API_KEY" type="password" placeholder="(rimane solo sul robot)"/>
+<label>Deployment realtime</label>
+<input id="AZURE_OPENAI_REALTIME_DEPLOYMENT" placeholder="gpt-realtime"/>
+<label>Maestro (chi impersona Buddy)</label>
+<select id="MIRRORBUDDY_MAESTRO_ID"><option value="">— default (italiano) —</option></select>
+<label>Profilo DSA</label>
+<select id="MIRRORBUDDY_DSA_PROFILE">
+ <option value="cerebral">Paralisi cerebrale</option>
+ <option value="dyslexia">Dislessia</option>
+ <option value="dyscalculia">Discalculia</option>
+ <option value="adhd">ADHD</option>
+ <option value="autism">Autismo</option>
+ <option value="motor">Motorio</option>
+ <option value="visual">Visivo</option>
+ <option value="auditory">Uditivo</option>
+ <option value="default">Nessuno</option>
+</select>
+<label>Nome dello studente</label>
+<input id="MIRRORBUDDY_STUDENT_NAME" placeholder="Mario"/>
+<button onclick="save()">Salva</button>
+<p><small>La chiave Azure resta solo su questo robot (file .env locale).</small></p>
+<script>
+async function load(){
+ const s=await (await fetch('./api/status')).json();
+ const box=document.getElementById('status');
+ if(s.ready){box.className='status ok';box.textContent='✅ Pronto';}
+ else{box.className='status warn';box.textContent='⚠️ Manca: '+(s.missing||[]).join(', ');}
+ for(const k of ['MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME']){
+  if(s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName']) document.getElementById(k).value=s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName'];
+ }
+ try{
+  const m=await (await fetch('./api/maestri')).json();
+  const sel=document.getElementById('MIRRORBUDDY_MAESTRO_ID');
+  (m.maestri||[]).forEach(x=>{const o=document.createElement('option');o.value=x.id;o.textContent=x.name+' — '+x.subject+' ('+x.voice+')';sel.appendChild(o);});
+  if(s.maestroId) sel.value=s.maestroId;
+ }catch(e){}
+}
+async function save(){
+ const ids=['AZURE_OPENAI_REALTIME_ENDPOINT','AZURE_OPENAI_REALTIME_API_KEY','AZURE_OPENAI_REALTIME_DEPLOYMENT','MIRRORBUDDY_MAESTRO_ID','MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME'];
+ const body={};ids.forEach(i=>{const v=document.getElementById(i).value.trim();if(v)body[i]=v;});
+ const r=await (await fetch('./api/config',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)})).json();
+ load();
+ alert(r.ok?'Salvato!':'Errore: '+(r.error||'?'));
+}
+load();
+</script>
+</body>
+</html>
+"""

--- a/robot/reachy_mini_mirrorbuddy/settings_ui.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_ui.py
@@ -70,7 +70,7 @@ def mount_settings_routes(app, instance_path: str | None) -> None:
             return JSONResponse({"maestri": items})
         except Exception as e:
             logger.warning("maestri fetch failed: %s", e)
-            return JSONResponse({"maestri": [], "error": str(e)}, status_code=502)
+            return JSONResponse({"maestri": [], "error": "upstream unavailable"}, status_code=502)
 
     @app.post("/api/config")
     async def save_config(request: Request) -> JSONResponse:
@@ -86,8 +86,11 @@ def mount_settings_routes(app, instance_path: str | None) -> None:
             _write_env(env_path, updates)
         except Exception as e:
             logger.error("failed to write .env: %s", e)
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse({"ok": False, "error": "could not save configuration"}, status_code=500)
 
+        # Reload from the instance .env we just wrote (not the process cwd), so the
+        # first-run wait loop in main.py sees the new Azure keys without a restart.
+        config.env_path = str(env_path)
         config.reload()
         return JSONResponse({"ok": True, "ready": not config.missing(), "missing": config.missing()})
 

--- a/robot/reachy_mini_mirrorbuddy/tools.py
+++ b/robot/reachy_mini_mirrorbuddy/tools.py
@@ -1,0 +1,104 @@
+"""Realtime tool (function-calling) schemas and Maestro resolution.
+
+These tools let the student drive everything by voice — no screen needed:
+- ``list_professors``   → Buddy enumerates who is available.
+- ``call_professor``    → switch to another MirrorBuddy Maestro (persona + voice).
+- ``look_at_homework``  → capture one camera frame so Buddy can read the exercise.
+
+The schemas are sent in ``session.update`` and the model calls them autonomously.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .mirrorbuddy_client import Maestro
+
+TOOL_SCHEMAS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "name": "list_professors",
+        "description": (
+            "Elenca i professori (Maestri) MirrorBuddy disponibili con la loro materia. "
+            "Usalo quando lo studente chiede chi c'e' o con chi puo' parlare."
+        ),
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "type": "function",
+        "name": "call_professor",
+        "description": (
+            "Passa la conversazione a un altro professore MirrorBuddy, cambiando persona e voce. "
+            "Usalo quando lo studente chiede un altro professore o un'altra materia "
+            "(es. 'voglio matematica', 'chiama Galileo', 'parliamo di arte')."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Nome del professore o materia richiesta (es. 'Galileo', 'matematica', 'storia').",
+                }
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "type": "function",
+        "name": "look_at_homework",
+        "description": (
+            "Scatta una foto con la telecamera per guardare il compito o l'esercizio che lo studente mostra, "
+            "poi leggilo e aiuta. Annuncia sempre a voce che stai guardando prima di usarlo."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "Cosa guardare o su cosa aiutare (es. 'leggi il problema', 'controlla l'operazione').",
+                }
+            },
+            "required": [],
+        },
+    },
+]
+
+
+def _norm(s: str) -> str:
+    return " ".join(str(s or "").lower().split())
+
+
+def resolve_maestro(maestri: list[Maestro], query: str) -> Maestro | None:
+    """Best-effort match of a spoken query to a Maestro by name/subject/specialty."""
+    q = _norm(query)
+    if not q or not maestri:
+        return None
+
+    # 1) exact id / name / display name.
+    for m in maestri:
+        if q in (_norm(m.id), _norm(m.name), _norm(m.display_name)):
+            return m
+    # 2) query mentions a professor name (or vice-versa).
+    for m in maestri:
+        name = _norm(m.display_name) or _norm(m.name)
+        if name and (name in q or q in name):
+            return m
+    # 3) subject / specialty contains the query token(s).
+    tokens = [t for t in q.split() if len(t) > 2]
+    best: tuple[int, Maestro] | None = None
+    for m in maestri:
+        hay = f"{_norm(m.subject)} {_norm(m.specialty)} {_norm(m.teaching_style)}"
+        score = sum(1 for t in tokens if t in hay)
+        if score and (best is None or score > best[0]):
+            best = (score, m)
+    return best[1] if best else None
+
+
+def professors_summary(maestri: list[Maestro], limit: int = 26) -> str:
+    """A compact spoken-friendly list of professors and their subjects."""
+    parts = []
+    for m in maestri[:limit]:
+        name = m.display_name or m.name
+        subject = m.subject or m.specialty
+        parts.append(f"{name} ({subject})" if subject else name)
+    return "; ".join(parts)

--- a/robot/reachy_mini_mirrorbuddy/tools.py
+++ b/robot/reachy_mini_mirrorbuddy/tools.py
@@ -47,15 +47,20 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
         "type": "function",
         "name": "look_at_homework",
         "description": (
-            "Scatta una foto con la telecamera per guardare il compito o l'esercizio che lo studente mostra, "
-            "poi leggilo e aiuta. Annuncia sempre a voce che stai guardando prima di usarlo."
+            "Scatta una foto con la telecamera per guardare cio' che lo studente mostra e aiutarlo: "
+            "un compito o esercizio, la pagina di un quaderno o di un libro appoggiato sul tavolo, "
+            "lo schermo del computer, una mappa o una figura. Leggi cosa c'e' scritto e aiuta. "
+            "Annuncia sempre a voce che stai guardando prima di usarlo."
         ),
         "parameters": {
             "type": "object",
             "properties": {
                 "question": {
                     "type": "string",
-                    "description": "Cosa guardare o su cosa aiutare (es. 'leggi il problema', 'controlla l'operazione').",
+                    "description": (
+                        "Cosa guardare o su cosa aiutare (es. 'leggi il problema', 'che pagina e' del libro', "
+                        "'controlla l'operazione', 'cosa c'e' sullo schermo')."
+                    ),
                 }
             },
             "required": [],


### PR DESCRIPTION
Type: Feature · 19 files, +2158 · robot/ only (no web app changes)

## What & why

MirrorBuddy today is a screen-based Italian tutor for kids with DSA (dyslexia,
dyscalculia). This PR gives it a **body**: a full app for the HuggingFace
**Reachy Mini** robot so the same tutor (26 Maestri personas, Azure OpenAI
Realtime voices, DSA profiles) becomes a physical desk companion with **eyes,
ears, a mouth and movement** — no screen required.

Built and validated live on Roberto's wireless Reachy Mini (RPi CM4,
`reachy_mini 1.9.0`).

## Highlights

- **Speech-to-speech** via Azure OpenAI Realtime (WebRTC) — same voices/personas
  as the web app, low-latency real-time interaction.
- **Everything by voice, no screen**: switch professor/subject, trigger features,
  organise the study session — all spoken. Starts **neutral** with the child's
  chosen Buddy (not a hard-coded persona).
- **Vision**: camera can *look at the homework* on request to help with exercises;
  **face-follow** while listening (privacy-first — the camera never streams, grabs
  a single frame only on an explicit `look_at_homework`, nothing persisted).
- **Movement**: full-body motion mapped to speech/turn-taking, calmer amplitude
  while speaking so it doesn't distract the student; visible wake gesture.
- **Deterministic stop (accessibility-critical)**: on "basta/zitto/fermati/aspetta/
  pausa" the robot goes **silent immediately** via a hard local audio interrupt
  (`audio.clear_player()`), with **no auto-resume** — insistence stresses the child.

## Module map (`robot/reachy_mini_mirrorbuddy/`)

- `main.py` — app entrypoint / session loop
- `azure_realtime.py` — Azure Realtime WebRTC client
- `audio_io.py` / `rt_messages.py` — mic/speaker I/O + realtime event handling
- `controller.py` / `movements.py` — motion orchestration + gesture library
- `camera.py` — single-frame capture for homework/face-follow
- `prompt_builder.py` / `dsa.py` — persona + DSA-profile prompt assembly
- `tools.py` — voice-invokable tools (switch professor, look at homework, …)
- `safety.py` — stop-word interrupt logic
- `settings_ui.py` — local settings server
- `config.py` — env-driven configuration

## Docs & store

- `robot/README.md`: setup, module map, privacy model, HuggingFace **app-store
  card** (front-matter title/emoji/tags/thumbnail), buy link.

## Testing

- Validated live on hardware (voice, professor switching, vision, movement,
  deterministic stop all confirmed by the user).
- Robot code follows the repo's 250-line-per-file limit.

## Notes for reviewers

- Self-contained under `robot/`; **no changes to the web app** — zero blast radius
  on production MirrorBuddy.
- Device **pairing** with the logged-in child's account is a **follow-up PR**
  stacked on this branch (`feat/reachy-mini-mirrorbuddy-pairing`).

Co-authored-by: Copilot
