### PR TITLE
feat(pairing): bind Reachy Mini to the logged-in child's MirrorBuddy profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/AI%20Maestri-26-purple" alt="26 AI Maestri">
   <img src="https://img.shields.io/badge/DSA%20Profiles-7-orange" alt="7 DSA Profiles">
+  <a href="robot/README.md"><img src="https://img.shields.io/badge/Reachy%20Mini-Robot%20app-5b47e0?logo=huggingface" alt="Reachy Mini Robot"></a>
   <img src="https://img.shields.io/badge/GDPR-Compliant-blue" alt="GDPR Compliant">
   <img src="https://img.shields.io/badge/Child%20Safe-5%20Layer%20Security-brightgreen" alt="Child Safe">
   <a href="docs/compliance/PROFESSORS-CONSTITUTION.md"><img src="https://img.shields.io/badge/Amodei%202026-Constitution%20Compliant-blueviolet" alt="Amodei Constitution"></a>
@@ -276,6 +277,39 @@ npx cap open android  # Opens Android Studio
 ```
 
 **→ Complete mobile build guide: [docs/mobile/BUILD-GUIDE.md](docs/mobile/BUILD-GUIDE.md)**
+
+---
+
+## Reachy Mini Robot 🤖
+
+MirrorBuddy also has a **body**. The [`robot/`](robot/) app turns a **Reachy Mini** — the
+open-source desktop robot by [Hugging Face](https://huggingface.co/blog/reachy-mini) &
+[Pollen Robotics](https://www.reachy-mini.org/) — into a MirrorBuddy Maestro with
+**👁️ eyes** (camera), **👂 ears** (microphone), **👄 mouth** (speaker) and **🤸 movement**.
+
+<p align="center">
+  <a href="https://www.reachy-mini.org/">
+    <img src="https://huggingface.co/blog/assets/reachy-mini/thumbnail.jpg" alt="Reachy Mini robot" width="520">
+  </a>
+</p>
+
+It reuses **MirrorBuddy's brain 1:1**: the same 26 Maestri (fetched live from
+`/api/maestri`), the same Azure OpenAI **Realtime** speech-to-speech voices, the same
+child-safety constitution and the 7 DSA accessibility profiles — everything by **voice**,
+no screen needed.
+
+- **Change professor/subject by voice** — _«voglio matematica»_, _«chiama Galileo»_.
+- **Look at homework** — _«guarda questo compito»_ captures one frame; Buddy reads it and helps.
+- **Accessibility-first** — deterministic _"basta / fermati"_ stop, calm motion, patient
+  turn-taking for children with dyslexia, dyscalculia or cerebral palsy.
+- **Device pairing** — from **Settings → Integrations → "Collega un robot"**, generate a
+  6-digit code and type it on the robot. It binds to the logged-in child's profile using a
+  scoped, revocable **device token** — the child's password never leaves their computer.
+
+**🛒 Get the robot:** [Reachy Mini](https://www.reachy-mini.org/buy.html) — **Lite $299**
+(USB-tethered) or **Wireless $449** (on-board compute).
+
+**→ Robot app & setup guide: [robot/README.md](robot/README.md)**
 
 ---
 
@@ -565,6 +599,7 @@ print(f'Last 7 days: \${result.total_cost:.2f}')
 | [TROUBLESHOOTING.md](TROUBLESHOOTING.md)             | Common issues and solutions               |
 | [ARCHITECTURE.md](ARCHITECTURE.md)                   | Technical architecture details            |
 | [ARCHITECTURE-DIAGRAMS.md](ARCHITECTURE-DIAGRAMS.md) | Visual architecture (24 Mermaid diagrams) |
+| [robot/README.md](robot/README.md)                   | Reachy Mini robot app (voice + embodiment) |
 | [CONTRIBUTING.md](CONTRIBUTING.md)                   | Contribution guidelines                   |
 | [CLAUDE.md](CLAUDE.md)                               | Developer quick reference                 |
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ no screen needed.
 (USB-tethered) or **Wireless $449** (on-board compute).
 
 **→ Robot app & setup guide: [robot/README.md](robot/README.md)**
+**→ Feature overview (also for families without a robot): [docs/reachy-mini-robot.md](docs/reachy-mini-robot.md)**
 
 ---
 

--- a/apps/web/messages/de/settings.json
+++ b/apps/web/messages/de/settings.json
@@ -1283,7 +1283,22 @@
       "pairedOn": "Gekoppelt am {date}",
       "pendingPairing": "Wartet auf Kopplung",
       "unpair": "Trennen",
-      "privacyNote": "Der Roboter erhält nur ein eigenes Token und das Lernprofil (Name, bevorzugter Lehrer, Barrierefreiheitseinstellungen). Kein Passwort verlässt dieses Gerät. Sie können den Roboter jederzeit trennen."
+      "privacyNote": "Der Roboter erhält nur ein eigenes Token und das Lernprofil (Name, bevorzugter Lehrer, Barrierefreiheitseinstellungen). Kein Passwort verlässt dieses Gerät. Sie können den Roboter jederzeit trennen.",
+      "whatIsTitle": "Was ist der Reachy-Mini-Roboter?",
+      "whatIsBody": "Reachy Mini ist ein kleiner Tischroboter von Hugging Face, der zum Körper von MirrorBuddy wird: derselbe Tutor, dieselbe Stimme und dieselben Lehrer, aber mit Augen, die dir folgen, Ohren, die zuhören, einer Stimme, die spricht, und ausdrucksstarken Bewegungen. Kein Bildschirm nötig: Er wird allein per Stimme bedient.",
+      "featuresTitle": "Was er kann",
+      "featureEyes": "Augen, die dem Gesicht des Kindes beim Zuhören folgen",
+      "featureVoice": "Echtzeit-Stimme, genau wie MirrorBuddy im Web",
+      "featureCamera": "Eine Kamera, um die Hausaufgaben auf dem Tisch anzusehen und zu helfen",
+      "featureMovement": "Ausdrucksstarke Bewegungen, an den Stil jedes Lehrers angepasst",
+      "featureStop": "Stoppt sofort, wenn du „Stopp“ sagst — kein Stress",
+      "howItWorksTitle": "So verbindest du deinen Roboter",
+      "step1": "Erzeuge unten einen Kopplungscode.",
+      "step2": "Gib den Code am Roboter auf seiner Einstellungsseite ein.",
+      "step3": "Der Roboter startet bereits mit dem Profil deines Kindes personalisiert.",
+      "noRobotYet": "Noch keinen Roboter?",
+      "buyCta": "Einen Reachy Mini kaufen",
+      "buyNote": "Reachy Mini Lite ab etwa 299 $, Wireless-Version ab etwa 449 $, auf reachy-mini.org."
     }
   }
 }

--- a/apps/web/messages/de/settings.json
+++ b/apps/web/messages/de/settings.json
@@ -1268,6 +1268,22 @@
       "saved": "Gespeichert!",
       "saveError": "Fehler beim Speichern der Kontakte",
       "privacyNote": "Diese Daten werden ausschliesslich fuer Sicherheitsbenachrichtigungen verwendet und nicht an Dritte weitergegeben."
+    },
+    "robotPairing": {
+      "title": "Roboter verbinden",
+      "description": "Verwandeln Sie einen Reachy Mini in MirrorBuddys Körper: gleiche Stimme, gleiche Lehrer, jetzt mit Augen, Ohren und Bewegung. Der Roboter nutzt das Profil Ihres Kindes, niemals seine Zugangsdaten.",
+      "generateCode": "Kopplungscode erzeugen",
+      "codeHint": "Geben Sie diesen Code am Roboter ein, um ihn zu verbinden:",
+      "codeExpires": "Der Code läuft in 10 Minuten ab.",
+      "copy": "Code kopieren",
+      "pairedRobots": "Gekoppelte Roboter",
+      "loading": "Wird geladen…",
+      "noRobots": "Keine Roboter verbunden.",
+      "unnamedRobot": "Unbenannter Roboter",
+      "pairedOn": "Gekoppelt am {date}",
+      "pendingPairing": "Wartet auf Kopplung",
+      "unpair": "Trennen",
+      "privacyNote": "Der Roboter erhält nur ein eigenes Token und das Lernprofil (Name, bevorzugter Lehrer, Barrierefreiheitseinstellungen). Kein Passwort verlässt dieses Gerät. Sie können den Roboter jederzeit trennen."
     }
   }
 }

--- a/apps/web/messages/en/settings.json
+++ b/apps/web/messages/en/settings.json
@@ -1283,7 +1283,22 @@
       "pairedOn": "Paired on {date}",
       "pendingPairing": "Waiting to pair",
       "unpair": "Unpair",
-      "privacyNote": "The robot only receives a dedicated token and the learning profile (name, preferred teacher, accessibility settings). No password ever leaves this device. You can unpair the robot at any time."
+      "privacyNote": "The robot only receives a dedicated token and the learning profile (name, preferred teacher, accessibility settings). No password ever leaves this device. You can unpair the robot at any time.",
+      "whatIsTitle": "What is the Reachy Mini robot?",
+      "whatIsBody": "Reachy Mini is a small desktop robot from Hugging Face that becomes MirrorBuddy's body: the same tutor, the same voice and the same teachers, but with eyes that follow you, ears that listen, a voice that speaks and expressive movement. No screen needed: you use it with your voice alone.",
+      "featuresTitle": "What it can do",
+      "featureEyes": "Eyes that follow the student's face while listening",
+      "featureVoice": "Real-time voice, just like MirrorBuddy on the web",
+      "featureCamera": "A camera to look at the homework on the desk and help",
+      "featureMovement": "Expressive movement adapted to each teacher's style",
+      "featureStop": "Stops immediately when you say “stop” — no stress",
+      "howItWorksTitle": "How to connect your robot",
+      "step1": "Generate a pairing code below.",
+      "step2": "Type the code on the robot, in its settings page.",
+      "step3": "The robot starts already personalised with your child's profile.",
+      "noRobotYet": "Don't have a robot yet?",
+      "buyCta": "Buy a Reachy Mini",
+      "buyNote": "Reachy Mini Lite from about $299, Wireless version from about $449, at reachy-mini.org."
     }
   }
 }

--- a/apps/web/messages/en/settings.json
+++ b/apps/web/messages/en/settings.json
@@ -1268,6 +1268,22 @@
       "saved": "Saved!",
       "saveError": "Error saving contacts",
       "privacyNote": "This data is used exclusively for safety notifications and will not be shared with third parties."
+    },
+    "robotPairing": {
+      "title": "Connect a robot",
+      "description": "Turn a Reachy Mini into MirrorBuddy's body: same voice, same teachers, now with eyes, ears and movement. The robot uses your child's profile, never their credentials.",
+      "generateCode": "Generate pairing code",
+      "codeHint": "Type this code on the robot to connect it:",
+      "codeExpires": "The code expires in 10 minutes.",
+      "copy": "Copy code",
+      "pairedRobots": "Paired robots",
+      "loading": "Loading…",
+      "noRobots": "No robots connected.",
+      "unnamedRobot": "Unnamed robot",
+      "pairedOn": "Paired on {date}",
+      "pendingPairing": "Waiting to pair",
+      "unpair": "Unpair",
+      "privacyNote": "The robot only receives a dedicated token and the learning profile (name, preferred teacher, accessibility settings). No password ever leaves this device. You can unpair the robot at any time."
     }
   }
 }

--- a/apps/web/messages/es/settings.json
+++ b/apps/web/messages/es/settings.json
@@ -1268,6 +1268,22 @@
       "saved": "Guardado!",
       "saveError": "Error al guardar los contactos",
       "privacyNote": "Estos datos se utilizan exclusivamente para notificaciones de seguridad y no se compartiran con terceros."
+    },
+    "robotPairing": {
+      "title": "Conectar un robot",
+      "description": "Convierte un Reachy Mini en el cuerpo de MirrorBuddy: misma voz, mismos profesores, ahora con ojos, oídos y movimiento. El robot usa el perfil de tu hijo, nunca sus credenciales.",
+      "generateCode": "Generar código de vinculación",
+      "codeHint": "Escribe este código en el robot para conectarlo:",
+      "codeExpires": "El código caduca en 10 minutos.",
+      "copy": "Copiar código",
+      "pairedRobots": "Robots vinculados",
+      "loading": "Cargando…",
+      "noRobots": "Ningún robot conectado.",
+      "unnamedRobot": "Robot sin nombre",
+      "pairedOn": "Vinculado el {date}",
+      "pendingPairing": "Esperando vinculación",
+      "unpair": "Desvincular",
+      "privacyNote": "El robot solo recibe un token propio y el perfil de aprendizaje (nombre, profesor preferido, ajustes de accesibilidad). Ninguna contraseña sale de este dispositivo. Puedes desvincular el robot en cualquier momento."
     }
   }
 }

--- a/apps/web/messages/es/settings.json
+++ b/apps/web/messages/es/settings.json
@@ -1283,7 +1283,22 @@
       "pairedOn": "Vinculado el {date}",
       "pendingPairing": "Esperando vinculación",
       "unpair": "Desvincular",
-      "privacyNote": "El robot solo recibe un token propio y el perfil de aprendizaje (nombre, profesor preferido, ajustes de accesibilidad). Ninguna contraseña sale de este dispositivo. Puedes desvincular el robot en cualquier momento."
+      "privacyNote": "El robot solo recibe un token propio y el perfil de aprendizaje (nombre, profesor preferido, ajustes de accesibilidad). Ninguna contraseña sale de este dispositivo. Puedes desvincular el robot en cualquier momento.",
+      "whatIsTitle": "¿Qué es el robot Reachy Mini?",
+      "whatIsBody": "Reachy Mini es un pequeño robot de escritorio de Hugging Face que se convierte en el cuerpo de MirrorBuddy: el mismo tutor, la misma voz y los mismos profesores, pero con ojos que te siguen, oídos que escuchan, una voz que habla y movimientos expresivos. No hace falta pantalla: se usa solo con la voz.",
+      "featuresTitle": "Qué puede hacer",
+      "featureEyes": "Ojos que siguen la cara del estudiante mientras escucha",
+      "featureVoice": "Voz en tiempo real, igual que MirrorBuddy en la web",
+      "featureCamera": "Una cámara para mirar los deberes sobre la mesa y ayudar",
+      "featureMovement": "Movimientos expresivos adaptados al estilo de cada profesor",
+      "featureStop": "Se detiene enseguida cuando dices «basta»: sin estrés",
+      "howItWorksTitle": "Cómo conectar tu robot",
+      "step1": "Genera un código de vinculación abajo.",
+      "step2": "Escribe el código en el robot, en su página de ajustes.",
+      "step3": "El robot arranca ya personalizado con el perfil de tu hijo.",
+      "noRobotYet": "¿Aún no tienes un robot?",
+      "buyCta": "Comprar un Reachy Mini",
+      "buyNote": "Reachy Mini Lite desde unos 299 $, versión Wireless desde unos 449 $, en reachy-mini.org."
     }
   }
 }

--- a/apps/web/messages/fr/settings.json
+++ b/apps/web/messages/fr/settings.json
@@ -1268,6 +1268,22 @@
       "saved": "Enregistre !",
       "saveError": "Erreur lors de l'enregistrement des contacts",
       "privacyNote": "Ces donnees sont utilisees exclusivement pour les notifications de securite et ne seront pas partagees avec des tiers."
+    },
+    "robotPairing": {
+      "title": "Connecter un robot",
+      "description": "Transformez un Reachy Mini en corps de MirrorBuddy : même voix, mêmes professeurs, avec des yeux, des oreilles et des mouvements. Le robot utilise le profil de votre enfant, jamais ses identifiants.",
+      "generateCode": "Générer un code d'association",
+      "codeHint": "Saisissez ce code sur le robot pour le connecter :",
+      "codeExpires": "Le code expire dans 10 minutes.",
+      "copy": "Copier le code",
+      "pairedRobots": "Robots associés",
+      "loading": "Chargement…",
+      "noRobots": "Aucun robot connecté.",
+      "unnamedRobot": "Robot sans nom",
+      "pairedOn": "Associé le {date}",
+      "pendingPairing": "En attente d'association",
+      "unpair": "Dissocier",
+      "privacyNote": "Le robot ne reçoit qu'un jeton dédié et le profil d'apprentissage (nom, professeur préféré, réglages d'accessibilité). Aucun mot de passe ne quitte cet appareil. Vous pouvez dissocier le robot à tout moment."
     }
   }
 }

--- a/apps/web/messages/fr/settings.json
+++ b/apps/web/messages/fr/settings.json
@@ -1283,7 +1283,22 @@
       "pairedOn": "Associé le {date}",
       "pendingPairing": "En attente d'association",
       "unpair": "Dissocier",
-      "privacyNote": "Le robot ne reçoit qu'un jeton dédié et le profil d'apprentissage (nom, professeur préféré, réglages d'accessibilité). Aucun mot de passe ne quitte cet appareil. Vous pouvez dissocier le robot à tout moment."
+      "privacyNote": "Le robot ne reçoit qu'un jeton dédié et le profil d'apprentissage (nom, professeur préféré, réglages d'accessibilité). Aucun mot de passe ne quitte cet appareil. Vous pouvez dissocier le robot à tout moment.",
+      "whatIsTitle": "Qu'est-ce que le robot Reachy Mini ?",
+      "whatIsBody": "Reachy Mini est un petit robot de bureau de Hugging Face qui devient le corps de MirrorBuddy : le même tuteur, la même voix et les mêmes professeurs, mais avec des yeux qui vous suivent, des oreilles qui écoutent, une voix qui parle et des mouvements expressifs. Aucun écran nécessaire : il s'utilise uniquement à la voix.",
+      "featuresTitle": "Ce qu'il peut faire",
+      "featureEyes": "Des yeux qui suivent le visage de l'élève pendant qu'il écoute",
+      "featureVoice": "Voix en temps réel, comme MirrorBuddy sur le web",
+      "featureCamera": "Une caméra pour regarder les devoirs sur le bureau et aider",
+      "featureMovement": "Des mouvements expressifs adaptés au style de chaque professeur",
+      "featureStop": "S'arrête immédiatement quand vous dites « stop » : aucun stress",
+      "howItWorksTitle": "Comment connecter votre robot",
+      "step1": "Générez un code d'association ci-dessous.",
+      "step2": "Saisissez le code sur le robot, dans sa page de réglages.",
+      "step3": "Le robot démarre déjà personnalisé avec le profil de votre enfant.",
+      "noRobotYet": "Vous n'avez pas encore de robot ?",
+      "buyCta": "Acheter un Reachy Mini",
+      "buyNote": "Reachy Mini Lite à partir d'environ 299 $, version Wireless à partir d'environ 449 $, sur reachy-mini.org."
     }
   }
 }

--- a/apps/web/messages/it/settings.json
+++ b/apps/web/messages/it/settings.json
@@ -1283,7 +1283,22 @@
       "pairedOn": "Collegato il {date}",
       "pendingPairing": "In attesa di collegamento",
       "unpair": "Scollega",
-      "privacyNote": "Il robot riceve solo un token dedicato e il profilo di apprendimento (nome, professore preferito, impostazioni di accessibilità). Nessuna password lascia mai questo dispositivo. Puoi scollegare il robot in qualsiasi momento."
+      "privacyNote": "Il robot riceve solo un token dedicato e il profilo di apprendimento (nome, professore preferito, impostazioni di accessibilità). Nessuna password lascia mai questo dispositivo. Puoi scollegare il robot in qualsiasi momento.",
+      "whatIsTitle": "Cos'è il robot Reachy Mini?",
+      "whatIsBody": "Reachy Mini è un piccolo robot da scrivania di Hugging Face che diventa il corpo di MirrorBuddy: lo stesso tutor, la stessa voce e gli stessi professori, ma con occhi che ti seguono, orecchie che ascoltano, una voce che parla e movimenti espressivi. Non serve uno schermo: si usa solo con la voce.",
+      "featuresTitle": "Cosa può fare",
+      "featureEyes": "Occhi che seguono il volto dello studente mentre ascolta",
+      "featureVoice": "Voce in tempo reale, come MirrorBuddy sul web",
+      "featureCamera": "Telecamera per guardare i compiti sul tavolo e aiutare",
+      "featureMovement": "Movimenti espressivi adattati allo stile del professore",
+      "featureStop": "Si ferma subito quando dici «basta»: nessuno stress",
+      "howItWorksTitle": "Come collegare il tuo robot",
+      "step1": "Genera un codice di collegamento qui sotto.",
+      "step2": "Digita il codice sul robot, nella sua pagina delle impostazioni.",
+      "step3": "Il robot parte già personalizzato con il profilo di tuo figlio.",
+      "noRobotYet": "Non hai ancora un robot?",
+      "buyCta": "Acquista un Reachy Mini",
+      "buyNote": "Reachy Mini Lite da circa 299 $, versione Wireless da circa 449 $, su reachy-mini.org."
     }
   }
 }

--- a/apps/web/messages/it/settings.json
+++ b/apps/web/messages/it/settings.json
@@ -1268,6 +1268,22 @@
       "saved": "Salvato!",
       "saveError": "Errore nel salvataggio dei contatti",
       "privacyNote": "Questi dati vengono utilizzati esclusivamente per notifiche di sicurezza e non verranno condivisi con terze parti."
+    },
+    "robotPairing": {
+      "title": "Collega un robot",
+      "description": "Trasforma un Reachy Mini nel corpo di MirrorBuddy: stessa voce, stessi professori, con occhi, orecchie e movimenti. Il robot usa il profilo di tuo figlio, mai le sue credenziali.",
+      "generateCode": "Genera codice di collegamento",
+      "codeHint": "Digita questo codice sul robot per collegarlo:",
+      "codeExpires": "Il codice scade tra 10 minuti.",
+      "copy": "Copia codice",
+      "pairedRobots": "Robot collegati",
+      "loading": "Caricamento…",
+      "noRobots": "Nessun robot collegato.",
+      "unnamedRobot": "Robot senza nome",
+      "pairedOn": "Collegato il {date}",
+      "pendingPairing": "In attesa di collegamento",
+      "unpair": "Scollega",
+      "privacyNote": "Il robot riceve solo un token dedicato e il profilo di apprendimento (nome, professore preferito, impostazioni di accessibilità). Nessuna password lascia mai questo dispositivo. Puoi scollegare il robot in qualsiasi momento."
     }
   }
 }

--- a/apps/web/prisma/migrations/20260620000000_add_robot_device/migration.sql
+++ b/apps/web/prisma/migrations/20260620000000_add_robot_device/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable: RobotDevice binds a Reachy Mini to a MirrorBuddy account
+CREATE TABLE "RobotDevice" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "label" TEXT,
+    "pairCodeHash" TEXT,
+    "pairCodeExpiresAt" TIMESTAMP(3),
+    "pairedAt" TIMESTAMP(3),
+    "tokenHash" TEXT,
+    "lastSeenAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RobotDevice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RobotDevice_pairCodeHash_key" ON "RobotDevice"("pairCodeHash");
+CREATE UNIQUE INDEX "RobotDevice_tokenHash_key" ON "RobotDevice"("tokenHash");
+CREATE INDEX "RobotDevice_userId_idx" ON "RobotDevice"("userId");
+CREATE INDEX "RobotDevice_revokedAt_idx" ON "RobotDevice"("revokedAt");
+
+-- AddForeignKey
+ALTER TABLE "RobotDevice" ADD CONSTRAINT "RobotDevice_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema/robot-device.prisma
+++ b/apps/web/prisma/schema/robot-device.prisma
@@ -1,0 +1,29 @@
+/// Robot Device Pairing
+/// Binds a physical Reachy Mini (MirrorBuddy Robot) to a MirrorBuddy account so
+/// the voice-only robot can load the logged-in child's profile without a screen.
+/// A short-lived 6-digit code (hashed) is exchanged for a long-lived, revocable
+/// device token (hashed). No plaintext secret is ever stored.
+
+model RobotDevice {
+  id     String @id @default(cuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+
+  label String? // Human label, e.g. "Reachy in cameretta"
+
+  // Pairing handshake: 6-digit code, hashed, short expiry, cleared after pairing.
+  pairCodeHash      String?   @unique
+  pairCodeExpiresAt DateTime?
+  pairedAt          DateTime?
+
+  // Long-lived device credential: random token, stored hashed, revocable.
+  tokenHash String?   @unique
+  lastSeenAt DateTime?
+  revokedAt  DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([revokedAt])
+}

--- a/apps/web/prisma/schema/user.prisma
+++ b/apps/web/prisma/schema/user.prisma
@@ -108,6 +108,9 @@ model User {
   // Password Reset Tokens (Plan 125)
   passwordResetTokens PasswordResetToken[]
 
+  // Paired Reachy Mini robots (voice embodiment)
+  robotDevices RobotDevice[]
+
   @@index([emailHash])
 }
 

--- a/apps/web/src/app/api/devices/[id]/route.ts
+++ b/apps/web/src/app/api/devices/[id]/route.ts
@@ -1,0 +1,29 @@
+/**
+ * DELETE /api/devices/[id] — revoke (unpair) a robot the user owns.
+ */
+import { NextResponse } from "next/server";
+import {
+  pipe,
+  withSentry,
+  withCSRF,
+  withAuth,
+  withRateLimit,
+} from "@/lib/api/middlewares";
+import { RATE_LIMITS } from "@/lib/rate-limit";
+import { revokeDevice } from "@/lib/devices/device-service";
+
+export const revalidate = 0;
+
+export const DELETE = pipe(
+  withSentry("/api/devices/[id]"),
+  withCSRF,
+  withAuth,
+  withRateLimit(RATE_LIMITS.GENERAL),
+)(async (ctx) => {
+  const { id } = await ctx.params;
+  const revoked = await revokeDevice(ctx.userId!, id);
+  if (!revoked) {
+    return NextResponse.json({ error: "Device not found" }, { status: 404 });
+  }
+  return NextResponse.json({ success: true });
+});

--- a/apps/web/src/app/api/devices/me/route.test.ts
+++ b/apps/web/src/app/api/devices/me/route.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for GET /api/devices/me (robot fetches profile via device token).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api/middlewares", () => ({
+  pipe:
+    (..._mw: unknown[]) =>
+    (handler: unknown) =>
+      handler,
+  withSentry: () => vi.fn(),
+  withRateLimit: () => vi.fn(),
+}));
+
+vi.mock("@/lib/devices/device-service", () => ({
+  getDeviceProfile: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getDeviceProfile } from "@/lib/devices/device-service";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handler = GET as unknown as (ctx: any) => Promise<Response>;
+const mockProfile = getDeviceProfile as unknown as ReturnType<typeof vi.fn>;
+
+function ctxWith(auth?: string) {
+  return { req: { headers: new Headers(auth ? { authorization: auth } : {}) } };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/devices/me", () => {
+  it("returns 401 when the bearer token is missing", async () => {
+    const res = await handler(ctxWith());
+    expect(res.status).toBe(401);
+    expect(mockProfile).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for an invalid token", async () => {
+    mockProfile.mockResolvedValue(null);
+    const res = await handler(ctxWith("Bearer bad"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the profile for a valid device token", async () => {
+    mockProfile.mockResolvedValue({ name: "Mario", preferredBuddy: "sofia" });
+
+    const res = await handler(ctxWith("Bearer good-token"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.profile.name).toBe("Mario");
+    expect(mockProfile).toHaveBeenCalledWith("good-token");
+  });
+});

--- a/apps/web/src/app/api/devices/me/route.test.ts
+++ b/apps/web/src/app/api/devices/me/route.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/lib/devices/device-service", () => ({
 import { GET } from "./route";
 import { getDeviceProfile } from "@/lib/devices/device-service";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const handler = GET as unknown as (ctx: any) => Promise<Response>;
 const mockProfile = getDeviceProfile as unknown as ReturnType<typeof vi.fn>;
 

--- a/apps/web/src/app/api/devices/me/route.ts
+++ b/apps/web/src/app/api/devices/me/route.ts
@@ -1,0 +1,29 @@
+/**
+ * GET /api/devices/me
+ *
+ * The robot fetches the paired child's profile scope using its device token,
+ * passed as `Authorization: Bearer <token>`. Read-only; no session/CSRF.
+ */
+import { NextResponse } from "next/server";
+import { pipe, withSentry, withRateLimit } from "@/lib/api/middlewares";
+import { RATE_LIMITS } from "@/lib/rate-limit";
+import { getDeviceProfile } from "@/lib/devices/device-service";
+
+export const revalidate = 0;
+
+export const GET = pipe(
+  withSentry("/api/devices/me"),
+  withRateLimit(RATE_LIMITS.DEVICE_ME),
+)(async (ctx) => {
+  const header = ctx.req.headers.get("authorization") || "";
+  const token = header.startsWith("Bearer ") ? header.slice(7).trim() : "";
+  if (!token) {
+    return NextResponse.json({ error: "Missing device token" }, { status: 401 });
+  }
+
+  const profile = await getDeviceProfile(token);
+  if (!profile) {
+    return NextResponse.json({ error: "Invalid device token" }, { status: 401 });
+  }
+  return NextResponse.json({ profile });
+});

--- a/apps/web/src/app/api/devices/pair-code/route.test.ts
+++ b/apps/web/src/app/api/devices/pair-code/route.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/lib/devices/device-service", () => ({
 import { POST } from "./route";
 import { createPairingCode } from "@/lib/devices/device-service";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const handler = POST as unknown as (ctx: any) => Promise<Response>;
 const mockCreate = createPairingCode as unknown as ReturnType<typeof vi.fn>;
 

--- a/apps/web/src/app/api/devices/pair-code/route.test.ts
+++ b/apps/web/src/app/api/devices/pair-code/route.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for POST /api/devices/pair-code.
+ * The middleware chain is stubbed; we assert the handler's own behaviour.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api/middlewares", () => ({
+  pipe:
+    (..._mw: unknown[]) =>
+    (handler: unknown) =>
+      handler,
+  withSentry: () => vi.fn(),
+  withCSRF: vi.fn(),
+  withAuth: vi.fn(),
+  withRateLimit: () => vi.fn(),
+}));
+
+vi.mock("@/lib/devices/device-service", () => ({
+  createPairingCode: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createPairingCode } from "@/lib/devices/device-service";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handler = POST as unknown as (ctx: any) => Promise<Response>;
+const mockCreate = createPairingCode as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /api/devices/pair-code", () => {
+  it("returns the generated code for the authenticated user", async () => {
+    const expiresAt = new Date(Date.now() + 60000);
+    mockCreate.mockResolvedValue({ code: "123456", expiresAt });
+
+    const res = await handler({
+      userId: "user-1",
+      req: { json: async () => ({ label: "Cameretta" }) },
+    });
+    const body = await res.json();
+
+    expect(body.code).toBe("123456");
+    expect(body.expiresAt).toBe(expiresAt.toISOString());
+    expect(mockCreate).toHaveBeenCalledWith("user-1", "Cameretta");
+  });
+
+  it("works without a body (label optional)", async () => {
+    mockCreate.mockResolvedValue({ code: "000000", expiresAt: new Date() });
+
+    const res = await handler({
+      userId: "user-1",
+      req: {
+        json: async () => {
+          throw new Error("no body");
+        },
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockCreate).toHaveBeenCalledWith("user-1", undefined);
+  });
+});

--- a/apps/web/src/app/api/devices/pair-code/route.ts
+++ b/apps/web/src/app/api/devices/pair-code/route.ts
@@ -1,0 +1,40 @@
+/**
+ * POST /api/devices/pair-code
+ *
+ * Authenticated user generates a short-lived 6-digit pairing code to bind a
+ * Reachy Mini robot to their MirrorBuddy account. Body: { label?: string }.
+ */
+import { NextResponse } from "next/server";
+import {
+  pipe,
+  withSentry,
+  withCSRF,
+  withAuth,
+  withRateLimit,
+} from "@/lib/api/middlewares";
+import { RATE_LIMITS } from "@/lib/rate-limit";
+import { createPairingCode } from "@/lib/devices/device-service";
+
+export const revalidate = 0;
+
+export const POST = pipe(
+  withSentry("/api/devices/pair-code"),
+  withCSRF,
+  withAuth,
+  withRateLimit(RATE_LIMITS.DEVICE_PAIR_CODE),
+)(async (ctx) => {
+  const userId = ctx.userId!;
+
+  let label: string | undefined;
+  try {
+    const body: unknown = await ctx.req.json();
+    if (body && typeof (body as { label?: unknown }).label === "string") {
+      label = (body as { label: string }).label;
+    }
+  } catch {
+    // No/invalid body is fine — label is optional.
+  }
+
+  const { code, expiresAt } = await createPairingCode(userId, label);
+  return NextResponse.json({ code, expiresAt: expiresAt.toISOString() });
+});

--- a/apps/web/src/app/api/devices/pair/route.test.ts
+++ b/apps/web/src/app/api/devices/pair/route.test.ts
@@ -16,14 +16,24 @@ vi.mock("@/lib/devices/device-service", () => ({
   redeemPairingCode: vi.fn(),
 }));
 
+vi.mock("@/lib/rate-limit", () => ({
+  RATE_LIMITS: { DEVICE_PAIR: {}, DEVICE_PAIR_GLOBAL: {} },
+  checkRateLimitAsync: vi.fn(),
+}));
+
 import { POST } from "./route";
 import { redeemPairingCode } from "@/lib/devices/device-service";
+import { checkRateLimitAsync } from "@/lib/rate-limit";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const handler = POST as unknown as (ctx: any) => Promise<Response>;
 const mockRedeem = redeemPairingCode as unknown as ReturnType<typeof vi.fn>;
+const mockGlobal = checkRateLimitAsync as unknown as ReturnType<typeof vi.fn>;
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGlobal.mockResolvedValue({ success: true });
+});
 
 describe("POST /api/devices/pair", () => {
   it("returns a device token for a valid code", async () => {
@@ -60,5 +70,14 @@ describe("POST /api/devices/pair", () => {
 
     expect(res.status).toBe(400);
     expect(mockRedeem).toHaveBeenCalledWith("");
+  });
+
+  it("returns 429 when the global brute-force ceiling is hit", async () => {
+    mockGlobal.mockResolvedValue({ success: false });
+
+    const res = await handler({ req: { json: async () => ({ code: "123456" }) } });
+
+    expect(res.status).toBe(429);
+    expect(mockRedeem).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/devices/pair/route.test.ts
+++ b/apps/web/src/app/api/devices/pair/route.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for POST /api/devices/pair (robot redeems a pairing code).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api/middlewares", () => ({
+  pipe:
+    (..._mw: unknown[]) =>
+    (handler: unknown) =>
+      handler,
+  withSentry: () => vi.fn(),
+  withRateLimit: () => vi.fn(),
+}));
+
+vi.mock("@/lib/devices/device-service", () => ({
+  redeemPairingCode: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { redeemPairingCode } from "@/lib/devices/device-service";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handler = POST as unknown as (ctx: any) => Promise<Response>;
+const mockRedeem = redeemPairingCode as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /api/devices/pair", () => {
+  it("returns a device token for a valid code", async () => {
+    mockRedeem.mockResolvedValue({ token: "a".repeat(64), deviceId: "d1" });
+
+    const res = await handler({ req: { json: async () => ({ code: "123456" }) } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.token).toBe("a".repeat(64));
+    expect(body.deviceId).toBe("d1");
+    expect(mockRedeem).toHaveBeenCalledWith("123456");
+  });
+
+  it("returns 400 for an invalid or expired code", async () => {
+    mockRedeem.mockResolvedValue(null);
+
+    const res = await handler({ req: { json: async () => ({ code: "000000" }) } });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid/i);
+  });
+
+  it("returns 400 when the body is missing", async () => {
+    mockRedeem.mockResolvedValue(null);
+
+    const res = await handler({
+      req: {
+        json: async () => {
+          throw new Error("no body");
+        },
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockRedeem).toHaveBeenCalledWith("");
+  });
+});

--- a/apps/web/src/app/api/devices/pair/route.ts
+++ b/apps/web/src/app/api/devices/pair/route.ts
@@ -6,16 +6,27 @@
  */
 import { NextResponse } from "next/server";
 import { pipe, withSentry, withRateLimit } from "@/lib/api/middlewares";
-import { RATE_LIMITS } from "@/lib/rate-limit";
+import { RATE_LIMITS, checkRateLimitAsync } from "@/lib/rate-limit";
 import { redeemPairingCode } from "@/lib/devices/device-service";
 
 export const revalidate = 0;
 
-// eslint-disable-next-line local-rules/require-csrf-mutating-routes -- Machine endpoint: the robot authenticates with the one-time pairing code itself and has no browser session or cookies, so cookie-based CSRF does not apply. Brute-force is bounded by the strict DEVICE_PAIR rate limit and the 10-minute code expiry.
+// SECURITY: machine endpoint. The robot authenticates with the one-time pairing
+// code itself and has no browser session or cookies, so cookie-based CSRF does not
+// apply. Brute-force is bounded by (1) the strict per-IP DEVICE_PAIR rate limit,
+// (2) a global DEVICE_PAIR_GLOBAL ceiling that holds even if per-IP keying is
+// defeated by a spoofed proxy header, and (3) the code's 10-minute expiry. Codes
+// are single-use and stored only as sha256 hashes; redemption is atomic.
 export const POST = pipe(
   withSentry("/api/devices/pair"),
   withRateLimit(RATE_LIMITS.DEVICE_PAIR),
 )(async (ctx) => {
+  // Deployment-independent global brute-force ceiling (constant key, all clients).
+  const global = await checkRateLimitAsync("device-pair:global", RATE_LIMITS.DEVICE_PAIR_GLOBAL);
+  if (!global.success) {
+    return NextResponse.json({ error: "Too many attempts, try again later" }, { status: 429 });
+  }
+
   let code = "";
   try {
     const body: unknown = await ctx.req.json();

--- a/apps/web/src/app/api/devices/pair/route.ts
+++ b/apps/web/src/app/api/devices/pair/route.ts
@@ -1,0 +1,37 @@
+/**
+ * POST /api/devices/pair
+ *
+ * The robot redeems a 6-digit pairing code for a long-lived device token.
+ * Body: { code: string }. Returns { token, deviceId }.
+ */
+import { NextResponse } from "next/server";
+import { pipe, withSentry, withRateLimit } from "@/lib/api/middlewares";
+import { RATE_LIMITS } from "@/lib/rate-limit";
+import { redeemPairingCode } from "@/lib/devices/device-service";
+
+export const revalidate = 0;
+
+// eslint-disable-next-line local-rules/require-csrf-mutating-routes -- Machine endpoint: the robot authenticates with the one-time pairing code itself and has no browser session or cookies, so cookie-based CSRF does not apply. Brute-force is bounded by the strict DEVICE_PAIR rate limit and the 10-minute code expiry.
+export const POST = pipe(
+  withSentry("/api/devices/pair"),
+  withRateLimit(RATE_LIMITS.DEVICE_PAIR),
+)(async (ctx) => {
+  let code = "";
+  try {
+    const body: unknown = await ctx.req.json();
+    if (body && typeof (body as { code?: unknown }).code === "string") {
+      code = (body as { code: string }).code;
+    }
+  } catch {
+    // Invalid body -> treated as an invalid code below.
+  }
+
+  const result = await redeemPairingCode(code);
+  if (!result) {
+    return NextResponse.json(
+      { error: "Invalid or expired code" },
+      { status: 400 },
+    );
+  }
+  return NextResponse.json({ token: result.token, deviceId: result.deviceId });
+});

--- a/apps/web/src/app/api/devices/route.test.ts
+++ b/apps/web/src/app/api/devices/route.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for GET /api/devices (list) and DELETE /api/devices/[id] (revoke).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api/middlewares", () => ({
+  pipe:
+    (..._mw: unknown[]) =>
+    (handler: unknown) =>
+      handler,
+  withSentry: () => vi.fn(),
+  withCSRF: vi.fn(),
+  withAuth: vi.fn(),
+  withRateLimit: () => vi.fn(),
+}));
+
+vi.mock("@/lib/devices/device-service", () => ({
+  listDevices: vi.fn(),
+  revokeDevice: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { DELETE } from "./[id]/route";
+import { listDevices, revokeDevice } from "@/lib/devices/device-service";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const listHandler = GET as unknown as (ctx: any) => Promise<Response>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const deleteHandler = DELETE as unknown as (ctx: any) => Promise<Response>;
+const mockList = listDevices as unknown as ReturnType<typeof vi.fn>;
+const mockRevoke = revokeDevice as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/devices", () => {
+  it("lists the user's devices", async () => {
+    mockList.mockResolvedValue([{ id: "d1", label: "Robot" }]);
+
+    const res = await listHandler({ userId: "user-1" });
+    const body = await res.json();
+
+    expect(body.devices).toHaveLength(1);
+    expect(mockList).toHaveBeenCalledWith("user-1");
+  });
+});
+
+describe("DELETE /api/devices/[id]", () => {
+  it("revokes an owned device", async () => {
+    mockRevoke.mockResolvedValue(true);
+
+    const res = await deleteHandler({
+      userId: "user-1",
+      params: Promise.resolve({ id: "d1" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    expect(mockRevoke).toHaveBeenCalledWith("user-1", "d1");
+  });
+
+  it("returns 404 when the device is not the user's", async () => {
+    mockRevoke.mockResolvedValue(false);
+
+    const res = await deleteHandler({
+      userId: "user-1",
+      params: Promise.resolve({ id: "other" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/devices/route.test.ts
+++ b/apps/web/src/app/api/devices/route.test.ts
@@ -23,9 +23,9 @@ import { GET } from "./route";
 import { DELETE } from "./[id]/route";
 import { listDevices, revokeDevice } from "@/lib/devices/device-service";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const listHandler = GET as unknown as (ctx: any) => Promise<Response>;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const deleteHandler = DELETE as unknown as (ctx: any) => Promise<Response>;
 const mockList = listDevices as unknown as ReturnType<typeof vi.fn>;
 const mockRevoke = revokeDevice as unknown as ReturnType<typeof vi.fn>;

--- a/apps/web/src/app/api/devices/route.ts
+++ b/apps/web/src/app/api/devices/route.ts
@@ -1,0 +1,18 @@
+/**
+ * GET /api/devices — list the authenticated user's paired robots (no secrets).
+ */
+import { NextResponse } from "next/server";
+import { pipe, withSentry, withAuth, withRateLimit } from "@/lib/api/middlewares";
+import { RATE_LIMITS } from "@/lib/rate-limit";
+import { listDevices } from "@/lib/devices/device-service";
+
+export const revalidate = 0;
+
+export const GET = pipe(
+  withSentry("/api/devices"),
+  withAuth,
+  withRateLimit(RATE_LIMITS.GENERAL),
+)(async (ctx) => {
+  const devices = await listDevices(ctx.userId!);
+  return NextResponse.json({ devices });
+});

--- a/apps/web/src/components/settings/sections/index.ts
+++ b/apps/web/src/components/settings/sections/index.ts
@@ -10,3 +10,4 @@ export { AIProviderSettings } from './ai-provider-settings';
 export { DiagnosticsTab } from './diagnostics-tab';
 export { GuardianContactSection } from './guardian-contact-section';
 export { MobileToolsSection } from './mobile-tools-section';
+export { RobotPairingCard } from './robot-pairing-card';

--- a/apps/web/src/components/settings/sections/robot-pairing-card.test.tsx
+++ b/apps/web/src/components/settings/sections/robot-pairing-card.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for RobotPairingCard — Settings › Integrations.
+ * Covers the explainer/buy affordances (visible to everyone, even without a
+ * robot) and the pairing-code generation flow.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { RobotPairingCard } from "./robot-pairing-card";
+
+vi.mock("next-intl", () => ({
+  // Identity translator: assert against the raw keys.
+  useTranslations: () => (key: string) => key,
+}));
+
+const csrfFetch = vi.fn();
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return { ...actual, csrfFetch: (...args: unknown[]) => csrfFetch(...args) };
+});
+
+vi.mock("@/lib/logger/client", () => ({
+  clientLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ devices: [] }),
+  }) as unknown as typeof fetch;
+});
+
+describe("RobotPairingCard", () => {
+  it("explains what the robot is and lists its features to everyone", async () => {
+    render(<RobotPairingCard />);
+
+    expect(screen.getByText("whatIsTitle")).toBeInTheDocument();
+    expect(screen.getByText("whatIsBody")).toBeInTheDocument();
+    for (const key of [
+      "featureEyes",
+      "featureVoice",
+      "featureCamera",
+      "featureMovement",
+      "featureStop",
+    ]) {
+      expect(screen.getByText(key)).toBeInTheDocument();
+    }
+    await waitFor(() =>
+      expect(screen.getByText("noRobots")).toBeInTheDocument(),
+    );
+  });
+
+  it("offers a safe external buy link for people without a robot", () => {
+    render(<RobotPairingCard />);
+
+    const buy = screen.getByRole("link", { name: /buyCta/ });
+    expect(buy).toHaveAttribute("href", "https://www.reachy-mini.org/buy.html");
+    expect(buy).toHaveAttribute?.("target", "_blank");
+    expect(buy).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("shows the three connection steps", () => {
+    render(<RobotPairingCard />);
+    expect(screen.getByText("step1")).toBeInTheDocument();
+    expect(screen.getByText("step2")).toBeInTheDocument();
+    expect(screen.getByText("step3")).toBeInTheDocument();
+  });
+
+  it("generates a pairing code on demand", async () => {
+    csrfFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ code: "123456", expiresAt: new Date().toISOString() }),
+    });
+    render(<RobotPairingCard />);
+
+    await userEvent.click(screen.getByText("generateCode"));
+
+    await waitFor(() => expect(screen.getByText("123456")).toBeInTheDocument());
+    expect(csrfFetch).toHaveBeenCalledWith(
+      "/api/devices/pair-code",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/apps/web/src/components/settings/sections/robot-pairing-card.tsx
+++ b/apps/web/src/components/settings/sections/robot-pairing-card.tsx
@@ -11,8 +11,22 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useTranslations } from "next-intl";
-import { Bot, Loader2, Trash2, KeyRound, Copy, Check } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import {
+  Bot,
+  Loader2,
+  Trash2,
+  KeyRound,
+  Copy,
+  Check,
+  Eye,
+  Mic,
+  Camera,
+  Activity,
+  Hand,
+  ShoppingCart,
+  ExternalLink,
+} from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -20,8 +34,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { csrfFetch } from "@/lib/auth/csrf-client";
+import { csrfFetch } from "@/lib/auth";
 import { clientLogger as logger } from "@/lib/logger/client";
+
+const BUY_URL = "https://www.reachy-mini.org/buy.html";
 
 interface DeviceSummary {
   id: string;
@@ -101,6 +117,14 @@ export function RobotPairingCard() {
     }
   }, [code]);
 
+  const features = [
+    { icon: Eye, key: "featureEyes" },
+    { icon: Mic, key: "featureVoice" },
+    { icon: Camera, key: "featureCamera" },
+    { icon: Activity, key: "featureMovement" },
+    { icon: Hand, key: "featureStop" },
+  ] as const;
+
   return (
     <Card>
       <CardHeader>
@@ -110,15 +134,57 @@ export function RobotPairingCard() {
         </CardTitle>
         <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <Button onClick={generate} disabled={generating}>
-          {generating ? (
-            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-          ) : (
-            <KeyRound className="w-4 h-4 mr-2" />
-          )}
-          {t("generateCode")}
-        </Button>
+      <CardContent className="space-y-6">
+        <section className="space-y-3" aria-labelledby="robot-whatis">
+          <h4 id="robot-whatis" className="text-sm font-semibold">
+            {t("whatIsTitle")}
+          </h4>
+          <p className="text-sm text-muted-foreground">{t("whatIsBody")}</p>
+          <ul className="space-y-2" aria-label={t("featuresTitle")}>
+            {features.map(({ icon: Icon, key }) => (
+              <li key={key} className="flex items-start gap-2 text-sm">
+                <Icon
+                  className="w-4 h-4 mt-0.5 shrink-0 text-accent-themed"
+                  aria-hidden="true"
+                />
+                <span>{t(key)}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-3 space-y-2">
+            <p className="text-sm font-medium">{t("noRobotYet")}</p>
+            <p className="text-xs text-muted-foreground">{t("buyNote")}</p>
+            <a
+              href={BUY_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              <ShoppingCart className="w-4 h-4 mr-2" aria-hidden="true" />
+              {t("buyCta")}
+              <ExternalLink className="w-3 h-3 ml-2" aria-hidden="true" />
+            </a>
+          </div>
+        </section>
+
+        <section className="space-y-3" aria-labelledby="robot-howto">
+          <h4 id="robot-howto" className="text-sm font-semibold">
+            {t("howItWorksTitle")}
+          </h4>
+          <ol className="list-decimal list-inside space-y-1 text-sm text-muted-foreground">
+            <li>{t("step1")}</li>
+            <li>{t("step2")}</li>
+            <li>{t("step3")}</li>
+          </ol>
+          <Button onClick={generate} disabled={generating}>
+            {generating ? (
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            ) : (
+              <KeyRound className="w-4 h-4 mr-2" />
+            )}
+            {t("generateCode")}
+          </Button>
+        </section>
 
         {code && (
           <div className="rounded-lg border border-accent-themed/40 bg-accent-themed/5 p-4 space-y-2">

--- a/apps/web/src/components/settings/sections/robot-pairing-card.tsx
+++ b/apps/web/src/components/settings/sections/robot-pairing-card.tsx
@@ -18,15 +18,8 @@ import {
   KeyRound,
   Copy,
   Check,
-  Eye,
-  Mic,
-  Camera,
-  Activity,
-  Hand,
-  ShoppingCart,
-  ExternalLink,
 } from "lucide-react";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -36,8 +29,7 @@ import {
 } from "@/components/ui/card";
 import { csrfFetch } from "@/lib/auth";
 import { clientLogger as logger } from "@/lib/logger/client";
-
-const BUY_URL = "https://www.reachy-mini.org/buy.html";
+import { RobotPairingExplainer } from "./robot-pairing-explainer";
 
 interface DeviceSummary {
   id: string;
@@ -117,14 +109,6 @@ export function RobotPairingCard() {
     }
   }, [code]);
 
-  const features = [
-    { icon: Eye, key: "featureEyes" },
-    { icon: Mic, key: "featureVoice" },
-    { icon: Camera, key: "featureCamera" },
-    { icon: Activity, key: "featureMovement" },
-    { icon: Hand, key: "featureStop" },
-  ] as const;
-
   return (
     <Card>
       <CardHeader>
@@ -135,37 +119,7 @@ export function RobotPairingCard() {
         <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
-        <section className="space-y-3" aria-labelledby="robot-whatis">
-          <h4 id="robot-whatis" className="text-sm font-semibold">
-            {t("whatIsTitle")}
-          </h4>
-          <p className="text-sm text-muted-foreground">{t("whatIsBody")}</p>
-          <ul className="space-y-2" aria-label={t("featuresTitle")}>
-            {features.map(({ icon: Icon, key }) => (
-              <li key={key} className="flex items-start gap-2 text-sm">
-                <Icon
-                  className="w-4 h-4 mt-0.5 shrink-0 text-accent-themed"
-                  aria-hidden="true"
-                />
-                <span>{t(key)}</span>
-              </li>
-            ))}
-          </ul>
-          <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-3 space-y-2">
-            <p className="text-sm font-medium">{t("noRobotYet")}</p>
-            <p className="text-xs text-muted-foreground">{t("buyNote")}</p>
-            <a
-              href={BUY_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={buttonVariants({ variant: "outline", size: "sm" })}
-            >
-              <ShoppingCart className="w-4 h-4 mr-2" aria-hidden="true" />
-              {t("buyCta")}
-              <ExternalLink className="w-3 h-3 ml-2" aria-hidden="true" />
-            </a>
-          </div>
-        </section>
+        <RobotPairingExplainer />
 
         <section className="space-y-3" aria-labelledby="robot-howto">
           <h4 id="robot-howto" className="text-sm font-semibold">

--- a/apps/web/src/components/settings/sections/robot-pairing-card.tsx
+++ b/apps/web/src/components/settings/sections/robot-pairing-card.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * RobotPairingCard — Settings › Integrations
+ *
+ * Lets a parent pair a Reachy Mini robot with the logged-in child's account:
+ * generate a 6-digit code to type on the robot, see paired robots, unpair.
+ * The robot never sees credentials — only a scoped device token it earns by
+ * redeeming the code. Serves the "MirrorBuddy with a body" flow.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { Bot, Loader2, Trash2, KeyRound, Copy, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { csrfFetch } from "@/lib/auth/csrf-client";
+import { clientLogger as logger } from "@/lib/logger/client";
+
+interface DeviceSummary {
+  id: string;
+  label: string | null;
+  pairedAt: string | null;
+  lastSeenAt: string | null;
+  createdAt: string;
+}
+
+interface PairCode {
+  code: string;
+  expiresAt: string;
+}
+
+export function RobotPairingCard() {
+  const t = useTranslations("settings.robotPairing");
+  const [devices, setDevices] = useState<DeviceSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const [code, setCode] = useState<PairCode | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/devices", { credentials: "include" });
+      if (res.ok) {
+        const data = await res.json();
+        setDevices(data.devices ?? []);
+      }
+    } catch (error) {
+      logger.error("Failed to load robots", { error: String(error) });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const generate = useCallback(async () => {
+    setGenerating(true);
+    setCode(null);
+    try {
+      const res = await csrfFetch("/api/devices/pair-code", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+      if (res.ok) setCode(await res.json());
+    } catch (error) {
+      logger.error("Failed to generate pairing code", { error: String(error) });
+    } finally {
+      setGenerating(false);
+    }
+  }, []);
+
+  const revoke = useCallback(
+    async (id: string) => {
+      try {
+        const res = await csrfFetch(`/api/devices/${id}`, { method: "DELETE" });
+        if (res.ok) setDevices((d) => d.filter((x) => x.id !== id));
+      } catch (error) {
+        logger.error("Failed to revoke robot", { error: String(error) });
+      }
+    },
+    [],
+  );
+
+  const copyCode = useCallback(async () => {
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code.code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable — the code is shown on screen anyway */
+    }
+  }, [code]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Bot className="w-5 h-5" />
+          {t("title")}
+        </CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Button onClick={generate} disabled={generating}>
+          {generating ? (
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+          ) : (
+            <KeyRound className="w-4 h-4 mr-2" />
+          )}
+          {t("generateCode")}
+        </Button>
+
+        {code && (
+          <div className="rounded-lg border border-accent-themed/40 bg-accent-themed/5 p-4 space-y-2">
+            <p className="text-sm text-muted-foreground">{t("codeHint")}</p>
+            <div className="flex items-center gap-3">
+              <span className="text-3xl font-mono font-bold tracking-[0.3em]">
+                {code.code}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={copyCode}
+                aria-label={t("copy")}
+              >
+                {copied ? (
+                  <Check className="w-4 h-4" />
+                ) : (
+                  <Copy className="w-4 h-4" />
+                )}
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">{t("codeExpires")}</p>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <h4 className="text-sm font-medium">{t("pairedRobots")}</h4>
+          {loading ? (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span>{t("loading")}</span>
+            </div>
+          ) : devices.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t("noRobots")}</p>
+          ) : (
+            <ul className="space-y-2">
+              {devices.map((d) => (
+                <li
+                  key={d.id}
+                  className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-700 p-3"
+                >
+                  <div>
+                    <p className="text-sm font-medium">
+                      {d.label || t("unnamedRobot")}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {d.pairedAt
+                        ? t("pairedOn", {
+                            date: new Date(d.pairedAt).toLocaleDateString(),
+                          })
+                        : t("pendingPairing")}
+                    </p>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => revoke(d.id)}
+                    aria-label={t("unpair")}
+                  >
+                    <Trash2 className="w-4 h-4 text-red-500" />
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <p className="text-xs text-muted-foreground">{t("privacyNote")}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/settings/sections/robot-pairing-explainer.tsx
+++ b/apps/web/src/components/settings/sections/robot-pairing-explainer.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * RobotPairingExplainer — the "what is the robot" block of the pairing card.
+ *
+ * Presentational only: explains the Reachy Mini embodiment, lists what it can
+ * do, and links out to buy one — so the settings section makes sense even to
+ * parents who don't own the robot yet. Split out of RobotPairingCard to keep
+ * each file under the 250-line limit.
+ */
+
+import { useTranslations } from "next-intl";
+import { Eye, Mic, Camera, Activity, Hand, ShoppingCart, ExternalLink } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+
+const BUY_URL = "https://www.reachy-mini.org/buy.html";
+
+const FEATURES = [
+  { icon: Eye, key: "featureEyes" },
+  { icon: Mic, key: "featureVoice" },
+  { icon: Camera, key: "featureCamera" },
+  { icon: Activity, key: "featureMovement" },
+  { icon: Hand, key: "featureStop" },
+] as const;
+
+export function RobotPairingExplainer() {
+  const t = useTranslations("settings.robotPairing");
+  return (
+    <section className="space-y-3" aria-labelledby="robot-whatis">
+      <h4 id="robot-whatis" className="text-sm font-semibold">
+        {t("whatIsTitle")}
+      </h4>
+      <p className="text-sm text-muted-foreground">{t("whatIsBody")}</p>
+      <ul className="space-y-2" aria-label={t("featuresTitle")}>
+        {FEATURES.map(({ icon: Icon, key }) => (
+          <li key={key} className="flex items-start gap-2 text-sm">
+            <Icon
+              className="w-4 h-4 mt-0.5 shrink-0 text-accent-themed"
+              aria-hidden="true"
+            />
+            <span>{t(key)}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-3 space-y-2">
+        <p className="text-sm font-medium">{t("noRobotYet")}</p>
+        <p className="text-xs text-muted-foreground">{t("buyNote")}</p>
+        <a
+          href={BUY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={buttonVariants({ variant: "outline", size: "sm" })}
+        >
+          <ShoppingCart className="w-4 h-4 mr-2" aria-hidden="true" />
+          {t("buyCta")}
+          <ExternalLink className="w-3 h-3 ml-2" aria-hidden="true" />
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/settings-view.tsx
+++ b/apps/web/src/components/settings/settings-view.tsx
@@ -30,6 +30,7 @@ import {
   AIProviderSettings,
   DiagnosticsTab,
   GuardianContactSection,
+  RobotPairingCard,
 } from './sections';
 import { GoogleAccountCard } from '@/components/google-drive';
 import { getUserId } from '@/lib/hooks/use-saved-materials/utils/user-id';
@@ -206,6 +207,7 @@ export function SettingsView() {
         {activeTab === 'integrations' && (
           <div className="space-y-6">
             <GoogleAccountCard userId={getUserId()} />
+            <RobotPairingCard />
           </div>
         )}
 

--- a/apps/web/src/lib/db/__tests__/schema-split.test.ts
+++ b/apps/web/src/lib/db/__tests__/schema-split.test.ts
@@ -45,6 +45,7 @@ const EXPECTED_SCHEMA_FILES = [
   'communications.prisma', // EmailTemplate, EmailCampaign, EmailRecipient, EmailPreference, EmailEvent
   'maintenance.prisma', // MaintenanceWindow (planned outages/maintenance)
   'waitlist.prisma', // WaitlistEntry (coming soon waitlist)
+  'robot-device.prisma', // RobotDevice (Reachy Mini device pairing)
 ];
 
 // Expected models that should be present across all schema files
@@ -145,6 +146,8 @@ const EXPECTED_MODELS = [
   'MaintenanceWindow',
   // waitlist.prisma
   'WaitlistEntry',
+  // robot-device.prisma
+  'RobotDevice',
 ];
 
 describe('Prisma Schema Split', () => {

--- a/apps/web/src/lib/devices/__tests__/device-service.test.ts
+++ b/apps/web/src/lib/devices/__tests__/device-service.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for device-service (robot pairing).
+ * TDD: behaviour specified before wiring the routes.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", async () => {
+  const { createMockPrisma } = await import("@/test/mocks/prisma");
+  return { prisma: createMockPrisma() };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { prisma } from "@/lib/db";
+import {
+  createPairingCode,
+  redeemPairingCode,
+  getDeviceProfile,
+  listDevices,
+  revokeDevice,
+} from "../device-service";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = prisma as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createPairingCode", () => {
+  it("stores a hashed code and returns a 6-digit code with future expiry", async () => {
+    db.robotDevice.create.mockResolvedValue({ id: "d1" });
+
+    const result = await createPairingCode("user-1", "Cameretta");
+
+    expect(result.code).toMatch(/^\d{6}$/);
+    expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    const data = db.robotDevice.create.mock.calls[0][0].data;
+    expect(data.userId).toBe("user-1");
+    expect(data.label).toBe("Cameretta");
+    expect(data.pairCodeHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(data.pairCodeHash).not.toContain(result.code);
+  });
+
+  it("retries on a hashed-code collision", async () => {
+    db.robotDevice.create
+      .mockRejectedValueOnce(new Error("unique"))
+      .mockResolvedValueOnce({ id: "d2" });
+
+    const result = await createPairingCode("user-1");
+
+    expect(result.code).toMatch(/^\d{6}$/);
+    expect(db.robotDevice.create).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("redeemPairingCode", () => {
+  it("rejects a malformed code without hitting the database", async () => {
+    expect(await redeemPairingCode("abc")).toBeNull();
+    expect(db.robotDevice.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns null for an unknown code", async () => {
+    db.robotDevice.findUnique.mockResolvedValue(null);
+    expect(await redeemPairingCode("123456")).toBeNull();
+  });
+
+  it("returns null for an expired code", async () => {
+    db.robotDevice.findUnique.mockResolvedValue({
+      id: "d1",
+      revokedAt: null,
+      tokenHash: null,
+      pairCodeExpiresAt: new Date(Date.now() - 1000),
+    });
+    expect(await redeemPairingCode("123456")).toBeNull();
+  });
+
+  it("returns null for an already-paired device", async () => {
+    db.robotDevice.findUnique.mockResolvedValue({
+      id: "d1",
+      revokedAt: null,
+      tokenHash: "existing",
+      pairCodeExpiresAt: new Date(Date.now() + 10000),
+    });
+    expect(await redeemPairingCode("123456")).toBeNull();
+  });
+
+  it("issues a token and clears the code on success", async () => {
+    db.robotDevice.findUnique.mockResolvedValue({
+      id: "d1",
+      revokedAt: null,
+      tokenHash: null,
+      pairCodeExpiresAt: new Date(Date.now() + 10000),
+    });
+    db.robotDevice.update.mockResolvedValue({});
+
+    const result = await redeemPairingCode("123456");
+
+    expect(result?.token).toMatch(/^[a-f0-9]{64}$/);
+    expect(result?.deviceId).toBe("d1");
+    const data = db.robotDevice.update.mock.calls[0][0].data;
+    expect(data.pairCodeHash).toBeNull();
+    expect(data.tokenHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(data.tokenHash).not.toBe(result?.token);
+  });
+});
+
+describe("getDeviceProfile", () => {
+  it("returns null for an unknown token", async () => {
+    db.robotDevice.findUnique.mockResolvedValue(null);
+    expect(await getDeviceProfile("tok")).toBeNull();
+  });
+
+  it("returns null for a revoked device", async () => {
+    db.robotDevice.findUnique.mockResolvedValue({
+      id: "d1",
+      revokedAt: new Date(),
+      user: { profile: null, settings: null },
+    });
+    expect(await getDeviceProfile("tok")).toBeNull();
+  });
+
+  it("maps profile + settings and refreshes lastSeenAt", async () => {
+    db.robotDevice.findUnique.mockResolvedValue({
+      id: "d1",
+      revokedAt: null,
+      user: {
+        profile: {
+          name: "Mario",
+          preferredBuddy: "sofia",
+          preferredCoach: "roberto",
+          schoolLevel: "superiore",
+          gradeLevel: "2",
+          age: 15,
+          learningGoals: '["matematica","storia"]',
+        },
+        settings: { language: "it", dyslexiaFont: true, adhdMode: true },
+      },
+    });
+    db.robotDevice.update.mockResolvedValue({});
+
+    const profile = await getDeviceProfile("tok");
+
+    expect(profile?.name).toBe("Mario");
+    expect(profile?.preferredBuddy).toBe("sofia");
+    expect(profile?.subjects).toEqual(["matematica", "storia"]);
+    expect(profile?.language).toBe("it");
+    expect(profile?.accessibility.dyslexiaFont).toBe(true);
+    expect(profile?.accessibility.adhdMode).toBe(true);
+    expect(db.robotDevice.update).toHaveBeenCalledWith({
+      where: { id: "d1" },
+      data: { lastSeenAt: expect.any(Date) },
+    });
+  });
+});
+
+describe("listDevices / revokeDevice", () => {
+  it("lists a user's active devices", async () => {
+    db.robotDevice.findMany.mockResolvedValue([{ id: "d1", label: "Robot" }]);
+    const devices = await listDevices("user-1");
+    expect(devices).toHaveLength(1);
+    expect(db.robotDevice.findMany.mock.calls[0][0].where).toEqual({
+      userId: "user-1",
+      revokedAt: null,
+    });
+  });
+
+  it("returns true when a device is revoked", async () => {
+    db.robotDevice.updateMany.mockResolvedValue({ count: 1 });
+    expect(await revokeDevice("user-1", "d1")).toBe(true);
+  });
+
+  it("returns false when nothing is revoked", async () => {
+    db.robotDevice.updateMany.mockResolvedValue({ count: 0 });
+    expect(await revokeDevice("user-1", "d1")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/devices/__tests__/device-service.test.ts
+++ b/apps/web/src/lib/devices/__tests__/device-service.test.ts
@@ -10,7 +10,18 @@ vi.mock("@/lib/db", async () => {
 });
 
 vi.mock("@/lib/logger", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
 }));
 
 import { prisma } from "@/lib/db";
@@ -22,7 +33,7 @@ import {
   revokeDevice,
 } from "../device-service";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const db = prisma as any;
 
 beforeEach(() => {
@@ -44,9 +55,10 @@ describe("createPairingCode", () => {
     expect(data.pairCodeHash).not.toContain(result.code);
   });
 
-  it("retries on a hashed-code collision", async () => {
+  it("retries on a hashed-code collision (P2002)", async () => {
+    const collision = Object.assign(new Error("unique"), { code: "P2002" });
     db.robotDevice.create
-      .mockRejectedValueOnce(new Error("unique"))
+      .mockRejectedValueOnce(collision)
       .mockResolvedValueOnce({ id: "d2" });
 
     const result = await createPairingCode("user-1");
@@ -54,56 +66,49 @@ describe("createPairingCode", () => {
     expect(result.code).toMatch(/^\d{6}$/);
     expect(db.robotDevice.create).toHaveBeenCalledTimes(2);
   });
+
+  it("surfaces a non-collision error immediately without retrying", async () => {
+    db.robotDevice.create.mockRejectedValue(new Error("db down"));
+
+    await expect(createPairingCode("user-1")).rejects.toThrow("db down");
+    expect(db.robotDevice.create).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("redeemPairingCode", () => {
   it("rejects a malformed code without hitting the database", async () => {
     expect(await redeemPairingCode("abc")).toBeNull();
-    expect(db.robotDevice.findUnique).not.toHaveBeenCalled();
+    expect(db.robotDevice.updateMany).not.toHaveBeenCalled();
   });
 
-  it("returns null for an unknown code", async () => {
-    db.robotDevice.findUnique.mockResolvedValue(null);
+  it("returns null when no redeemable code matches (unknown/expired/already-paired)", async () => {
+    db.robotDevice.updateMany.mockResolvedValue({ count: 0 });
     expect(await redeemPairingCode("123456")).toBeNull();
+    // The guard lives in the atomic updateMany where-clause.
+    const where = db.robotDevice.updateMany.mock.calls[0][0].where;
+    expect(where.tokenHash).toBeNull();
+    expect(where.revokedAt).toBeNull();
+    expect(where.pairCodeExpiresAt.gt).toBeInstanceOf(Date);
   });
 
-  it("returns null for an expired code", async () => {
-    db.robotDevice.findUnique.mockResolvedValue({
-      id: "d1",
-      revokedAt: null,
-      tokenHash: null,
-      pairCodeExpiresAt: new Date(Date.now() - 1000),
-    });
-    expect(await redeemPairingCode("123456")).toBeNull();
-  });
-
-  it("returns null for an already-paired device", async () => {
-    db.robotDevice.findUnique.mockResolvedValue({
-      id: "d1",
-      revokedAt: null,
-      tokenHash: "existing",
-      pairCodeExpiresAt: new Date(Date.now() + 10000),
-    });
-    expect(await redeemPairingCode("123456")).toBeNull();
-  });
-
-  it("issues a token and clears the code on success", async () => {
-    db.robotDevice.findUnique.mockResolvedValue({
-      id: "d1",
-      revokedAt: null,
-      tokenHash: null,
-      pairCodeExpiresAt: new Date(Date.now() + 10000),
-    });
-    db.robotDevice.update.mockResolvedValue({});
+  it("issues a token atomically and clears the code on success", async () => {
+    db.robotDevice.updateMany.mockResolvedValue({ count: 1 });
+    db.robotDevice.findUnique.mockResolvedValue({ id: "d1" });
 
     const result = await redeemPairingCode("123456");
 
     expect(result?.token).toMatch(/^[a-f0-9]{64}$/);
     expect(result?.deviceId).toBe("d1");
-    const data = db.robotDevice.update.mock.calls[0][0].data;
+    const data = db.robotDevice.updateMany.mock.calls[0][0].data;
     expect(data.pairCodeHash).toBeNull();
     expect(data.tokenHash).toMatch(/^[a-f0-9]{64}$/);
     expect(data.tokenHash).not.toBe(result?.token);
+  });
+
+  it("returns null if the claimed row cannot be read back", async () => {
+    db.robotDevice.updateMany.mockResolvedValue({ count: 1 });
+    db.robotDevice.findUnique.mockResolvedValue(null);
+    expect(await redeemPairingCode("123456")).toBeNull();
   });
 });
 
@@ -164,6 +169,7 @@ describe("listDevices / revokeDevice", () => {
     expect(db.robotDevice.findMany.mock.calls[0][0].where).toEqual({
       userId: "user-1",
       revokedAt: null,
+      pairedAt: { not: null },
     });
   });
 

--- a/apps/web/src/lib/devices/device-service.ts
+++ b/apps/web/src/lib/devices/device-service.ts
@@ -87,9 +87,11 @@ export async function createPairingCode(
       });
       return { code, expiresAt };
     } catch (error) {
-      // Unique collision on the hashed code: retry with a new code.
-      if (attempt === MAX_CODE_ATTEMPTS - 1) {
-        logger.error("Failed to allocate pairing code", { error });
+      // Retry ONLY on a unique-constraint collision of the hashed code (P2002);
+      // surface any other error (DB down, FK violation) immediately.
+      const code = (error as { code?: string }).code;
+      if (code !== "P2002" || attempt === MAX_CODE_ATTEMPTS - 1) {
+        logger.error("Failed to allocate pairing code", undefined, error);
         throw error;
       }
     }
@@ -104,29 +106,34 @@ export async function redeemPairingCode(
   const trimmed = code?.trim();
   if (!trimmed || !/^\d{6}$/.test(trimmed)) return null;
 
-  const device = await prisma.robotDevice.findUnique({
-    where: { pairCodeHash: sha256(trimmed) },
-  });
-  if (
-    !device ||
-    device.revokedAt ||
-    device.tokenHash ||
-    !device.pairCodeExpiresAt ||
-    device.pairCodeExpiresAt.getTime() < Date.now()
-  ) {
-    return null;
-  }
-
   const token = generateToken();
-  await prisma.robotDevice.update({
-    where: { id: device.id },
+  const tokenHash = sha256(token);
+  const now = new Date();
+
+  // Atomic redemption: a single guarded updateMany claims the code only if it is still
+  // unredeemed, unrevoked and unexpired. This closes the double-redeem (TOCTOU) race —
+  // concurrent requests for the same code cannot both succeed.
+  const claimed = await prisma.robotDevice.updateMany({
+    where: {
+      pairCodeHash: sha256(trimmed),
+      tokenHash: null,
+      revokedAt: null,
+      pairCodeExpiresAt: { gt: now },
+    },
     data: {
-      tokenHash: sha256(token),
-      pairedAt: new Date(),
+      tokenHash,
+      pairedAt: now,
       pairCodeHash: null,
       pairCodeExpiresAt: null,
     },
   });
+  if (claimed.count === 0) return null;
+
+  const device = await prisma.robotDevice.findUnique({
+    where: { tokenHash },
+    select: { id: true },
+  });
+  if (!device) return null;
   logger.info("Robot device paired", { deviceId: device.id });
   return { token, deviceId: device.id };
 }
@@ -175,7 +182,7 @@ export async function getDeviceProfile(
 /** List a user's paired devices (no secrets). */
 export async function listDevices(userId: string): Promise<DeviceSummary[]> {
   return prisma.robotDevice.findMany({
-    where: { userId, revokedAt: null },
+    where: { userId, revokedAt: null, pairedAt: { not: null } },
     orderBy: { createdAt: "desc" },
     select: {
       id: true,

--- a/apps/web/src/lib/devices/device-service.ts
+++ b/apps/web/src/lib/devices/device-service.ts
@@ -1,0 +1,216 @@
+/**
+ * Robot Device Pairing service.
+ *
+ * Binds a physical Reachy Mini (MirrorBuddy Robot) to a MirrorBuddy account so
+ * the voice-only robot can load the logged-in child's profile without a screen.
+ *
+ * Security model:
+ * - A short-lived 6-digit pairing code is generated for the logged-in user.
+ * - The robot redeems the code for a long-lived, revocable device token.
+ * - Only SHA-256 hashes of the code and token are ever stored — never plaintext.
+ */
+
+import { createHash, randomBytes, randomInt } from "crypto";
+import { prisma } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+const CODE_TTL_MS = 10 * 60 * 1000; // pairing code valid for 10 minutes
+const CODE_DIGITS = 6;
+const MAX_CODE_ATTEMPTS = 5; // retries on the (rare) hashed-code collision
+const MAX_LABEL_LEN = 80;
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function generateCode(): string {
+  return String(randomInt(0, 10 ** CODE_DIGITS)).padStart(CODE_DIGITS, "0");
+}
+
+function generateToken(): string {
+  return randomBytes(32).toString("hex"); // 256-bit device token
+}
+
+export interface PairingCode {
+  code: string;
+  expiresAt: Date;
+}
+
+export interface DeviceAccessibility {
+  fontSize: string;
+  highContrast: boolean;
+  dyslexiaFont: boolean;
+  reducedMotion: boolean;
+  simplifiedLanguage: boolean;
+  adhdMode: boolean;
+  voiceEnabled: boolean;
+}
+
+export interface DeviceProfile {
+  name: string | null;
+  preferredBuddy: string | null;
+  preferredCoach: string | null;
+  schoolLevel: string | null;
+  gradeLevel: string | null;
+  age: number | null;
+  language: string;
+  subjects: string[];
+  accessibility: DeviceAccessibility;
+}
+
+export interface DeviceSummary {
+  id: string;
+  label: string | null;
+  pairedAt: Date | null;
+  lastSeenAt: Date | null;
+  createdAt: Date;
+}
+
+/** Generate a fresh pairing code for a user, storing only its hash. */
+export async function createPairingCode(
+  userId: string,
+  label?: string,
+): Promise<PairingCode> {
+  const expiresAt = new Date(Date.now() + CODE_TTL_MS);
+  const safeLabel = label?.trim().slice(0, MAX_LABEL_LEN) || null;
+
+  for (let attempt = 0; attempt < MAX_CODE_ATTEMPTS; attempt++) {
+    const code = generateCode();
+    try {
+      await prisma.robotDevice.create({
+        data: {
+          userId,
+          label: safeLabel,
+          pairCodeHash: sha256(code),
+          pairCodeExpiresAt: expiresAt,
+        },
+      });
+      return { code, expiresAt };
+    } catch (error) {
+      // Unique collision on the hashed code: retry with a new code.
+      if (attempt === MAX_CODE_ATTEMPTS - 1) {
+        logger.error("Failed to allocate pairing code", { error });
+        throw error;
+      }
+    }
+  }
+  throw new Error("Unable to allocate pairing code");
+}
+
+/** Redeem a pairing code, returning a one-time device token (hash stored). */
+export async function redeemPairingCode(
+  code: string,
+): Promise<{ token: string; deviceId: string } | null> {
+  const trimmed = code?.trim();
+  if (!trimmed || !/^\d{6}$/.test(trimmed)) return null;
+
+  const device = await prisma.robotDevice.findUnique({
+    where: { pairCodeHash: sha256(trimmed) },
+  });
+  if (
+    !device ||
+    device.revokedAt ||
+    device.tokenHash ||
+    !device.pairCodeExpiresAt ||
+    device.pairCodeExpiresAt.getTime() < Date.now()
+  ) {
+    return null;
+  }
+
+  const token = generateToken();
+  await prisma.robotDevice.update({
+    where: { id: device.id },
+    data: {
+      tokenHash: sha256(token),
+      pairedAt: new Date(),
+      pairCodeHash: null,
+      pairCodeExpiresAt: null,
+    },
+  });
+  logger.info("Robot device paired", { deviceId: device.id });
+  return { token, deviceId: device.id };
+}
+
+/** Resolve a device token to the owner's robot-facing profile scope. */
+export async function getDeviceProfile(
+  token: string,
+): Promise<DeviceProfile | null> {
+  const trimmed = token?.trim();
+  if (!trimmed) return null;
+
+  const device = await prisma.robotDevice.findUnique({
+    where: { tokenHash: sha256(trimmed) },
+    include: { user: { include: { profile: true, settings: true } } },
+  });
+  if (!device || device.revokedAt) return null;
+
+  await prisma.robotDevice.update({
+    where: { id: device.id },
+    data: { lastSeenAt: new Date() },
+  });
+
+  const profile = device.user.profile;
+  const settings = device.user.settings;
+  return {
+    name: profile?.name ?? null,
+    preferredBuddy: profile?.preferredBuddy ?? null,
+    preferredCoach: profile?.preferredCoach ?? null,
+    schoolLevel: profile?.schoolLevel ?? null,
+    gradeLevel: profile?.gradeLevel ?? null,
+    age: profile?.age ?? null,
+    language: settings?.language ?? "it",
+    subjects: parseSubjects(profile?.learningGoals),
+    accessibility: {
+      fontSize: settings?.fontSize ?? "medium",
+      highContrast: settings?.highContrast ?? false,
+      dyslexiaFont: settings?.dyslexiaFont ?? false,
+      reducedMotion: settings?.reducedMotion ?? false,
+      simplifiedLanguage: settings?.simplifiedLanguage ?? false,
+      adhdMode: settings?.adhdMode ?? false,
+      voiceEnabled: settings?.voiceEnabled ?? true,
+    },
+  };
+}
+
+/** List a user's paired devices (no secrets). */
+export async function listDevices(userId: string): Promise<DeviceSummary[]> {
+  return prisma.robotDevice.findMany({
+    where: { userId, revokedAt: null },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      label: true,
+      pairedAt: true,
+      lastSeenAt: true,
+      createdAt: true,
+    },
+  });
+}
+
+/** Revoke a device the user owns. Returns false if not found / not theirs. */
+export async function revokeDevice(
+  userId: string,
+  deviceId: string,
+): Promise<boolean> {
+  const result = await prisma.robotDevice.updateMany({
+    where: { id: deviceId, userId, revokedAt: null },
+    data: { revokedAt: new Date(), tokenHash: null, pairCodeHash: null },
+  });
+  return result.count > 0;
+}
+
+function parseSubjects(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((s): s is string => typeof s === "string");
+    }
+  } catch {
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [];
+}

--- a/apps/web/src/lib/devices/device-service.ts
+++ b/apps/web/src/lib/devices/device-service.ts
@@ -10,7 +10,7 @@
  * - Only SHA-256 hashes of the code and token are ever stored — never plaintext.
  */
 
-import { createHash, randomBytes, randomInt } from "crypto";
+import { createHash, createHmac, randomBytes, randomInt } from "crypto";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
 
@@ -19,8 +19,26 @@ const CODE_DIGITS = 6;
 const MAX_CODE_ATTEMPTS = 5; // retries on the (rare) hashed-code collision
 const MAX_LABEL_LEN = 80;
 
+// Pepper for the low-entropy pairing code (used only when DEVICE_PAIRING_PEPPER
+// is unset). A 6-digit code has just 10^6 possibilities, so a bare hash could be
+// brute-forced from a DB leak; a server-side HMAC key makes the stored verifier
+// useless without the secret.
+const FALLBACK_PEPPER = "mirrorbuddy-device-pairing-fallback-pepper";
+
 function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+/** Keyed hash for the low-entropy pairing code (HMAC with a server pepper). */
+function hashCode(code: string): string {
+  let pepper = process.env.DEVICE_PAIRING_PEPPER || process.env.ENCRYPTION_KEY;
+  if (!pepper) {
+    logger.warn(
+      "DEVICE_PAIRING_PEPPER is not set, using fallback pepper for pairing codes",
+    );
+    pepper = FALLBACK_PEPPER;
+  }
+  return createHmac("sha256", pepper).update(code).digest("hex");
 }
 
 function generateCode(): string {
@@ -81,7 +99,7 @@ export async function createPairingCode(
         data: {
           userId,
           label: safeLabel,
-          pairCodeHash: sha256(code),
+          pairCodeHash: hashCode(code),
           pairCodeExpiresAt: expiresAt,
         },
       });
@@ -115,7 +133,7 @@ export async function redeemPairingCode(
   // concurrent requests for the same code cannot both succeed.
   const claimed = await prisma.robotDevice.updateMany({
     where: {
-      pairCodeHash: sha256(trimmed),
+      pairCodeHash: hashCode(trimmed),
       tokenHash: null,
       revokedAt: null,
       pairCodeExpiresAt: { gt: now },

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -409,6 +409,24 @@ export const RATE_LIMITS = {
     maxRequests: 5,
     windowMs: 60 * 60 * 1000,
   },
+
+  // ========== ROBOT DEVICE PAIRING ==========
+
+  /** Robot pairing-code generation: 10 per hour (authenticated user) */
+  DEVICE_PAIR_CODE: {
+    maxRequests: 10,
+    windowMs: 60 * 60 * 1000,
+  },
+  /** Robot code redemption: 5 per 15 minutes (anti brute-force of 6-digit code) */
+  DEVICE_PAIR: {
+    maxRequests: 5,
+    windowMs: 15 * 60 * 1000,
+  },
+  /** Robot profile fetch (device token): 60 per minute */
+  DEVICE_ME: {
+    maxRequests: 60,
+    windowMs: 60 * 1000,
+  },
 } as const;
 
 /**

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -422,6 +422,16 @@ export const RATE_LIMITS = {
     maxRequests: 5,
     windowMs: 15 * 60 * 1000,
   },
+  /**
+   * Global ceiling on code redemption across ALL clients. Belt-and-suspenders so the
+   * 6-digit brute-force bound does not depend solely on per-IP keying (which can be
+   * defeated by a spoofed X-Forwarded-For behind a naive proxy). Pairing is a rare
+   * action, so a low global cap is safe for legitimate use.
+   */
+  DEVICE_PAIR_GLOBAL: {
+    maxRequests: 100,
+    windowMs: 15 * 60 * 1000,
+  },
   /** Robot profile fetch (device token): 60 per minute */
   DEVICE_ME: {
     maxRequests: 60,

--- a/apps/web/src/test/mocks/prisma.ts
+++ b/apps/web/src/test/mocks/prisma.ts
@@ -94,6 +94,7 @@ export function createMockPrisma() {
     rateLimitEvent: createModelMock(),
     researchExperiment: createModelMock(),
     researchResult: createModelMock(),
+    robotDevice: createModelMock(),
     sSOSession: createModelMock(),
     safetyEvent: createModelMock(),
     scheduledSession: createModelMock(),

--- a/docs/adr/0170-reachy-mini-robot-embodiment.md
+++ b/docs/adr/0170-reachy-mini-robot-embodiment.md
@@ -1,0 +1,156 @@
+# ADR 0170: Reachy Mini as MirrorBuddy's Physical Embodiment + Device Pairing
+
+| Field          | Value                                                                                     |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| Status         | **PROPOSED**                                                                              |
+| Date           | 2026-07-19                                                                                |
+| Branch         | feat/reachy-mini-mirrorbuddy · feat/reachy-mini-mirrorbuddy-pairing                       |
+| Related ADRs   | ADR 0169 (Azure Realtime 2.1 Cedar), ADR 0122 (Realtime Vision), ADR 0126 (Unified Camera), ADR 0008 (Parent GDPR consent), ADR 0104 (i18n wrapper key) |
+| Related Issues | Reachy Mini embodiment, device pairing                                                     |
+
+## Context
+
+MirrorBuddy is a screen-based Italian tutor for children with DSA (dyslexia,
+dyscalculia) and additional needs. The product owner's own son (dyslexia,
+dyscalculia, cerebral palsy) benefits from a **voice-first, screen-free** modality:
+a physical desk companion is less fatiguing and more engaging than a browser.
+
+Hugging Face's **Reachy Mini** (a small, affordable desktop robot: RPi CM4,
+`reachy_mini` runtime, head/antenna motors, mic array, speaker, camera) is a
+natural body for the existing tutor. The question: how do we give MirrorBuddy a
+physical form **without forking the product**, and how does the robot know
+**which child** is using it, safely?
+
+### Constraints
+
+- **No screen.** Every interaction — switching professor/subject, invoking
+  features, reading homework — must be reachable **by voice alone**.
+- **Reuse, don't fork.** The robot must reuse MirrorBuddy's identity: Azure
+  OpenAI Realtime voices (ADR 0169), the 26 Maestri personas, DSA profiles.
+- **Accessibility is non-negotiable.** For a child with cerebral palsy, an
+  insistent robot causes stress. A stop word ("basta") must silence it
+  **immediately and deterministically**, never "after the current sentence".
+- **Privacy / GDPR (ADR 0008).** The robot must never hold the child's
+  credentials; a parent must be able to revoke its access at any time.
+- **No web-app regression.** The embodiment must not destabilise production
+  MirrorBuddy.
+
+## Decision Drivers
+
+1. Voice-only completeness (no feature stranded behind a screen).
+2. Identity reuse (same voice/personas/profiles as the web tutor).
+3. Deterministic, local safety (stop word cannot depend on the LLM).
+4. Privacy-safe personalisation (who is the logged-in child?).
+5. Minimal blast radius on the production web app.
+
+## Considered Options
+
+### A — Robot streams to the existing web app (thin client)
+
+The robot is a dumb mic/speaker/camera piped into the web session.
+
+**Pros:** zero robot-side logic; automatic feature parity.
+**Cons:** requires a live browser session + login on-device; latency of a full
+web round-trip; no local, deterministic stop (safety depends on the cloud);
+couples robot uptime to web deploys. **Rejected** on safety + latency.
+
+### B — Separate robot app that reuses MirrorBuddy's building blocks (**chosen**)
+
+A self-contained app under `robot/` (`reachy_mini_mirrorbuddy`) that:
+
+- Connects **directly** to Azure OpenAI Realtime (speech-to-speech, WebRTC) with
+  the same voices and persona prompts as the web app.
+- Runs a **local controller** mapping turn-taking to head/antenna motion, with a
+  calmer amplitude while speaking so movement does not distract the student.
+- Uses the camera on an **explicit** `look_at_homework` request only (single
+  frame, never streamed, nothing persisted) — consistent with ADR 0122/0126.
+- Enforces a **hard local interrupt** on stop words ("basta/zitto/fermati/
+  aspetta/pausa") via `audio.clear_player()`, with **no auto-resume**.
+- Exposes everything by voice tools (switch professor/subject, look at homework).
+
+**Pros:** low latency; safety is local and deterministic; robot survives web
+deploys; no web-app changes for the embodiment itself.
+**Cons:** a second (small) codebase to maintain; feature parity is manual.
+**Chosen** — safety and latency dominate.
+
+### C — Fork MirrorBuddy for the robot
+
+**Rejected** outright: duplicates 26 personas, DSA logic, and voice config;
+guarantees drift.
+
+## Decision — Device Pairing
+
+To personalise without credentials, the robot **pairs** with the logged-in
+child's account via a short-lived code exchanged for a scoped token:
+
+1. **Web** (`Settings → Integrations → RobotPairingCard`): the parent generates a
+   **6-digit, single-use code** (10-min TTL). Issued by `POST /api/devices/pair-code`.
+2. **Robot** settings page: the parent types the code; the robot calls
+   `POST /api/devices/pair` and receives a **device token** (only the SHA-256
+   hash is stored server-side). The token lives in the robot's local `.env`.
+3. On boot the robot calls `GET /api/devices/me` (Bearer token) to fetch a
+   **non-sensitive learning profile** (name, preferred buddy/coach, school/grade
+   level, age, language, subjects, accessibility flags) — **never** email/password.
+4. The parent can **revoke** any device from the same card (`DELETE /api/devices/:id`).
+
+The child's credentials never leave the computer; the robot only ever holds a
+revocable token and a learning profile.
+
+### Security model (reviewed — see Consequences)
+
+- Codes are 6-digit, single-use, 10-min TTL.
+- **Atomic redeem**: a single guarded `updateMany` (unredeemed + unrevoked +
+  unexpired) claims the code, closing the double-redeem (TOCTOU) race.
+- **Rate limiting**: per-IP **and** a global brute-force ceiling
+  (`DEVICE_PAIR_GLOBAL`, 100/15 min) that is deployment-independent.
+- **Only hashes stored**: `sha256(code)` and `sha256(token)`; plaintext is
+  returned once and never persisted.
+- `listDevices` returns only `pairedAt != null` rows (no phantom devices).
+
+## Consequences
+
+### Positive
+
+- MirrorBuddy gains a physical, voice-first embodiment reusing its whole tutor
+  stack; the web app is untouched by the embodiment (robot app is additive).
+- Children are personalised on the robot without any credential exposure;
+  parents retain revocation control (GDPR-aligned, ADR 0008).
+- Safety (stop word) and vision (homework) are handled locally and privately.
+
+### Negative / Costs
+
+- A second codebase (`robot/`) to keep in feature-parity with the web tutor.
+- New web surface: `RobotDevice` Prisma model + 5 `/api/devices/*` routes + a
+  settings card + 15 new i18n keys × 5 locales.
+
+### Security review outcome (@luca) — no critical findings
+
+Hardening above was applied post-review. Two follow-ups are tracked as roadmap
+(non-blocking):
+
+- **H2** — the robot's local settings server binds to the LAN. Mitigation:
+  run the robot on a trusted home network, or restrict to loopback + a PIN.
+- **L3** — device tokens are revocable but not yet TTL-rotated; `lastSeenAt` is
+  recorded to enable future idle-expiry.
+
+### Accessibility
+
+The deterministic stop word is an accessibility requirement, not a nicety: it
+must be enforced by a local audio interrupt, independent of the model, so a
+distressed child is always obeyed instantly.
+
+## Testing
+
+- Web: 25 unit tests (device service + 5 routes) + `RobotPairingCard` render/flow
+  tests; i18n parity 5/5 locales.
+- Robot: pure-logic device-profile tests; validated live on hardware
+  (voice, professor switching, vision, movement, deterministic stop).
+
+## Open Questions
+
+1. Should the settings-server bind (H2) be hardened to loopback+PIN before GA,
+   or is "trusted home network" acceptable for the pilot?
+2. Should device tokens gain an idle TTL (L3) now, or after field data on
+   `lastSeenAt`?
+3. Publishing to the Hugging Face Reachy Mini app store — packaging cadence and
+   who owns the listing.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -182,6 +182,7 @@
 | 0126 | Unified Camera Architecture                            | Video/photo mode selector                    |
 | 0133 | PWA Offline Strategy                                   | Native Service Worker, offline-first caching |
 | 0134 | Gamification UI - Surface Backend Achievements         | Achievements page, streaks, XP progress      |
+| 0170 | Reachy Mini Robot Embodiment + Device Pairing          | Voice-first robot tutor, credential-free pairing |
 
 ## Tier & Business
 

--- a/docs/reachy-mini-robot.md
+++ b/docs/reachy-mini-robot.md
@@ -1,0 +1,98 @@
+# MirrorBuddy on Reachy Mini — the robot tutor
+
+MirrorBuddy is normally a tutor you use on a screen. With a **Reachy Mini** robot
+it gets a **body**: the same tutor, the same voice and the same teachers, but with
+eyes that follow the child, ears that listen, a voice that speaks and expressive
+movement — used entirely **by voice, with no screen**.
+
+This page explains the feature for everyone, **including families who don't have a
+robot yet**. If you already have one, jump to [Pairing](#pairing-with-a-childs-profile).
+
+![Reachy Mini](https://huggingface.co/blog/assets/reachy-mini/thumbnail.jpg)
+
+## What is Reachy Mini?
+
+[Reachy Mini](https://huggingface.co/blog/reachy-mini) is a small, affordable
+desktop robot from Hugging Face (Raspberry Pi CM4, moving head and antennas, a
+microphone array, a speaker and a camera). MirrorBuddy runs as an app **on the
+robot** and turns it into a physical study companion.
+
+- **Buy it:** <https://www.reachy-mini.org/buy.html> — Reachy Mini **Lite** from
+  about **$299**, **Wireless** from about **$449**.
+- Announcement & specs: <https://huggingface.co/blog/reachy-mini>
+
+You do **not** need a robot to use MirrorBuddy — the web tutor at mirrorbuddy.org
+is complete on its own. The robot is an optional, delightful add-on.
+
+## What the robot can do
+
+| Capability          | What it means for the child                                             |
+| ------------------- | ----------------------------------------------------------------------- |
+| 👀 **Eyes**         | The camera-driven head **follows the student's face** while listening.  |
+| 👂 **Ears / 🗣 Voice** | Real-time speech-to-speech (Azure OpenAI Realtime) — same voices as web. |
+| 📷 **Homework camera** | On request, it **looks at the homework** on the desk and helps.      |
+| 🤸 **Movement**     | Expressive head/antenna motion adapted to each teacher's style.         |
+| ✋ **Deterministic stop** | Say **"basta"** and it goes silent **immediately** — no stress.    |
+| 🎓 **All 26 Maestri** | Switch professor or subject **by voice**; no screen required.         |
+
+Everything is voice-first: there is no on-robot UI to read. The child talks; Buddy
+answers, moves, and can look at what's on the table.
+
+## Pairing with a child's profile
+
+Because there's no screen, the robot needs to know **which child** it's helping —
+without ever handling the child's password. It does this with a short pairing code.
+
+1. On the child's computer, open **Settings → Integrations → "Collega un robot"**
+   and tap **Genera codice** (a 6-digit code, valid 10 minutes).
+2. On the robot's settings page, under **"Profilo del bambino"**, type that code.
+3. The robot exchanges the code for a scoped **device token** and boots already
+   personalised: the child's name, preferred teacher, language and accessibility
+   settings.
+
+A parent can **unpair** the robot at any time from the same settings card.
+
+### Privacy by design
+
+- The child's **password and email never leave the computer**. The robot only
+  ever holds a **revocable device token** and a **non-sensitive learning profile**
+  (name, preferred buddy/coach, school/grade level, age, language, subjects,
+  accessibility flags).
+- The camera **never streams**: it grabs a **single frame** only on an explicit
+  *"look at my homework"* request, always announced out loud, and **nothing is
+  persisted** to disk.
+- See [ADR 0170](adr/0170-reachy-mini-robot-embodiment.md) for the full
+architecture and security model, and [ADR 0008](adr/0008-parent-dashboard-gdpr.md)
+  for the parental-consent model.
+
+### Safety: the stop word
+
+For a child with additional needs, an insistent robot is stressful. Saying
+**"basta", "zitto", "fermati", "aspetta"** or **"pausa"** triggers a **hard local
+audio interrupt** — the robot stops speaking instantly and does **not**
+auto-resume. This is enforced on the robot itself, independently of the AI model,
+so the child is always obeyed immediately.
+
+## Configuring the app
+
+The web-side pairing UI lives in **Settings → Integrations**. The robot-side
+configuration (Azure endpoint, camera on/off, face-follow, frame saving for
+debugging, API base URL and the device token) is documented in the robot app's
+own README:
+
+- Robot app README (install, modules, env vars): [`robot/README.md`](../robot/README.md)
+- Example environment: [`robot/.env.example`](../robot/.env.example)
+
+Key toggles: `MIRRORBUDDY_ENABLE_CAMERA`, `MIRRORBUDDY_FOLLOW_FACE`,
+`MIRRORBUDDY_DEVICE_TOKEN`, `MIRRORBUDDY_API_BASE`.
+
+## Publishing to the Reachy Mini app store
+
+The robot README ships with Hugging Face app-store front-matter (title, emoji,
+tags, thumbnail) so the app can be listed on the Reachy Mini store. See
+[`robot/README.md`](../robot/README.md) → *Publishing to the Reachy Mini app store*.
+
+## Localisation
+
+All user-facing pairing copy is localised in the 5 supported locales
+(it/en/fr/de/es) under `apps/web/messages/*/settings.json` → `settings.robotPairing`.

--- a/robot/.env.example
+++ b/robot/.env.example
@@ -23,6 +23,15 @@ MIRRORBUDDY_DSA_PROFILE=cerebral
 # Personalise the greeting.
 MIRRORBUDDY_STUDENT_NAME=Mario
 
+# --- device pairing (optional) ------------------------------------------------
+# When paired to a logged-in child (via the robot settings page > "Profilo del bambino",
+# or the parent's MirrorBuddy Settings > Integrations), the robot fetches that child's
+# profile (name, accessibility, locale) and starts personalised. Only a scoped token is
+# stored here — never the child's password. Leave empty to use the local config above.
+MIRRORBUDDY_DEVICE_TOKEN=
+# Where the pairing API lives. Defaults to MIRRORBUDDY_URL if empty.
+MIRRORBUDDY_API_BASE=
+
 # --- feature toggles ----------------------------------------------------------
 # Camera (vision): let Buddy take a photo to read homework, on explicit request only.
 MIRRORBUDDY_ENABLE_CAMERA=true

--- a/robot/README.md
+++ b/robot/README.md
@@ -74,8 +74,9 @@ model speech stream over a single Azure Realtime WebSocket (`azure_realtime`).
 | `audio_io.py` | Robot mic ↔ speaker bridge (resampling, playback, barge-in) |
 | `movements.py` | Expressive full-body motion + daemon face-follow while listening |
 | `camera.py` | On-demand JPEG capture + daemon head/face tracking helpers |
-| `tools.py` | Voice tool schemas (list/change professor, look at homework) + resolver |
-| `controller.py` | Tool dispatch, live professor switching and vision |
+| `tools.py` | Voice tool schemas (list/change professor, look at homework, friend/study) + resolver |
+| `session_flow.py` | Pure stop / end / wake decisions for the live loop (accessibility-critical) |
+| `controller.py` | Tool dispatch, live professor switching, vision, sleep/wake |
 | `settings_ui.py` | Minimal in-app settings page (creds + Maestro/DSA selection) |
 | `main.py` | App entry point wiring everything together |
 
@@ -89,6 +90,27 @@ Buddy is voice-only, so the model drives the robot through realtime **tools**:
 - **Look at homework** — say e.g. *«guarda questo compito»*. `look_at_homework` captures
   one camera frame and the model reads the exercise and helps step by step.
 - **Who is here** — `list_professors` enumerates the available Maestri and their subjects.
+- **Just a friend (not school)** — say e.g. *«non voglio fare i compiti»* or *«parliamo un
+  po'»*. Buddy switches to **friend mode** (`talk_as_friend`): the peer‑companion Buddy of
+  MirrorBuddy's Support Triangle — a warm coetaneo you can talk to about anything, not a
+  tutor. Say *«torniamo ai compiti»* (`back_to_study`) to go back to studying.
+
+## Ending a session & interrupting (accessibility‑critical)
+
+Insistence is stressful for the child, so these are handled **deterministically and
+locally** — never left to the model:
+
+- **Stop / be quiet now** — say *«basta»*, *«zitto»*, *«fermati»*, *«aspetta»*, *«pausa»*.
+  Buddy goes silent immediately (local audio flush + turn cancel); it stays available and
+  the next thing you say resumes normally.
+- **We're done for today** — say *«abbiamo finito»*, *«a domani»*, *«buonanotte»*,
+  *«vai a dormire»*. Buddy says **one** short goodbye, then **goes to sleep**: it stops
+  moving, stops talking and ignores ambient chatter — no nagging, no restart.
+- **Wake it back up** — while asleep, say its name *«Buddy»* (or *«svegliati»*, *«ci sei?»*).
+  Buddy wakes with a small gesture, greets again and asks what you'd like to do.
+
+These intents are detected in `session_flow.py`/`rt_messages.py` and enforced in
+`azure_realtime.py`, so they work even if the model would rather keep talking.
 
 ## Pair with the child's MirrorBuddy profile
 

--- a/robot/README.md
+++ b/robot/README.md
@@ -100,13 +100,13 @@ Buddy is voice-only, so the model drives the robot through realtime **tools**:
 Insistence is stressful for the child, so these are handled **deterministically and
 locally** — never left to the model:
 
-- **Stop / be quiet now** — say *«basta»*, *«zitto»*, *«fermati»*, *«aspetta»*, *«pausa»*.
-  Buddy goes silent immediately (local audio flush + turn cancel); it stays available and
-  the next thing you say resumes normally.
+- **Stop / rest now** — say *«basta»*, *«zitto»*, *«fermati»*, *«aspetta»*, *«pausa»*.
+  Buddy goes silent immediately (local audio flush + turn cancel), settles into a calm
+  **rest position** and **stays parked** — no fidgeting, no talking — until you call it back.
+  A stop is a full stop, not a brief pause that resumes on the next sound.
 - **We're done for today** — say *«abbiamo finito»*, *«a domani»*, *«buonanotte»*,
-  *«vai a dormire»*. Buddy says **one** short goodbye, then **goes to sleep**: it stops
-  moving, stops talking and ignores ambient chatter — no nagging, no restart.
-- **Wake it back up** — while asleep, say its name *«Buddy»* (or *«svegliati»*, *«ci sei?»*).
+  *«vai a dormire»*. Buddy says **one** short goodbye, then rests the same way.
+- **Wake it back up** — while resting, say its name *«Buddy»* (or *«svegliati»*, *«ci sei?»*).
   Buddy wakes with a small gesture, greets again and asks what you'd like to do.
 
 These intents are detected in `session_flow.py`/`rt_messages.py` and enforced in

--- a/robot/README.md
+++ b/robot/README.md
@@ -100,12 +100,14 @@ Buddy is voice-only, so the model drives the robot through realtime **tools**:
 Insistence is stressful for the child, so these are handled **deterministically and
 locally** — never left to the model:
 
-- **Stop / rest now** — say *«basta»*, *«zitto»*, *«fermati»*, *«aspetta»*, *«pausa»*.
-  Buddy goes silent immediately (local audio flush + turn cancel), settles into a calm
-  **rest position** and **stays parked** — no fidgeting, no talking — until you call it back.
-  A stop is a full stop, not a brief pause that resumes on the next sound.
+- **Stop / rest now** — say *«basta»*, *«zitto»*, *«fermati»*, *«aspetta»*, *«pausa»*, or
+  the explicit sleep command *«dormi»* / *«vai a dormire»* / *«riposati»*.
+  Buddy goes silent **immediately and says nothing back** (local audio flush + turn cancel,
+  and the server is configured **not** to auto-reply — a response is only ever requested
+  after an ordinary turn), settles into a calm **rest position** and **stays parked** — no
+  fidgeting, no talking — until you call it back. A stop is a full stop, never a reply.
 - **We're done for today** — say *«abbiamo finito»*, *«a domani»*, *«buonanotte»*,
-  *«vai a dormire»*. Buddy says **one** short goodbye, then rests the same way.
+  *«ci vediamo»*. Buddy says **one** short goodbye, then rests the same way.
 - **Wake it back up** — while resting, say its name *«Buddy»* (or *«svegliati»*, *«ci sei?»*).
   Buddy wakes with a small gesture, greets again and asks what you'd like to do.
 

--- a/robot/README.md
+++ b/robot/README.md
@@ -108,8 +108,9 @@ locally** — never left to the model:
   fidgeting, no talking — until you call it back. A stop is a full stop, never a reply.
 - **We're done for today** — say *«abbiamo finito»*, *«a domani»*, *«buonanotte»*,
   *«ci vediamo»*. Buddy says **one** short goodbye, then rests the same way.
-- **Wake it back up** — while resting, say its name *«Buddy»* (or *«svegliati»*, *«ci sei?»*).
-  Buddy wakes with a small gesture, greets again and asks what you'd like to do.
+- **Wake it back up** — while resting it ignores everything **except its name**: say
+  *«Buddy»* and it wakes with a small gesture, greets again and asks what you'd like to do.
+  Nothing else brings it back, so a rest really lasts until you call it.
 
 These intents are detected in `session_flow.py`/`rt_messages.py` and enforced in
 `azure_realtime.py`, so they work even if the model would rather keep talking.

--- a/robot/README.md
+++ b/robot/README.md
@@ -107,6 +107,13 @@ ever holds a revocable device token and a non-sensitive learning profile. A pare
 **unpair** the robot at any time from the same settings page. If the robot is not paired,
 it falls back to the local `.env` configuration.
 
+**Security model.** The redeem endpoint is protected by per-IP **and** a global
+brute-force ceiling; codes are 6-digit, single-use, expire in 10 minutes, and are claimed
+atomically (no double-redeem). Two hardening follow-ups are tracked on the roadmap: (1) the
+robot's local settings server binds to the LAN — run the robot on a trusted home network or
+restrict it to loopback + a PIN; (2) device tokens are revocable but do not yet auto-rotate
+on a TTL (`lastSeenAt` is recorded for future idle-expiry).
+
 ## Eyes: face-follow & privacy
 
 While listening, the robot **follows the student's face** (daemon head tracking); when

--- a/robot/README.md
+++ b/robot/README.md
@@ -1,4 +1,31 @@
+---
+title: MirrorBuddy on Reachy Mini
+emoji: 🤖
+license: apache-2.0
+tags:
+  - reachy-mini
+  - reachy_mini_app
+  - education
+  - accessibility
+  - tutoring
+  - azure-openai
+  - realtime
+short_description: A MirrorBuddy tutor with eyes, ears, mouth and movement — for kids with DSA.
+thumbnail: https://huggingface.co/blog/assets/reachy-mini/thumbnail.jpg
+---
+
+<!--
+Hugging Face app-store card (front-matter above). Reachy Mini discovers this app via the
+[project.entry-points.reachy_mini_apps] group in pyproject.toml.
+-->
+
 # MirrorBuddy on Reachy Mini 🤖
+
+[![Reachy Mini](https://huggingface.co/blog/assets/reachy-mini/thumbnail.jpg)](https://www.reachy-mini.org/)
+
+> 🛒 **Get the robot:** [Reachy Mini](https://www.reachy-mini.org/buy.html) by Hugging Face &
+> Pollen Robotics — **Lite $299** (USB-tethered) or **Wireless $449** (on-board compute).
+> See the [Hugging Face announcement](https://huggingface.co/blog/reachy-mini).
 
 The **physical embodiment of MirrorBuddy**: a Reachy Mini robot that becomes a
 MirrorBuddy Maestro with a body —
@@ -63,6 +90,23 @@ Buddy is voice-only, so the model drives the robot through realtime **tools**:
   one camera frame and the model reads the exercise and helps step by step.
 - **Who is here** — `list_professors` enumerates the available Maestri and their subjects.
 
+## Pair with the child's MirrorBuddy profile
+
+The robot can bind to the **logged-in child's MirrorBuddy account** so it starts
+personalised for that child (name, preferred professor, accessibility settings, locale)
+instead of a generic default:
+
+1. In MirrorBuddy on the child's computer, open **Settings → Integrations → "Collega un
+   robot"** and tap **Genera codice** (a 6-digit code, valid 10 minutes).
+2. On the robot's settings page, under **"Profilo del bambino"**, type that code.
+3. The robot redeems it at `POST /api/devices/pair`, stores only a scoped **device token**
+   in its local `.env`, and fetches the child's profile from `GET /api/devices/me`.
+
+**Privacy by design:** the child's password never leaves their computer — the robot only
+ever holds a revocable device token and a non-sensitive learning profile. A parent can
+**unpair** the robot at any time from the same settings page. If the robot is not paired,
+it falls back to the local `.env` configuration.
+
 ## Eyes: face-follow & privacy
 
 While listening, the robot **follows the student's face** (daemon head tracking); when
@@ -72,10 +116,6 @@ Privacy by design: the camera **never streams** and captures a frame **only** on
 explicit `look_at_homework` request, always preceded by a spoken *"I'm going to look…"*.
 Nothing (audio or images) is persisted to disk. Face-follow and the camera can be turned
 off with `MIRRORBUDDY_FOLLOW_FACE=false` / `MIRRORBUDDY_ENABLE_CAMERA=false`.
-
-Identity: the robot is configured **per device** (`MIRRORBUDDY_STUDENT_NAME`,
-`MIRRORBUDDY_DSA_PROFILE`) rather than tied to a MirrorBuddy web login; secure
-device-to-account pairing is on the roadmap.
 
 ## Configuration
 
@@ -94,6 +134,16 @@ Useful optional:
 - `MIRRORBUDDY_MAESTRO_ID` — which professor to embody (empty = first Italian tutor)
 - `MIRRORBUDDY_DSA_PROFILE` — `cerebral` (default), `dyslexia`, `adhd`, …
 - `MIRRORBUDDY_STUDENT_NAME` — personalises the greeting (e.g. `Mario`)
+- `MIRRORBUDDY_DEVICE_TOKEN` — set automatically when you pair (see *Pair with the
+  child's MirrorBuddy profile* above); overrides the fields above with the live profile
+
+### Publishing to the Reachy Mini app store
+
+No secrets are baked into the package — the Azure credentials and the device token live
+only in the **instance `.env`**, entered by the user on the in-app settings page. So the
+package can be published to the Hugging Face Hub as-is: it self-declares under the
+`reachy_mini_apps` entry-point group and carries the app-card front-matter at the top of
+this README (title, emoji, tags, thumbnail).
 
 ## Install on the robot
 

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -56,7 +56,20 @@ class AudioIO:
         self.robot.media.start_recording()
         self.robot.media.start_playing()
         time.sleep(1.0)  # let the gstreamer pipelines come up
+        self._probe_rates()
 
+        self._recording = True
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._input_loop, name="MirrorBuddyMic", daemon=True)
+        self._thread.start()
+
+    def _probe_rates(self) -> None:
+        """Read the actual mic/speaker sample rates from the media server.
+
+        Must run before any playback: play() resamples from the realtime rate to
+        the speaker rate, and an unknown speaker rate makes the first audio chunks
+        play at the wrong pitch (a "ghost" voice) until the rate is known.
+        """
         try:
             self._in_rate = int(self.robot.media.get_input_audio_samplerate())
         except Exception:
@@ -67,11 +80,6 @@ class AudioIO:
             self._out_rate = 16000
         logger.info("Audio rates — mic: %s Hz, speaker: %s Hz, realtime: %s Hz",
                     self._in_rate, self._out_rate, SAMPLE_RATE)
-
-        self._recording = True
-        self._stop.clear()
-        self._thread = threading.Thread(target=self._input_loop, name="MirrorBuddyMic", daemon=True)
-        self._thread.start()
 
     def stop(self) -> None:
         self._recording = False
@@ -103,6 +111,11 @@ class AudioIO:
                 logger.debug("movement feed error: %s", e)
 
         out_rate = self._out_rate or SAMPLE_RATE
+        if self._out_rate is None:
+            # Playback started before rates were probed (e.g. an early greeting):
+            # probe now so we don't emit the first chunks at the wrong rate.
+            self._probe_rates()
+            out_rate = self._out_rate or SAMPLE_RATE
         if out_rate != SAMPLE_RATE and audio.size:
             audio = _resample(audio, SAMPLE_RATE, out_rate)
         audio_f32 = (np.asarray(audio, dtype=np.float32)) / 32768.0

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -15,6 +15,8 @@ from collections.abc import Callable
 import websockets
 
 from . import rt_messages
+from . import session_flow
+from . import tools
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +47,8 @@ class AzureRealtimeClient:
         on_transcript: Callable[[str, bool], None] | None = None,
         on_ready: Callable[[], None] | None = None,
         on_tool_call: Callable[[str, dict, str], None] | None = None,
+        on_sleep: Callable[[], None] | None = None,
+        on_wake: Callable[[], None] | None = None,
     ) -> None:
         self.ws_url = ws_url
         self.api_key = api_key
@@ -59,6 +63,8 @@ class AzureRealtimeClient:
         self.on_transcript = on_transcript
         self.on_ready = on_ready
         self.on_tool_call = on_tool_call
+        self.on_sleep = on_sleep
+        self.on_wake = on_wake
         self._fc_names: dict[str, str] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
@@ -68,6 +74,9 @@ class AzureRealtimeClient:
         self._responding = False  # a model response is currently streaming
         self._suppress = False  # drop in-flight audio after a barge-in cancel
         self._quiet = False  # student asked for silence: keep model muted
+        self._asleep = False  # session ended: stay muted until the wake word
+        self._sleep_after = False  # go to sleep once the farewell response finishes
+        self._pending_farewell = False  # a goodbye was requested; sleep when it starts→done
 
     def start(self) -> None:
         self._thread = threading.Thread(target=self._run, name="AzureRealtime", daemon=True)
@@ -165,6 +174,10 @@ class AzureRealtimeClient:
         )
         await self._safe_send(json.dumps({"type": "response.create", "response": {"instructions": instructions}}))
 
+    async def _request_response(self, instructions: str | None = None) -> None:
+        """Ask the model to speak now, optionally steering what it should say."""
+        await self._safe_send(json.dumps(rt_messages.response_create(instructions)))
+
     async def _handle_event(self, event: dict) -> None:
         etype = event.get("type", "")
 
@@ -185,23 +198,47 @@ class AzureRealtimeClient:
             return
 
         if etype == "response.created":
-            if self._quiet:
+            if self._quiet or self._asleep:
                 await self._safe_send(rt_messages.CANCEL)
                 self._suppress = True
                 return
+            if self._pending_farewell:  # the goodbye is now starting → sleep once it's done
+                self._pending_farewell = False
+                self._sleep_after = True
             self._responding = True
             self._suppress = False
             return
         if etype == "response.done":
             self._responding = False
+            if self._sleep_after:  # farewell just finished → go to sleep
+                self._sleep_after = False
+                self._asleep = True
+                if self.on_sleep:
+                    _safe_cb(self.on_sleep)
             return
 
-        # Student's speech transcribed: honour stop-intent deterministically.
+        # Student's speech transcribed: honour stop / end / wake intents deterministically.
         if etype.endswith("input_audio_transcription.completed"):
             text = (event.get("transcript") or "").strip()
             if not text:
                 return
-            self._quiet = rt_messages.is_stop(text)
+            action = session_flow.decide(text, self._asleep)
+            if action == session_flow.IGNORE:
+                return
+            if action == session_flow.WAKE:
+                self._asleep = self._quiet = False
+                if self.on_wake:
+                    _safe_cb(self.on_wake)
+                await self._request_response(rt_messages.WAKE_INSTR)
+                return
+            if action == session_flow.END:
+                self._pending_farewell = True
+                self._suppress = False
+                if self._responding:
+                    await self._safe_send(rt_messages.CANCEL)
+                await self._request_response(rt_messages.FAREWELL_INSTR)
+                return
+            self._quiet = action == session_flow.STOP
             if self._quiet:
                 self._suppress = True
                 if self._responding:
@@ -212,6 +249,8 @@ class AzureRealtimeClient:
 
         # Barge-in: cancel the turn, drop in-flight audio; each new turn starts un-muted.
         if etype == "input_audio_buffer.speech_started":
+            if self._asleep:
+                return  # ignore ambient speech while asleep; wake word handles it
             self._suppress = True
             self._quiet = False
             if self._responding:
@@ -236,12 +275,7 @@ class AzureRealtimeClient:
 
         if etype == "response.function_call_arguments.done":
             call_id = event.get("call_id") or ""
-            name = event.get("name") or self._fc_names.get(call_id, "")
-            raw_args = event.get("arguments") or "{}"
-            try:
-                args = json.loads(raw_args) if isinstance(raw_args, str) else dict(raw_args)
-            except (ValueError, TypeError):
-                args = {}
+            name, args = tools.parse_call_arguments(event, self._fc_names.get(call_id, ""))
             self._fc_names.pop(call_id, None)
             logger.info("Tool call: %s(%s) call_id=%s", name, args, call_id)
             if name and self.on_tool_call:

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -251,6 +251,12 @@ class AzureRealtimeClient:
                     _safe_cb(self.on_speech_started)  # flush local playback now
                 if self.on_sleep:
                     _safe_cb(self.on_sleep)  # settle into the rest position
+                return
+            if action == session_flow.SPEAK:
+                # The server no longer auto-creates a response (create_response=False),
+                # so we ask for one only once we've classified the turn as ordinary.
+                # This guarantees a stop/sleep word never produces a spoken reply.
+                await self._request_response()
             return
 
         # Barge-in: cancel the turn, drop in-flight audio; each new turn starts un-muted.

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -238,13 +238,19 @@ class AzureRealtimeClient:
                     await self._safe_send(rt_messages.CANCEL)
                 await self._request_response(rt_messages.FAREWELL_INSTR)
                 return
-            self._quiet = action == session_flow.STOP
-            if self._quiet:
+            if action == session_flow.STOP:
+                # "basta / fermati" → go quiet AND park in a rest posture, staying put
+                # until called back by name. Insistence stresses the child, so a stop is
+                # a full stop, not a brief pause that resumes on the next sound.
+                self._asleep = True
+                self._quiet = True
                 self._suppress = True
                 if self._responding:
                     await self._safe_send(rt_messages.CANCEL)
                 if self.on_speech_started:
                     _safe_cb(self.on_speech_started)  # flush local playback now
+                if self.on_sleep:
+                    _safe_cb(self.on_sleep)  # settle into the rest position
             return
 
         # Barge-in: cancel the turn, drop in-flight audio; each new turn starts un-muted.

--- a/robot/reachy_mini_mirrorbuddy/config.py
+++ b/robot/reachy_mini_mirrorbuddy/config.py
@@ -15,6 +15,9 @@ Optional:
     MIRRORBUDDY_MAESTRO_ID             which Maestro to embody (default: first Italian tutor)
     MIRRORBUDDY_DSA_PROFILE            one of the DSA profiles (see dsa.py); default "cerebral"
     MIRRORBUDDY_STUDENT_NAME           personalise the greeting (e.g. "Mario")
+    MIRRORBUDDY_DEVICE_TOKEN           pairing token; when set, the logged-in child's profile
+                                       (name, accessibility, locale) is fetched and applied
+    MIRRORBUDDY_API_BASE               where the pairing API lives (default: MIRRORBUDDY_URL)
 """
 
 from __future__ import annotations
@@ -53,6 +56,11 @@ class Config:
         self.MAESTRO_ID: str | None = (os.getenv("MIRRORBUDDY_MAESTRO_ID") or "").strip() or None
         self.DSA_PROFILE: str = (os.getenv("MIRRORBUDDY_DSA_PROFILE") or "cerebral").strip()
         self.STUDENT_NAME: str | None = (os.getenv("MIRRORBUDDY_STUDENT_NAME") or "").strip() or None
+        # Device pairing: a token bound to the logged-in child's account. When present, the
+        # robot fetches that child's profile (name, accessibility, locale) from the web app.
+        self.DEVICE_TOKEN: str | None = (os.getenv("MIRRORBUDDY_DEVICE_TOKEN") or "").strip() or None
+        api_base = (os.getenv("MIRRORBUDDY_API_BASE") or "").strip().rstrip("/")
+        self.API_BASE: str = api_base or self.MIRRORBUDDY_URL
         # Start neutrally as "Buddy" (organise the study session) instead of impersonating a
         # historical Maestro. A pinned MIRRORBUDDY_MAESTRO_ID always takes precedence.
         self.START_NEUTRAL: bool = _flag("MIRRORBUDDY_START_NEUTRAL", True)

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -95,11 +95,11 @@ class Controller:
 
     # ------------------------------------------------------------------ sleep / wake
     def _on_sleep(self) -> None:
-        """Session ended: park the robot quietly until it is called back."""
+        """Stop/end: settle into a calm rest posture and stay put until called back."""
         try:
             self.audio.interrupt()
-            self.movements.hold_still()  # freeze motion, antennas rest — a calm 'sleep'
-            logger.info("Session ended; robot is now asleep. Say 'Buddy' to wake it.")
+            self.movements.hold_still()  # rest position: head level, antennas calm, no motion
+            logger.info("Robot is resting. Say 'Buddy' to wake it up.")
         except Exception as e:  # pragma: no cover - runtime robustness
             logger.debug("sleep handling failed: %s", e)
 

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -19,7 +19,7 @@ from .audio_io import AudioIO
 from .azure_realtime import AzureRealtimeClient
 from .config import Config
 from .dsa import turn_detection_config
-from .mirrorbuddy_client import Maestro
+from .mirrorbuddy_client import Maestro, friend_buddy, neutral_buddy
 from .movements import Movements, temperament_for
 from .prompt_builder import build_instructions
 
@@ -89,7 +89,28 @@ class Controller:
             on_speech_started=self.audio.interrupt,
             on_transcript=_log_transcript,
             on_tool_call=self._on_tool_call,
+            on_sleep=self._on_sleep,
+            on_wake=self._on_wake,
         )
+
+    # ------------------------------------------------------------------ sleep / wake
+    def _on_sleep(self) -> None:
+        """Session ended: park the robot quietly until it is called back."""
+        try:
+            self.audio.interrupt()
+            self.movements.hold_still()  # freeze motion, antennas rest — a calm 'sleep'
+            logger.info("Session ended; robot is now asleep. Say 'Buddy' to wake it.")
+        except Exception as e:  # pragma: no cover - runtime robustness
+            logger.debug("sleep handling failed: %s", e)
+
+    def _on_wake(self) -> None:
+        """Called back by name: resume motion with a small wake gesture."""
+        try:
+            self.movements.release_hold()
+            self.movements.wake()
+            logger.info("Woken up; resuming the session.")
+        except Exception as e:  # pragma: no cover - runtime robustness
+            logger.debug("wake handling failed: %s", e)
 
     # ------------------------------------------------------------------ tools
     def _on_tool_call(self, name: str, args: dict, call_id: str) -> None:
@@ -104,6 +125,10 @@ class Controller:
                 self._handle_call_professor(client, args, call_id)
             elif name == "look_at_homework":
                 self._handle_look_at_homework(client, args, call_id)
+            elif name == "talk_as_friend":
+                self._switch_persona(client, call_id, friend=True)
+            elif name == "back_to_study":
+                self._switch_persona(client, call_id, friend=False)
             else:
                 client.send_function_result(call_id, "Ok.")
         except Exception as e:  # pragma: no cover - runtime robustness
@@ -121,6 +146,19 @@ class Controller:
         # Acknowledge without a spoken reply here; the new Maestro will greet.
         client.send_function_result(call_id, f"Passo la parola a {target.display_name}.", respond=False)
         threading.Thread(target=self._switch_to, args=(target,), name="MaestroSwitch", daemon=True).start()
+
+    def _switch_persona(self, client: AzureRealtimeClient, call_id: str, friend: bool) -> None:
+        """Swap between the friend companion and the study tutor (persona + voice)."""
+        target = (
+            friend_buddy(self.cfg.STUDENT_NAME, self.cfg.BUDDY_VOICE)
+            if friend
+            else neutral_buddy(self.cfg.STUDENT_NAME, self.cfg.BUDDY_VOICE)
+        )
+        if target.id == self.maestro.id:
+            client.send_function_result(call_id, "Certo, sono qui.")
+            return
+        client.send_function_result(call_id, "Va bene.", respond=False)
+        threading.Thread(target=self._switch_to, args=(target,), name="PersonaSwitch", daemon=True).start()
 
     def _handle_look_at_homework(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
         if not self.cfg.ENABLE_CAMERA:

--- a/robot/reachy_mini_mirrorbuddy/device.py
+++ b/robot/reachy_mini_mirrorbuddy/device.py
@@ -1,0 +1,91 @@
+"""Device pairing: fetch the paired child's profile and apply it to the config.
+
+When the robot is paired (``MIRRORBUDDY_DEVICE_TOKEN`` set), it calls the MirrorBuddy
+web app ``GET /api/devices/me`` with a Bearer token and receives the logged-in child's
+learning profile — never their credentials. We map that profile onto the robot config
+so Buddy starts personalised (name, accessibility, locale, calm motion) for that child.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DeviceProfile:
+    """The scoped, non-sensitive profile the web app returns for a paired device."""
+
+    name: str | None = None
+    preferred_buddy: str | None = None
+    preferred_coach: str | None = None
+    language: str = "it"
+    subjects: list[str] = field(default_factory=list)
+    accessibility: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_json(cls, d: dict[str, Any]) -> "DeviceProfile":
+        acc = d.get("accessibility")
+        return cls(
+            name=(str(d.get("name")).strip() or None) if d.get("name") else None,
+            preferred_buddy=(d.get("preferredBuddy") or None),
+            preferred_coach=(d.get("preferredCoach") or None),
+            language=str(d.get("language") or "it").strip() or "it",
+            subjects=[str(s) for s in (d.get("subjects") or []) if s],
+            accessibility=acc if isinstance(acc, dict) else {},
+        )
+
+
+def fetch_device_profile(api_base: str, token: str, timeout: float = 15.0) -> DeviceProfile | None:
+    """GET /api/devices/me with the device token. Returns None on any failure."""
+    url = f"{api_base.rstrip('/')}/api/devices/me"
+    try:
+        resp = httpx.get(
+            url,
+            timeout=timeout,
+            headers={"authorization": f"Bearer {token}", "accept": "application/json"},
+        )
+        if resp.status_code == 401:
+            logger.warning("Device token rejected (401). Re-pair the robot from the parent's settings.")
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+        profile = data.get("profile") if isinstance(data, dict) else None
+        if not isinstance(profile, dict):
+            return None
+        return DeviceProfile.from_json(profile)
+    except Exception as e:  # network / parse — degrade gracefully to local config
+        logger.warning("Could not fetch device profile from %s: %s", url, e)
+        return None
+
+
+def _dsa_from_accessibility(acc: dict[str, Any]) -> str | None:
+    """Map MirrorBuddy accessibility flags to a robot DSA profile (best-effort)."""
+    if acc.get("adhdMode"):
+        return "adhd"
+    if acc.get("dyslexiaFont"):
+        return "dyslexia"
+    return None
+
+
+def apply_device_profile(config, profile: DeviceProfile) -> None:
+    """Overlay a paired child's profile onto the runtime config (in place)."""
+    if profile.name:
+        config.STUDENT_NAME = profile.name
+    if profile.language:
+        config.LOCALE = profile.language
+    dsa = _dsa_from_accessibility(profile.accessibility)
+    if dsa:
+        config.DSA_PROFILE = dsa
+    # Reduced-motion is accessibility-critical: keep the robot calm for this child.
+    if profile.accessibility.get("reducedMotion"):
+        config.CALM_MOVEMENT = True
+    logger.info(
+        "Applied paired profile: name=%s locale=%s dsa=%s calm=%s",
+        config.STUDENT_NAME, config.LOCALE, config.DSA_PROFILE, config.CALM_MOVEMENT,
+    )

--- a/robot/reachy_mini_mirrorbuddy/dsa.py
+++ b/robot/reachy_mini_mirrorbuddy/dsa.py
@@ -54,6 +54,6 @@ def turn_detection_config(name: str | None) -> dict:
         "threshold": p.threshold,
         "prefix_padding_ms": p.prefix_padding_ms,
         "silence_duration_ms": p.silence_duration_ms,
-        "create_response": True,
+        "create_response": False,
         "interrupt_response": True,
     }

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -137,8 +137,11 @@ def run(
 
     movements.start()
     movements.wake()
-    controller.start()
+    # Start the audio pipeline *before* the realtime client so the speaker sample
+    # rate is probed before any greeting audio arrives. Otherwise the first chunks
+    # play at the wrong rate (a "ghost" voice) until the rate is known.
     audio.start()
+    controller.start()
     logger.info("MirrorBuddy is live 🎙️  — say something!")
 
     try:

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -82,6 +82,17 @@ def run(
             logger.error("Missing required configuration: %s", ", ".join(missing))
             sys.exit(1)
 
+    # If paired to a logged-in child, fetch and apply their profile (name, accessibility,
+    # locale) before choosing the persona — so Buddy starts personalised for that child.
+    if config.DEVICE_TOKEN:
+        from .device import apply_device_profile, fetch_device_profile
+
+        profile = fetch_device_profile(config.API_BASE, config.DEVICE_TOKEN)
+        if profile is not None:
+            apply_device_profile(config, profile)
+        else:
+            logger.info("No paired profile applied; using local .env configuration.")
+
     # Fetch the Maestro persona live from MirrorBuddy.
     mb = MirrorBuddyClient(config.MIRRORBUDDY_URL, locale=config.LOCALE)
     try:

--- a/robot/reachy_mini_mirrorbuddy/mirrorbuddy_client.py
+++ b/robot/reachy_mini_mirrorbuddy/mirrorbuddy_client.py
@@ -139,3 +139,45 @@ def neutral_buddy(student_name: str | None = None, voice: str = DEFAULT_VOICE) -
         system_prompt=system_prompt,
         greeting=greeting,
     )
+
+
+def friend_buddy(student_name: str | None = None, voice: str = DEFAULT_VOICE) -> Maestro:
+    """Buddy in *friend* mode — the peer companion, not the tutor.
+
+    Part of MirrorBuddy's Support Triangle (Maestri = subjects, Coach = method,
+    Buddy = peer/emotional support). Here Buddy is simply a friend to talk with
+    about anything — not school — mirroring the student: same learning
+    differences, about a year older, sharing struggles as an equal.
+    """
+    v = voice.strip().lower() if voice else DEFAULT_VOICE
+    if v not in VALID_VOICES:
+        v = DEFAULT_VOICE
+    name = (student_name or "").strip()
+    hello = f"Ehi {name}! " if name else "Ehi! "
+    greeting = (
+        f"{hello}Va bene, niente compiti adesso. Sono Buddy, il tuo amico: "
+        "di cosa hai voglia di parlare? Com'e' andata la giornata?"
+    )
+    system_prompt = (
+        "Sei Buddy in modalita' AMICO: non un tutor e non un professore, ma un amico coetaneo "
+        "dello studente (piu' grande di circa un anno) che ha le sue stesse difficolta' di "
+        "apprendimento e lo capisce davvero. Parli di QUALSIASI cosa lui voglia — la giornata, "
+        "gli amici, i videogiochi, lo sport, le passioni, le emozioni, le paure — con calore, "
+        "curiosita' e leggerezza. NON fai lezione e non riporti ai compiti: ci si rilassa e si "
+        "chiacchiera. Ascolti molto, fai domande semplici, condividi piccole esperienze da pari. "
+        "Se lo studente vuole tornare a studiare usa lo strumento 'back_to_study'. Restano valide "
+        "tutte le regole di sicurezza: se emerge un disagio serio, con dolcezza invitalo a parlarne "
+        "con un adulto di fiducia."
+    )
+    return Maestro(
+        id="buddy-friend",
+        name="Buddy",
+        display_name="Buddy",
+        subject="",
+        specialty="amicizia e ascolto",
+        voice=v,
+        voice_instructions="Voce calda, informale e amichevole; ritmo rilassato, tono da coetaneo.",
+        teaching_style="amico coetaneo, empatico, informale",
+        system_prompt=system_prompt,
+        greeting=greeting,
+    )

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -208,13 +208,14 @@ class Movements:
             if speaking:
                 body_yaw += math.radians(8.0 * s * energy * math.sin(2 * math.pi * 0.6 * t))
 
-            # Antennas: idle sway + perk up while speaking.
+            # Antennas: idle sway + a gentle lift while speaking (kept small so the
+            # antennas don't flap distractingly for the student).
             sway = math.radians(18.0 * s) * math.sin(2 * math.pi * 0.5 * w * t)
             if speaking:
                 perk = _ANTENNA_MAX * min(1.0, 0.4 + energy)
-                flutter = math.radians(12.0) * math.sin(2 * math.pi * 6.0 * t)
-                right = _clamp(_ANTENNA_NEUTRAL + perk * 0.6 + flutter)
-                left = _clamp(_ANTENNA_NEUTRAL + perk * 0.6 - flutter)
+                flutter = math.radians(5.0 * s) * math.sin(2 * math.pi * 4.0 * t)
+                right = _clamp(_ANTENNA_NEUTRAL + perk * 0.4 + flutter)
+                left = _clamp(_ANTENNA_NEUTRAL + perk * 0.4 - flutter)
             else:
                 right = _clamp(_ANTENNA_NEUTRAL + sway)
                 left = _clamp(_ANTENNA_NEUTRAL - sway)

--- a/robot/reachy_mini_mirrorbuddy/rt_messages.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_messages.py
@@ -30,6 +30,54 @@ def is_stop(text: str | None) -> bool:
     return bool(text and _STOP_RE.search(text))
 
 
+# End-of-session intent: the student signals they are done for now. Unlike a stop
+# (be quiet a moment), this ends the session — the robot says a short goodbye and
+# goes to sleep until it hears its name again. Deterministic, like the stop word.
+_END_RE = re.compile(
+    r"\b("
+    r"(?:abbiamo|ho|hai)\s+(?:finito|terminato|concluso)|"
+    r"finito\s+per\s+oggi|basta\s+(?:studiare|compiti|per\s+oggi)|"
+    r"a\s+domani|ci\s+vediamo|arrivederci|buonanotte|buona\s+notte|"
+    r"(?:vai\s+a|puoi|vatti\s+a)\s+dormire|riposati|spegniti|"
+    r"abbiamo\s+finito"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Wake intent: while asleep, only the robot's name (or a clear call) brings it back.
+_WAKE_RE = re.compile(r"\b(buddy|svegliati|sei\s+sveglio|ci\s+sei|ehi\s+robot)\b", re.IGNORECASE)
+
+
+def is_end(text: str | None) -> bool:
+    """True if the student is ending the session ('abbiamo finito', 'a domani'...)."""
+    return bool(text and _END_RE.search(text))
+
+
+def is_wake(text: str | None) -> bool:
+    """True if the student is calling the robot back from sleep."""
+    return bool(text and _WAKE_RE.search(text))
+
+
+# Spoken cues driven by the model on session end / wake (kept here so the client
+# stays focused on socket I/O and the copy is easy to review/translate).
+FAREWELL_INSTR = (
+    "Lo studente ha detto che avete finito. Salutalo con UNA frase breve, calda e "
+    "rassicurante (es. «Bravo, per oggi basta così: riposati, ci vediamo presto!»). "
+    "Non fare altre domande, non proporre altro: è un congedo."
+)
+WAKE_INSTR = (
+    "Sei appena stato richiamato. Saluta di nuovo con UNA frase breve e allegra e "
+    "chiedi con calma cosa vuole fare adesso."
+)
+
+
+def response_create(instructions: str | None = None) -> dict:
+    """Build a ``response.create`` (optionally steering what the model should say)."""
+    if instructions:
+        return {"type": "response.create", "response": {"instructions": instructions}}
+    return {"type": "response.create"}
+
+
 def session_update(
     instructions: str,
     voice: str,

--- a/robot/reachy_mini_mirrorbuddy/rt_messages.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_messages.py
@@ -20,7 +20,8 @@ CANCEL = json.dumps({"type": "response.cancel"})
 # This is an accessibility requirement: insistence stresses the student.
 _STOP_RE = re.compile(
     r"\b(basta|ferma(?:ti|te|lo)?|zitt[oaie]|silenzio|silence|aspetta|"
-    r"pausa|stop|taci|smettila|smetti|shh+|sh+t?)\b",
+    r"pausa|stop|taci|smettila|smetti|shh+|sh+t?|"
+    r"dormi|dormire|riposati|riposa|spegniti|mettiti\s+a\s+riposo)\b",
     re.IGNORECASE,
 )
 
@@ -38,7 +39,6 @@ _END_RE = re.compile(
     r"(?:abbiamo|ho|hai)\s+(?:finito|terminato|concluso)|"
     r"finito\s+per\s+oggi|basta\s+(?:studiare|compiti|per\s+oggi)|"
     r"a\s+domani|ci\s+vediamo|arrivederci|buonanotte|buona\s+notte|"
-    r"(?:vai\s+a|puoi|vatti\s+a)\s+dormire|riposati|spegniti|"
     r"abbiamo\s+finito"
     r")\b",
     re.IGNORECASE,

--- a/robot/reachy_mini_mirrorbuddy/rt_messages.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_messages.py
@@ -44,8 +44,10 @@ _END_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Wake intent: while asleep, only the robot's name (or a clear call) brings it back.
-_WAKE_RE = re.compile(r"\b(buddy|svegliati|sei\s+sveglio|ci\s+sei|ehi\s+robot)\b", re.IGNORECASE)
+# Wake intent: while asleep, ONLY the robot's name "Buddy" brings it back — so a
+# stop/rest really lasts until the child deliberately calls it again. A few ASR
+# spellings of the name are accepted (whisper sometimes drops a letter).
+_WAKE_RE = re.compile(r"\bbudd?(?:y|i|ie)\b", re.IGNORECASE)
 
 
 def is_end(text: str | None) -> bool:

--- a/robot/reachy_mini_mirrorbuddy/session_flow.py
+++ b/robot/reachy_mini_mirrorbuddy/session_flow.py
@@ -1,0 +1,33 @@
+"""Pure session-flow decisions for the live voice loop.
+
+Given a final user transcript and whether the robot is currently asleep, decide
+what the realtime client should do. Keeping this pure (no I/O, no sockets) makes
+the stop / end / wake behaviour — which is accessibility-critical — easy to unit
+test in isolation from Azure.
+"""
+
+from __future__ import annotations
+
+from . import rt_messages
+
+IGNORE = "ignore"  # asleep and not addressed → do nothing
+WAKE = "wake"  # asleep + wake word → resume and greet again
+END = "end"  # "abbiamo finito" → say a short goodbye, then sleep
+STOP = "stop"  # "basta" → go silent immediately (transient)
+SPEAK = "speak"  # ordinary turn → let the model answer
+
+
+def decide(text: str, asleep: bool) -> str:
+    """Classify a final transcript into the action the client should take.
+
+    Order matters: while asleep only the wake word matters; otherwise an
+    end-of-session intent takes precedence over a plain stop, which takes
+    precedence over a normal turn.
+    """
+    if asleep:
+        return WAKE if rt_messages.is_wake(text) else IGNORE
+    if rt_messages.is_end(text):
+        return END
+    if rt_messages.is_stop(text):
+        return STOP
+    return SPEAK

--- a/robot/reachy_mini_mirrorbuddy/settings_ui.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_ui.py
@@ -28,6 +28,8 @@ _EDITABLE_KEYS = (
     "MIRRORBUDDY_MAESTRO_ID",
     "MIRRORBUDDY_DSA_PROFILE",
     "MIRRORBUDDY_STUDENT_NAME",
+    "MIRRORBUDDY_DEVICE_TOKEN",
+    "MIRRORBUDDY_API_BASE",
 )
 
 
@@ -54,6 +56,7 @@ def mount_settings_routes(app, instance_path: str | None) -> None:
                 "studentName": config.STUDENT_NAME,
                 "mirrorbuddyUrl": config.MIRRORBUDDY_URL,
                 "locale": config.LOCALE,
+                "paired": bool(config.DEVICE_TOKEN),
             }
         )
 
@@ -94,6 +97,47 @@ def mount_settings_routes(app, instance_path: str | None) -> None:
         config.reload()
         return JSONResponse({"ok": True, "ready": not config.missing(), "missing": config.missing()})
 
+    @app.post("/api/pair")
+    async def pair(request: Request) -> JSONResponse:
+        """Redeem a pairing code from the parent's MirrorBuddy settings for a device token."""
+        import httpx
+
+        try:
+            body = await request.json()
+            code = str((body or {}).get("code") or "").strip()
+        except Exception:
+            return JSONResponse({"ok": False, "error": "invalid JSON"}, status_code=400)
+        if not code:
+            return JSONResponse({"ok": False, "error": "codice mancante"}, status_code=400)
+
+        api_base = config.API_BASE.rstrip("/")
+        try:
+            resp = httpx.post(
+                f"{api_base}/api/devices/pair",
+                json={"code": code},
+                timeout=15.0,
+                headers={"accept": "application/json"},
+            )
+        except Exception as e:
+            logger.error("pair request failed: %s", e)
+            return JSONResponse({"ok": False, "error": "robot non connesso a internet"}, status_code=502)
+
+        if resp.status_code != 200:
+            return JSONResponse({"ok": False, "error": "codice non valido o scaduto"}, status_code=400)
+
+        token = str((resp.json() or {}).get("token") or "").strip()
+        if not token:
+            return JSONResponse({"ok": False, "error": "risposta non valida"}, status_code=502)
+
+        try:
+            _write_env(env_path, {"MIRRORBUDDY_DEVICE_TOKEN": token})
+        except Exception as e:
+            logger.error("failed to store device token: %s", e)
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+        config.reload()
+        return JSONResponse({"ok": True, "paired": True})
+
 
 def _write_env(env_path: Path, updates: dict[str, str]) -> None:
     """Merge ``updates`` into the .env file, preserving existing keys."""
@@ -132,6 +176,15 @@ _PAGE = """<!doctype html>
 <body>
 <h1>🤖 MirrorBuddy Robot</h1>
 <div id="status" class="status warn">Carico…</div>
+
+<h2 style="font-size:1.1rem;margin-top:1.4rem">👤 Profilo del bambino</h2>
+<div id="pairState" class="status warn">Non collegato a nessun profilo.</div>
+<label>Codice di collegamento (dalle Impostazioni di MirrorBuddy del genitore)</label>
+<input id="pairCode" inputmode="numeric" maxlength="6" placeholder="123456"/>
+<button onclick="pair()">Collega al profilo</button>
+<p><small>Il robot userà nome, materie e impostazioni di accessibilità del bambino loggato. Nessuna password lascia il computer del genitore.</small></p>
+
+<h2 style="font-size:1.1rem;margin-top:1.4rem">🔧 Configurazione robot</h2>
 <label>Endpoint Azure Realtime</label>
 <input id="AZURE_OPENAI_REALTIME_ENDPOINT" placeholder="https://<risorsa>.openai.azure.com/"/>
 <label>Azure API key</label>
@@ -162,6 +215,9 @@ async function load(){
  const box=document.getElementById('status');
  if(s.ready){box.className='status ok';box.textContent='✅ Pronto';}
  else{box.className='status warn';box.textContent='⚠️ Manca: '+(s.missing||[]).join(', ');}
+ const ps=document.getElementById('pairState');
+ if(s.paired){ps.className='status ok';ps.textContent='✅ Collegato al profilo del bambino.';}
+ else{ps.className='status warn';ps.textContent='Non collegato a nessun profilo.';}
  for(const k of ['MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME']){
   if(s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName']) document.getElementById(k).value=s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName'];
  }
@@ -178,6 +234,14 @@ async function save(){
  const r=await (await fetch('./api/config',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)})).json();
  load();
  alert(r.ok?'Salvato!':'Errore: '+(r.error||'?'));
+}
+async function pair(){
+ const code=document.getElementById('pairCode').value.trim();
+ if(!code){alert('Inserisci il codice');return;}
+ const r=await (await fetch('./api/pair',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({code})})).json();
+ if(r.ok){document.getElementById('pairCode').value='';}
+ load();
+ alert(r.ok?'Collegato al profilo del bambino!':'Errore: '+(r.error||'?'));
 }
 load();
 </script>

--- a/robot/reachy_mini_mirrorbuddy/settings_ui.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_ui.py
@@ -133,7 +133,7 @@ def mount_settings_routes(app, instance_path: str | None) -> None:
             _write_env(env_path, {"MIRRORBUDDY_DEVICE_TOKEN": token})
         except Exception as e:
             logger.error("failed to store device token: %s", e)
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse({"ok": False, "error": "impossibile salvare il token"}, status_code=500)
 
         config.reload()
         return JSONResponse({"ok": True, "paired": True})

--- a/robot/reachy_mini_mirrorbuddy/tools.py
+++ b/robot/reachy_mini_mirrorbuddy/tools.py
@@ -10,6 +10,7 @@ The schemas are sent in ``session.update`` and the model calls them autonomously
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from .mirrorbuddy_client import Maestro
@@ -66,7 +67,40 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
             "required": [],
         },
     },
+    {
+        "type": "function",
+        "name": "talk_as_friend",
+        "description": (
+            "Passa alla modalita' AMICO: smetti di fare il tutor e diventa Buddy, un amico con cui "
+            "chiacchierare di qualsiasi cosa (la giornata, gli amici, i videogiochi, le passioni, le "
+            "emozioni), NON di scuola. Usalo quando lo studente non vuole studiare, vuole solo parlare, "
+            "sfogarsi o giocare (es. 'non voglio fare i compiti', 'parliamo un po'', 'raccontami qualcosa', "
+            "'sei mio amico?', 'modalita' amico')."
+        ),
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "type": "function",
+        "name": "back_to_study",
+        "description": (
+            "Torna alla modalita' STUDIO con Buddy tutor, che aiuta a organizzare i compiti e chiamare i "
+            "professori. Usalo quando lo studente vuole ricominciare a studiare o fare i compiti "
+            "(es. 'ok torniamo ai compiti', 'aiutami a studiare', 'modalita' studio')."
+        ),
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
 ]
+
+
+def parse_call_arguments(event: dict, fallback_name: str = "") -> tuple[str, dict]:
+    """Extract (tool name, parsed args) from a ``function_call_arguments.done`` event."""
+    name = event.get("name") or fallback_name
+    raw = event.get("arguments") or "{}"
+    try:
+        args = json.loads(raw) if isinstance(raw, str) else dict(raw)
+    except (ValueError, TypeError):
+        args = {}
+    return name, args
 
 
 def _norm(s: str) -> str:

--- a/robot/tests/test_device.py
+++ b/robot/tests/test_device.py
@@ -1,0 +1,72 @@
+"""Tests for the device-pairing profile mapping (pure logic, no network)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reachy_mini_mirrorbuddy.device import (  # noqa: E402
+    DeviceProfile,
+    _dsa_from_accessibility,
+    apply_device_profile,
+)
+
+
+class _FakeConfig:
+    STUDENT_NAME = None
+    LOCALE = "it"
+    DSA_PROFILE = "cerebral"
+    CALM_MOVEMENT = False
+
+
+def test_from_json_parses_fields():
+    p = DeviceProfile.from_json(
+        {
+            "name": "Mario",
+            "preferredBuddy": "sofia",
+            "language": "en",
+            "subjects": ["math", "history"],
+            "accessibility": {"adhdMode": True},
+        }
+    )
+    assert p.name == "Mario"
+    assert p.preferred_buddy == "sofia"
+    assert p.language == "en"
+    assert p.subjects == ["math", "history"]
+    assert p.accessibility == {"adhdMode": True}
+
+
+def test_from_json_defaults_are_safe():
+    p = DeviceProfile.from_json({})
+    assert p.name is None
+    assert p.language == "it"
+    assert p.subjects == []
+    assert p.accessibility == {}
+
+
+def test_dsa_mapping_priority():
+    assert _dsa_from_accessibility({"adhdMode": True, "dyslexiaFont": True}) == "adhd"
+    assert _dsa_from_accessibility({"dyslexiaFont": True}) == "dyslexia"
+    assert _dsa_from_accessibility({}) is None
+
+
+def test_apply_overlays_profile_on_config():
+    cfg = _FakeConfig()
+    apply_device_profile(
+        cfg,
+        DeviceProfile(name="Noemi", language="fr", accessibility={"dyslexiaFont": True, "reducedMotion": True}),
+    )
+    assert cfg.STUDENT_NAME == "Noemi"
+    assert cfg.LOCALE == "fr"
+    assert cfg.DSA_PROFILE == "dyslexia"
+    assert cfg.CALM_MOVEMENT is True
+
+
+def test_apply_keeps_config_when_profile_empty():
+    cfg = _FakeConfig()
+    cfg.STUDENT_NAME = "Existing"
+    apply_device_profile(cfg, DeviceProfile())
+    assert cfg.STUDENT_NAME == "Existing"
+    assert cfg.DSA_PROFILE == "cerebral"

--- a/robot/tests/test_session_flow.py
+++ b/robot/tests/test_session_flow.py
@@ -1,0 +1,111 @@
+"""Tests for the accessibility-critical session flow: stop / end / wake / friend mode.
+
+All pure logic, no hardware or network. These behaviours matter for the child:
+insistence is stressful, so "stop" and "we're done" must be honoured deterministically
+and locally, never left to the model.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reachy_mini_mirrorbuddy import rt_messages, session_flow, tools  # noqa: E402
+from reachy_mini_mirrorbuddy.mirrorbuddy_client import friend_buddy, neutral_buddy  # noqa: E402
+
+
+class TestStopIntent:
+    def test_stop_words(self):
+        for t in ["basta", "Basta!", "zitto", "stai zitto", "fermati", "silenzio",
+                  "aspetta", "pausa", "stop", "taci", "smettila"]:
+            assert rt_messages.is_stop(t), t
+
+    def test_not_stop(self):
+        for t in ["ciao", "quanto fa due più due", "", None, "parliamo di storia"]:
+            assert not rt_messages.is_stop(t), t
+
+
+class TestEndIntent:
+    def test_end_words(self):
+        for t in ["abbiamo finito", "ho finito", "finito per oggi", "basta per oggi",
+                  "a domani", "ci vediamo", "arrivederci", "buonanotte", "buona notte",
+                  "vai a dormire", "spegniti", "riposati"]:
+            assert rt_messages.is_end(t), t
+
+    def test_not_end(self):
+        for t in ["ciao", "basta", "aspetta un attimo", "", None, "che ore sono"]:
+            assert not rt_messages.is_end(t), t
+
+
+class TestWakeIntent:
+    def test_wake_words(self):
+        for t in ["buddy", "Buddy!", "svegliati", "sei sveglio", "ci sei", "ehi robot"]:
+            assert rt_messages.is_wake(t), t
+
+    def test_not_wake(self):
+        for t in ["ciao", "storia", "", None]:
+            assert not rt_messages.is_wake(t), t
+
+
+class TestDecide:
+    def test_asleep_ignores_normal_speech(self):
+        assert session_flow.decide("quanto fa due più due", asleep=True) == session_flow.IGNORE
+
+    def test_asleep_wakes_on_name(self):
+        assert session_flow.decide("buddy ci sei?", asleep=True) == session_flow.WAKE
+
+    def test_awake_end_takes_precedence(self):
+        assert session_flow.decide("abbiamo finito, a domani", asleep=False) == session_flow.END
+
+    def test_awake_stop(self):
+        assert session_flow.decide("basta", asleep=False) == session_flow.STOP
+
+    def test_awake_normal_turn(self):
+        assert session_flow.decide("spiegami le frazioni", asleep=False) == session_flow.SPEAK
+
+    def test_end_beats_stop_when_both_present(self):
+        # "basta per oggi" is an end intent, not a transient stop.
+        assert session_flow.decide("basta per oggi", asleep=False) == session_flow.END
+
+
+class TestResponseCreate:
+    def test_plain(self):
+        assert rt_messages.response_create() == {"type": "response.create"}
+
+    def test_with_instructions(self):
+        msg = rt_messages.response_create("saluta")
+        assert msg["type"] == "response.create"
+        assert msg["response"]["instructions"] == "saluta"
+
+
+class TestParseCallArguments:
+    def test_json_string(self):
+        name, args = tools.parse_call_arguments(
+            {"name": "call_professor", "arguments": '{"query": "storia"}'}
+        )
+        assert name == "call_professor"
+        assert args == {"query": "storia"}
+
+    def test_fallback_name_and_bad_json(self):
+        name, args = tools.parse_call_arguments({"arguments": "not-json"}, "back_to_study")
+        assert name == "back_to_study"
+        assert args == {}
+
+
+class TestFriendAndStudyTools:
+    def test_friend_tools_registered(self):
+        names = {t["name"] for t in tools.TOOL_SCHEMAS}
+        assert "talk_as_friend" in names
+        assert "back_to_study" in names
+
+    def test_friend_buddy_persona(self):
+        m = friend_buddy("Marco", "sage")
+        assert m.id == "buddy-friend"
+        assert m.voice == "sage"
+        # A friend, not a tutor: no school-only framing.
+        assert "compiti" not in m.voice_instructions.lower()
+
+    def test_neutral_buddy_distinct_from_friend(self):
+        assert neutral_buddy("Marco").id != friend_buddy("Marco").id

--- a/robot/tests/test_session_flow.py
+++ b/robot/tests/test_session_flow.py
@@ -42,11 +42,13 @@ class TestEndIntent:
 
 class TestWakeIntent:
     def test_wake_words(self):
-        for t in ["buddy", "Buddy!", "svegliati", "sei sveglio", "ci sei", "ehi robot"]:
+        for t in ["buddy", "Buddy!", "ehi buddy", "buddi", "ok buddy ci sei?"]:
             assert rt_messages.is_wake(t), t
 
     def test_not_wake(self):
-        for t in ["ciao", "storia", "", None]:
+        # Only "Buddy" reactivates — generic calls must NOT wake it from rest.
+        for t in ["ciao", "storia", "", None, "svegliati", "sei sveglio",
+                  "ci sei", "ehi robot"]:
             assert not rt_messages.is_wake(t), t
 
 

--- a/robot/tests/test_session_flow.py
+++ b/robot/tests/test_session_flow.py
@@ -19,7 +19,9 @@ from reachy_mini_mirrorbuddy.mirrorbuddy_client import friend_buddy, neutral_bud
 class TestStopIntent:
     def test_stop_words(self):
         for t in ["basta", "Basta!", "zitto", "stai zitto", "fermati", "silenzio",
-                  "aspetta", "pausa", "stop", "taci", "smettila"]:
+                  "aspetta", "pausa", "stop", "taci", "smettila",
+                  "dormi", "dormire", "vai a dormire", "riposati", "spegniti",
+                  "mettiti a riposo"]:
             assert rt_messages.is_stop(t), t
 
     def test_not_stop(self):
@@ -30,8 +32,7 @@ class TestStopIntent:
 class TestEndIntent:
     def test_end_words(self):
         for t in ["abbiamo finito", "ho finito", "finito per oggi", "basta per oggi",
-                  "a domani", "ci vediamo", "arrivederci", "buonanotte", "buona notte",
-                  "vai a dormire", "spegniti", "riposati"]:
+                  "a domani", "ci vediamo", "arrivederci", "buonanotte", "buona notte"]:
             assert rt_messages.is_end(t), t
 
     def test_not_end(self):
@@ -61,6 +62,14 @@ class TestDecide:
 
     def test_awake_stop(self):
         assert session_flow.decide("basta", asleep=False) == session_flow.STOP
+
+    def test_awake_sleep_command_is_stop(self):
+        # "dormi" is a sleep command: rest immediately, no reply, wake only on "buddy".
+        for t in ["dormi", "vai a dormire", "mettiti a riposo", "riposati"]:
+            assert session_flow.decide(t, asleep=False) == session_flow.STOP, t
+
+    def test_asleep_stays_asleep_on_sleep_command(self):
+        assert session_flow.decide("dormi", asleep=True) == session_flow.IGNORE
 
     def test_awake_normal_turn(self):
         assert session_flow.decide("spiegami le frazioni", asleep=False) == session_flow.SPEAK


### PR DESCRIPTION
Type: Feature + security · 33 files, +1557 / -5 · web API + UI + i18n + robot side

## What & why

Without pairing, the robot starts from a generic local `.env`. This PR lets the
robot **bind to the child's real MirrorBuddy account**, so it boots personalised
(name, preferred professor, accessibility settings, locale) for *that* child —
and lets a parent revoke it at any time. Answers the open question "how does the
robot know who's logged in?" with a proper, privacy-safe device-pairing flow.

## Flow

1. On the child's computer: **Settings → Integrations → "Collega un robot" →
   Genera codice** (6-digit, single-use, 10-min TTL).
2. On the robot settings page, under **"Profilo del bambino"**, type the code.
3. Robot redeems at `POST /api/devices/pair`, stores only a scoped, revocable
   **device token** in its local `.env`, and fetches the non-sensitive learning
   profile from `GET /api/devices/me`.

**Privacy by design:** the child's password/email never leave the computer — the
robot only ever holds a revocable token + a learning profile (name, preferred
buddy/coach, school/grade level, age, language, subjects, accessibility flags).

## Web changes (`apps/web/`)

- **Data**: `RobotDevice` Prisma model + migration (`user.prisma` relation).
- **API** (`src/app/api/devices/`): `pair-code` (issue), `pair` (redeem), `me`
  (robot fetches profile), `route` (list devices), `[id]` (revoke). Fully unit-
  tested (**25 tests**: 13 service + 12 route).
- **Service** (`src/lib/devices/device-service.ts`): code issue/redeem, token
  hashing (SHA-256, only hashes stored), profile projection, list/revoke.
- **UI**: `RobotPairingCard` in Settings › Integrations — generate code, see
  paired devices, unpair. i18n across **5 locales** (it/en/fr/de/es, 14 keys).

## Robot changes (`robot/`)

- `device.py`: fetch + apply the paired profile to the robot config; falls back
  to `.env` when unpaired.
- `settings_ui.py`: pairing code-entry UI + `/api/pair` proxy.
- `config.py` / `.env.example`: `MIRRORBUDDY_DEVICE_TOKEN`, `MIRRORBUDDY_API_BASE`.
- 5 pure-logic tests (`tests/test_device.py`).

## Security (reviewed by @luca — no critical findings)

Hardening applied in this PR:
- **Atomic redeem** — a single guarded `updateMany` claims the code only if
  unredeemed/unrevoked/unexpired, closing the double-redeem TOCTOU race.
- **Global brute-force cap** (`DEVICE_PAIR_GLOBAL`, 100/15min) on top of per-IP.
- **Orphan filter** — `listDevices` returns only `pairedAt != null` rows (no
  phantom devices).
- **Fail-fast on DB errors** — `createPairingCode` retries only on P2002 hash
  collisions, surfaces everything else.

Documented roadmap follow-ups (non-blocking): robot settings server is LAN-bound
(run on a trusted network / loopback+PIN); device tokens are revocable but not
yet TTL-rotated (`lastSeenAt` recorded for future idle-expiry).

## Docs

- `robot/README.md`: pairing flow + security model.
- Root `README.md`: **Reachy Mini Robot** section with official product image +
  buy link + badge.

## Testing

- `npm run test:unit -- src/app/api/devices src/lib/devices` → **25/25 green**.
- `eslint src/lib/devices src/app/api/devices` → clean.
- Robot device tests green.

## Merge order

Depends on **PR1** (`feat/reachy-mini-mirrorbuddy`). Merge PR1 first, then
retarget this PR to `main`.

## Pre-merge live checks (owner)

- [ ] End-to-end pairing: generate code on web → enter on robot → robot boots
      with the child's Buddy/profile.
- [ ] "basta" silences the robot immediately; camera reads a sheet of homework.
- [ ] Remove `MIRRORBUDDY_SAVE_FRAMES=1` from the robot `.env` after camera tests.

Co-authored-by: Copilot
