### PR TITLE
fix(robot): calmer antennas while speaking

### DIFF
--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -213,9 +213,9 @@ class Movements:
             sway = math.radians(18.0 * s) * math.sin(2 * math.pi * 0.5 * w * t)
             if speaking:
                 perk = _ANTENNA_MAX * min(1.0, 0.4 + energy)
-                flutter = math.radians(5.0 * s) * math.sin(2 * math.pi * 4.0 * t)
-                right = _clamp(_ANTENNA_NEUTRAL + perk * 0.4 + flutter)
-                left = _clamp(_ANTENNA_NEUTRAL + perk * 0.4 - flutter)
+                flutter = math.radians(2.0 * s) * math.sin(2 * math.pi * 2.5 * t)
+                right = _clamp(_ANTENNA_NEUTRAL + perk * 0.22 + flutter)
+                left = _clamp(_ANTENNA_NEUTRAL + perk * 0.22 - flutter)
             else:
                 right = _clamp(_ANTENNA_NEUTRAL + sway)
                 left = _clamp(_ANTENNA_NEUTRAL - sway)


### PR DESCRIPTION
## What
Reduce the antenna movement while Buddy is **speaking** so they no longer flap distractingly for the student.

- flutter: 5°@4Hz → **2°@2.5Hz**
- lift multiplier: perk*0.4 → **perk*0.22**
- idle sway unchanged (keeps the robot lively at rest)

## Why
Requested by the student's parent: the antennas moved too much while talking, which is distracting for a child with DSA.

## Test
- 26 robot tests green
- movements.py syntax validated

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>