### PR TITLE
fix(robot): instant on-device barge-in — 'basta' cuts audio immediately

### DIFF
--- a/robot/README.md
+++ b/robot/README.md
@@ -106,6 +106,12 @@ locally** — never left to the model:
   and the server is configured **not** to auto-reply — a response is only ever requested
   after an ordinary turn), settles into a calm **rest position** and **stays parked** — no
   fidgeting, no talking — until you call it back. A stop is a full stop, never a reply.
+- **Instant on-device barge-in** — the moment the child speaks *over* Buddy, playback is
+  cut on the robot itself, without waiting for the server. The Reachy Mini mic array is
+  echo-cancelled in hardware, so voice energy on the mic while Buddy is speaking is a real
+  nearby voice (not the robot hearing itself) — `audio_io.py` flushes the speaker and the
+  realtime client drops any in-flight audio right away. Sensitivity is tunable via
+  `MIRRORBUDDY_BARGE_RMS` (default `0.045`) and `MIRRORBUDDY_BARGE_FRAMES` (default `3`).
 - **We're done for today** — say *«abbiamo finito»*, *«a domani»*, *«buonanotte»*,
   *«ci vediamo»*. Buddy says **one** short goodbye, then rests the same way.
 - **Wake it back up** — while resting it ignores everything **except its name**: say

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -29,9 +29,29 @@ logger = logging.getLogger(__name__)
 # the server's ``speech_started`` round-trip (~200-400ms). The server path (cancel +
 # stop/sleep classification) still runs a moment later. Thresholds are env-tunable so
 # they can be adjusted in the field without a redeploy.
-_BARGE_RMS_THRESHOLD = float(os.getenv("MIRRORBUDDY_BARGE_RMS", "0.045"))  # normalised 0..1
-_BARGE_SUSTAIN_FRAMES = int(os.getenv("MIRRORBUDDY_BARGE_FRAMES", "3"))  # consecutive loud frames
+_DEFAULT_BARGE_RMS_THRESHOLD = 0.045  # normalised 0..1
+_DEFAULT_BARGE_SUSTAIN_FRAMES = 3  # consecutive loud frames
 _PLAY_TTL_S = 0.25  # treat Buddy as "speaking" for this long after the last audio chunk
+
+
+def _barge_rms_threshold() -> float:
+    """Read the barge-in RMS threshold from the env at call time.
+
+    Read lazily (not at import) so values saved in the robot's ``.env`` — which
+    ``main.run()`` loads *after* this module is imported — take effect.
+    """
+    try:
+        return float(os.getenv("MIRRORBUDDY_BARGE_RMS", _DEFAULT_BARGE_RMS_THRESHOLD))
+    except (TypeError, ValueError):
+        return _DEFAULT_BARGE_RMS_THRESHOLD
+
+
+def _barge_sustain_frames() -> int:
+    """Read the barge-in sustain-frame count from the env at call time."""
+    try:
+        return max(1, int(os.getenv("MIRRORBUDDY_BARGE_FRAMES", _DEFAULT_BARGE_SUSTAIN_FRAMES)))
+    except (TypeError, ValueError):
+        return _DEFAULT_BARGE_SUSTAIN_FRAMES
 
 
 def _resample(audio: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
@@ -69,6 +89,10 @@ class AudioIO:
         self._out_rate: int | None = None
         self._playing_until = 0.0  # monotonic deadline: Buddy is "speaking" until then
         self._loud_frames = 0  # consecutive over-threshold mic frames (barge-in debounce)
+        # Read env-tunable thresholds now — construction happens after main.run()
+        # has loaded the instance .env, so field overrides are honoured.
+        self._barge_rms_threshold = _barge_rms_threshold()
+        self._barge_sustain_frames = _barge_sustain_frames()
 
     # ------------------------------------------------------------------ lifecycle
     def start(self) -> None:
@@ -192,9 +216,9 @@ class AudioIO:
                 # while Buddy is speaking, cut playback instantly — no server round-trip.
                 if self.on_local_barge_in is not None and audio.size and time.monotonic() < self._playing_until:
                     rms = float(np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2)))
-                    if rms >= _BARGE_RMS_THRESHOLD:
+                    if rms >= self._barge_rms_threshold:
                         self._loud_frames += 1
-                        if self._loud_frames >= _BARGE_SUSTAIN_FRAMES:
+                        if self._loud_frames >= self._barge_sustain_frames:
                             self._loud_frames = 0
                             logger.info("Local barge-in (rms=%.3f) — cutting playback now", rms)
                             self.interrupt()  # flush our speaker immediately

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import time
 from collections.abc import Callable
@@ -20,6 +21,17 @@ from scipy.signal import resample_poly
 from .azure_realtime import SAMPLE_RATE
 
 logger = logging.getLogger(__name__)
+
+# On-device ("local") barge-in. The Reachy Mini mic array is echo-cancelled in
+# hardware (AEC removes the robot's own speaker audio from the mic), so energy on the
+# mic *while Buddy is speaking* means a real nearby voice — not the robot hearing
+# itself. That lets us cut playback the instant the child speaks, without waiting for
+# the server's ``speech_started`` round-trip (~200-400ms). The server path (cancel +
+# stop/sleep classification) still runs a moment later. Thresholds are env-tunable so
+# they can be adjusted in the field without a redeploy.
+_BARGE_RMS_THRESHOLD = float(os.getenv("MIRRORBUDDY_BARGE_RMS", "0.045"))  # normalised 0..1
+_BARGE_SUSTAIN_FRAMES = int(os.getenv("MIRRORBUDDY_BARGE_FRAMES", "3"))  # consecutive loud frames
+_PLAY_TTL_S = 0.25  # treat Buddy as "speaking" for this long after the last audio chunk
 
 
 def _resample(audio: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
@@ -40,16 +52,23 @@ class AudioIO:
         robot,
         on_input_pcm16: Callable[[bytes], None],
         movements=None,
+        on_local_barge_in: Callable[[], None] | None = None,
     ) -> None:
         self.robot = robot
         self.on_input_pcm16 = on_input_pcm16
         self.movements = movements
+        # Called from the mic thread the instant a real voice is heard over Buddy's
+        # own speech (local barge-in). Wired by the controller to the realtime client
+        # so in-flight model audio is suppressed immediately.
+        self.on_local_barge_in = on_local_barge_in
 
         self._recording = False
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._in_rate: int | None = None
         self._out_rate: int | None = None
+        self._playing_until = 0.0  # monotonic deadline: Buddy is "speaking" until then
+        self._loud_frames = 0  # consecutive over-threshold mic frames (barge-in debounce)
 
     # ------------------------------------------------------------------ lifecycle
     def start(self) -> None:
@@ -101,6 +120,8 @@ class AudioIO:
         """Play model speech (PCM16 @ realtime rate) through the robot speaker."""
         if not pcm16:
             return
+        # Mark Buddy as speaking so the mic loop knows to watch for a barge-in.
+        self._playing_until = time.monotonic() + _PLAY_TTL_S
         audio = np.frombuffer(pcm16, dtype=np.int16)
 
         # Lip-sync / head movement is driven by the raw speech signal.
@@ -126,6 +147,9 @@ class AudioIO:
 
     def interrupt(self) -> None:
         """Stop current playback (barge-in) and reset movement state."""
+        # Playback is being cut: stop watching for a barge-in until the next chunk.
+        self._playing_until = 0.0
+        self._loud_frames = 0
         # clear_output_buffer() is deprecated and a no-op on this firmware; clear_player()
         # actually flushes the queued speaker audio so speech stops immediately.
         try:
@@ -163,6 +187,25 @@ class AudioIO:
                         audio = (np.clip(audio, -1.0, 1.0) * 32767).astype(np.int16)
                     else:
                         audio = audio.astype(np.int16)
+
+                # Local barge-in: if the (echo-cancelled) mic hears a sustained voice
+                # while Buddy is speaking, cut playback instantly — no server round-trip.
+                if self.on_local_barge_in is not None and audio.size and time.monotonic() < self._playing_until:
+                    rms = float(np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2)))
+                    if rms >= _BARGE_RMS_THRESHOLD:
+                        self._loud_frames += 1
+                        if self._loud_frames >= _BARGE_SUSTAIN_FRAMES:
+                            self._loud_frames = 0
+                            logger.info("Local barge-in (rms=%.3f) — cutting playback now", rms)
+                            self.interrupt()  # flush our speaker immediately
+                            try:
+                                self.on_local_barge_in()  # tell the client to drop in-flight audio
+                            except Exception as e:  # pragma: no cover - runtime robustness
+                                logger.debug("local barge-in callback error: %s", e)
+                    else:
+                        self._loud_frames = 0
+                else:
+                    self._loud_frames = 0
 
                 # Resample microphone -> realtime rate.
                 if needs_resample and audio.size:

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -111,6 +111,17 @@ class AzureRealtimeClient:
         self._enqueue(json.dumps(rt_messages.image_message(data_url, prompt)))
         self._enqueue(json.dumps({"type": "response.create"}))
 
+    def local_barge_in(self) -> None:
+        """On-device barge-in (called from the mic thread when a real voice is heard
+        over Buddy's speech). Drops in-flight model audio immediately and asks the
+        server to cancel the active response, without waiting for the server's own
+        ``speech_started``. Thread-safe: only flag writes + a queued cancel. The
+        stop/sleep/wake classification still runs on the transcript that follows."""
+        self._suppress = True  # drop any audio deltas already in flight
+        self._quiet = False  # a normal turn stays un-muted; a stop word re-mutes below
+        if self._responding:
+            self._enqueue(rt_messages.CANCEL)
+
     def _enqueue(self, msg: str) -> None:
         if self._ws is None or self._loop is None:
             return

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -52,6 +52,7 @@ class Controller:
         """Connect the first Maestro. Returns True once the session is ready."""
         self._client = self._build_client(self.maestro)
         self.audio.on_input_pcm16 = self._client.send_audio_pcm16
+        self.audio.on_local_barge_in = self._client.local_barge_in
         self._client.start()
         ready = self._client.wait_ready(timeout=25.0)
         if not ready:
@@ -202,6 +203,7 @@ class Controller:
                 new.join()
                 return
             self.audio.on_input_pcm16 = new.send_audio_pcm16
+            self.audio.on_local_barge_in = new.local_barge_in
             self._client = new
             self.maestro = target
             if old:

--- a/robot/tests/test_barge_in.py
+++ b/robot/tests/test_barge_in.py
@@ -1,0 +1,57 @@
+"""Tests for the on-device (local) barge-in used to cut Buddy off the instant the
+child speaks.
+
+Why it matters for the child: waiting for the server's ``speech_started`` round-trip
+leaves a noticeable tail of speech after "basta". Because the Reachy Mini mic is
+echo-cancelled in hardware, mic energy while Buddy is speaking is a real voice, so we
+can flush playback locally and immediately. These tests cover the client-side hook in
+isolation (no hardware, no network).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reachy_mini_mirrorbuddy import rt_messages  # noqa: E402
+from reachy_mini_mirrorbuddy.azure_realtime import AzureRealtimeClient  # noqa: E402
+
+
+def _client() -> AzureRealtimeClient:
+    return AzureRealtimeClient(
+        ws_url="wss://example/invalid",
+        api_key="",
+        instructions="",
+        voice="alloy",
+        turn_detection={},
+    )
+
+
+class TestLocalBargeIn:
+    def test_suppresses_in_flight_audio(self):
+        c = _client()
+        assert c._suppress is False
+        c.local_barge_in()
+        assert c._suppress is True  # any queued audio deltas are now dropped
+
+    def test_stays_unmuted_for_a_normal_turn(self):
+        c = _client()
+        c._quiet = True
+        c.local_barge_in()
+        # A normal turn must not stay muted; a stop word re-mutes via the transcript path.
+        assert c._quiet is False
+
+    def test_sends_cancel_only_while_responding(self):
+        sent: list[str] = []
+        c = _client()
+        c._enqueue = lambda msg: sent.append(msg)  # type: ignore[assignment]
+
+        c._responding = False
+        c.local_barge_in()
+        assert sent == []  # nothing to cancel
+
+        c._responding = True
+        c.local_barge_in()
+        assert sent == [rt_messages.CANCEL]  # cancel the active response


### PR DESCRIPTION
## Problem
When the child said to stop, Buddy kept talking for a beat because the stop relied on the server's `speech_started` round-trip (~200-400ms).

## Fix
The Reachy Mini mic array is **echo-cancelled in hardware**, so mic energy while Buddy is speaking is a real nearby voice — not the robot hearing itself. `audio_io.py` now watches mic RMS while speaking and, on a sustained voice, **flushes the speaker locally and drops in-flight model audio immediately**, with no server round-trip. The server-side cancel + stop/sleep/wake classification still follow on the transcript.

Same model (whisper-1) and barge-in design as the MirrorBuddy web app; this only removes the network latency on the robot.

Sensitivity is env-tunable: `MIRRORBUDDY_BARGE_RMS` (default 0.045), `MIRRORBUDDY_BARGE_FRAMES` (default 3).

## Test
- 29 robot tests green (3 new for `local_barge_in`)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>