### PR TITLE
feat(robot): barge-in sensitivity as a robot config parameter

### DIFF
--- a/robot/README.md
+++ b/robot/README.md
@@ -110,8 +110,9 @@ locally** — never left to the model:
   cut on the robot itself, without waiting for the server. The Reachy Mini mic array is
   echo-cancelled in hardware, so voice energy on the mic while Buddy is speaking is a real
   nearby voice (not the robot hearing itself) — `audio_io.py` flushes the speaker and the
-  realtime client drops any in-flight audio right away. Sensitivity is tunable via
-  `MIRRORBUDDY_BARGE_RMS` (default `0.045`) and `MIRRORBUDDY_BARGE_FRAMES` (default `3`).
+  realtime client drops any in-flight audio right away. Sensitivity is configurable from
+  the robot's **settings page** ("Sensibilità basta") — or via `MIRRORBUDDY_BARGE_RMS`
+  (default `0.045`, lower = more sensitive) and `MIRRORBUDDY_BARGE_FRAMES` (default `3`).
 - **We're done for today** — say *«abbiamo finito»*, *«a domani»*, *«buonanotte»*,
   *«ci vediamo»*. Buddy says **one** short goodbye, then rests the same way.
 - **Wake it back up** — while resting it ignores everything **except its name**: say

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -73,6 +73,8 @@ class AudioIO:
         on_input_pcm16: Callable[[bytes], None],
         movements=None,
         on_local_barge_in: Callable[[], None] | None = None,
+        barge_rms_threshold: float | None = None,
+        barge_sustain_frames: int | None = None,
     ) -> None:
         self.robot = robot
         self.on_input_pcm16 = on_input_pcm16
@@ -89,10 +91,14 @@ class AudioIO:
         self._out_rate: int | None = None
         self._playing_until = 0.0  # monotonic deadline: Buddy is "speaking" until then
         self._loud_frames = 0  # consecutive over-threshold mic frames (barge-in debounce)
-        # Read env-tunable thresholds now — construction happens after main.run()
-        # has loaded the instance .env, so field overrides are honoured.
-        self._barge_rms_threshold = _barge_rms_threshold()
-        self._barge_sustain_frames = _barge_sustain_frames()
+        # Barge-in thresholds: prefer values passed by the caller (from Config, read
+        # after the instance .env loads); fall back to the env/defaults for standalone use.
+        self._barge_rms_threshold = (
+            barge_rms_threshold if barge_rms_threshold is not None else _barge_rms_threshold()
+        )
+        self._barge_sustain_frames = (
+            barge_sustain_frames if barge_sustain_frames is not None else _barge_sustain_frames()
+        )
 
     # ------------------------------------------------------------------ lifecycle
     def start(self) -> None:

--- a/robot/reachy_mini_mirrorbuddy/config.py
+++ b/robot/reachy_mini_mirrorbuddy/config.py
@@ -18,6 +18,10 @@ Optional:
     MIRRORBUDDY_DEVICE_TOKEN           pairing token; when set, the logged-in child's profile
                                        (name, accessibility, locale) is fetched and applied
     MIRRORBUDDY_API_BASE               where the pairing API lives (default: MIRRORBUDDY_URL)
+    MIRRORBUDDY_BARGE_RMS              local barge-in mic sensitivity, 0..1 (default 0.045);
+                                       lower = more sensitive (cuts sooner)
+    MIRRORBUDDY_BARGE_FRAMES           consecutive loud mic frames before cutting (default 3);
+                                       higher = more robust to background noise
 """
 
 from __future__ import annotations
@@ -74,6 +78,13 @@ class Config:
         # does not distract the student while speaking. Set to false for livelier motion.
         self.CALM_MOVEMENT: bool = _flag("MIRRORBUDDY_CALM_MOVEMENT", True)
 
+        # --- local barge-in (instant "basta") ---
+        # When the echo-cancelled mic hears a sustained voice over Buddy's own speech,
+        # playback is cut on-device instantly (no server round-trip). Field-tunable so
+        # sensitivity can be dialled in per environment without a redeploy.
+        self.BARGE_RMS_THRESHOLD: float = _float("MIRRORBUDDY_BARGE_RMS", 0.045)
+        self.BARGE_SUSTAIN_FRAMES: int = _int("MIRRORBUDDY_BARGE_FRAMES", 3, minimum=1)
+
     def missing(self) -> list[str]:
         """Return the list of required config values that are absent."""
         errors: list[str] = []
@@ -108,6 +119,31 @@ def _flag(name: str, default: bool) -> bool:
     if raw is None:
         return default
     return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r, using default %s", name, raw, default)
+        return default
+
+
+def _int(name: str, default: int, minimum: int | None = None) -> int:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r, using default %s", name, raw, default)
+        return default
+    if minimum is not None and value < minimum:
+        return minimum
+    return value
 
 
 # Global singleton, mirrors the pattern used by the other Reachy Mini apps.

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -121,7 +121,13 @@ def run(
     movements = Movements(robot, enabled=config.ENABLE_MOVEMENTS, temperament=temperament,
                           follow_face=follow_face, calm=config.CALM_MOVEMENT)
 
-    audio = AudioIO(robot, on_input_pcm16=lambda b: None, movements=movements)
+    audio = AudioIO(
+        robot,
+        on_input_pcm16=lambda b: None,
+        movements=movements,
+        barge_rms_threshold=config.BARGE_RMS_THRESHOLD,
+        barge_sustain_frames=config.BARGE_SUSTAIN_FRAMES,
+    )
 
     controller = Controller(robot, config, maestri, maestro, audio, movements)
 

--- a/robot/reachy_mini_mirrorbuddy/settings_page.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_page.py
@@ -1,0 +1,108 @@
+"""Static HTML/JS for the robot settings page (extracted to keep settings_ui.py
+within the repo 250-line/file limit)."""
+
+from __future__ import annotations
+
+PAGE = """<!doctype html>
+<html lang="it">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MirrorBuddy Robot — Impostazioni</title>
+<style>
+ body{font-family:system-ui,sans-serif;max-width:640px;margin:2rem auto;padding:0 1rem;color:#1a1a2e}
+ h1{font-size:1.4rem} label{display:block;margin:.6rem 0 .2rem;font-weight:600;font-size:.9rem}
+ input,select{width:100%;padding:.5rem;border:1px solid #ccc;border-radius:8px;font-size:1rem}
+ button{margin-top:1rem;padding:.6rem 1.2rem;border:0;border-radius:8px;background:#5b47e0;color:#fff;font-size:1rem;cursor:pointer}
+ .status{padding:.6rem;border-radius:8px;margin:.5rem 0;font-size:.9rem}
+ .ok{background:#e4f8ec;color:#0a7a3d} .warn{background:#fff3e0;color:#a35b00}
+ small{color:#666}
+</style>
+</head>
+<body>
+<h1>🤖 MirrorBuddy Robot</h1>
+<div id="status" class="status warn">Carico…</div>
+
+<h2 style="font-size:1.1rem;margin-top:1.4rem">👤 Profilo del bambino</h2>
+<div id="pairState" class="status warn">Non collegato a nessun profilo.</div>
+<label>Codice di collegamento (dalle Impostazioni di MirrorBuddy del genitore)</label>
+<input id="pairCode" inputmode="numeric" maxlength="6" placeholder="123456"/>
+<button onclick="pair()">Collega al profilo</button>
+<p><small>Il robot userà nome, materie e impostazioni di accessibilità del bambino loggato. Nessuna password lascia il computer del genitore.</small></p>
+
+<h2 style="font-size:1.1rem;margin-top:1.4rem">🔧 Configurazione robot</h2>
+<label>Endpoint Azure Realtime</label>
+<input id="AZURE_OPENAI_REALTIME_ENDPOINT" placeholder="https://<risorsa>.openai.azure.com/"/>
+<label>Azure API key</label>
+<input id="AZURE_OPENAI_REALTIME_API_KEY" type="password" placeholder="(rimane solo sul robot)"/>
+<label>Deployment realtime</label>
+<input id="AZURE_OPENAI_REALTIME_DEPLOYMENT" placeholder="gpt-realtime"/>
+<label>Maestro (chi impersona Buddy)</label>
+<select id="MIRRORBUDDY_MAESTRO_ID"><option value="">— default (italiano) —</option></select>
+<label>Profilo DSA</label>
+<select id="MIRRORBUDDY_DSA_PROFILE">
+ <option value="cerebral">Paralisi cerebrale</option>
+ <option value="dyslexia">Dislessia</option>
+ <option value="dyscalculia">Discalculia</option>
+ <option value="adhd">ADHD</option>
+ <option value="autism">Autismo</option>
+ <option value="motor">Motorio</option>
+ <option value="visual">Visivo</option>
+ <option value="auditory">Uditivo</option>
+ <option value="default">Nessuno</option>
+</select>
+<label>Nome dello studente</label>
+<input id="MIRRORBUDDY_STUDENT_NAME" placeholder="Mario"/>
+<label>Sensibilità "basta" (quando interrompere Buddy)</label>
+<select id="MIRRORBUDDY_BARGE_RMS">
+ <option value="0.030">Alta — si ferma al primo accenno di voce</option>
+ <option value="0.045">Media (consigliata)</option>
+ <option value="0.060">Bassa — serve una voce più decisa (ambienti rumorosi)</option>
+</select>
+<button onclick="save()">Salva</button>
+<p><small>La chiave Azure resta solo su questo robot (file .env locale).</small></p>
+<script>
+async function load(){
+ const s=await (await fetch('./api/status')).json();
+ const box=document.getElementById('status');
+ if(s.ready){box.className='status ok';box.textContent='✅ Pronto';}
+ else{box.className='status warn';box.textContent='⚠️ Manca: '+(s.missing||[]).join(', ');}
+ const ps=document.getElementById('pairState');
+ if(s.paired){ps.className='status ok';ps.textContent='✅ Collegato al profilo del bambino.';}
+ else{ps.className='status warn';ps.textContent='Non collegato a nessun profilo.';}
+ for(const k of ['MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME']){
+  if(s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName']) document.getElementById(k).value=s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName'];
+ }
+ if(typeof s.bargeRms==='number'){
+  const sel=document.getElementById('MIRRORBUDDY_BARGE_RMS');
+  let best=sel.options[0].value,bd=1e9;
+  for(const o of sel.options){const d=Math.abs(parseFloat(o.value)-s.bargeRms);if(d<bd){bd=d;best=o.value;}}
+  sel.value=best;
+ }
+ try{
+  const m=await (await fetch('./api/maestri')).json();
+  const sel=document.getElementById('MIRRORBUDDY_MAESTRO_ID');
+  (m.maestri||[]).forEach(x=>{const o=document.createElement('option');o.value=x.id;o.textContent=x.name+' — '+x.subject+' ('+x.voice+')';sel.appendChild(o);});
+  if(s.maestroId) sel.value=s.maestroId;
+ }catch(e){}
+}
+async function save(){
+ const ids=['AZURE_OPENAI_REALTIME_ENDPOINT','AZURE_OPENAI_REALTIME_API_KEY','AZURE_OPENAI_REALTIME_DEPLOYMENT','MIRRORBUDDY_MAESTRO_ID','MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME','MIRRORBUDDY_BARGE_RMS'];
+ const body={};ids.forEach(i=>{const v=document.getElementById(i).value.trim();if(v)body[i]=v;});
+ const r=await (await fetch('./api/config',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)})).json();
+ load();
+ alert(r.ok?'Salvato!':'Errore: '+(r.error||'?'));
+}
+async function pair(){
+ const code=document.getElementById('pairCode').value.trim();
+ if(!code){alert('Inserisci il codice');return;}
+ const r=await (await fetch('./api/pair',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({code})})).json();
+ if(r.ok){document.getElementById('pairCode').value='';}
+ load();
+ alert(r.ok?'Collegato al profilo del bambino!':'Errore: '+(r.error||'?'));
+}
+load();
+</script>
+</body>
+</html>
+"""

--- a/robot/reachy_mini_mirrorbuddy/settings_ui.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_ui.py
@@ -30,6 +30,8 @@ _EDITABLE_KEYS = (
     "MIRRORBUDDY_STUDENT_NAME",
     "MIRRORBUDDY_DEVICE_TOKEN",
     "MIRRORBUDDY_API_BASE",
+    "MIRRORBUDDY_BARGE_RMS",
+    "MIRRORBUDDY_BARGE_FRAMES",
 )
 
 
@@ -57,6 +59,8 @@ def mount_settings_routes(app, instance_path: str | None) -> None:
                 "mirrorbuddyUrl": config.MIRRORBUDDY_URL,
                 "locale": config.LOCALE,
                 "paired": bool(config.DEVICE_TOKEN),
+                "bargeRms": config.BARGE_RMS_THRESHOLD,
+                "bargeFrames": config.BARGE_SUSTAIN_FRAMES,
             }
         )
 
@@ -207,6 +211,12 @@ _PAGE = """<!doctype html>
 </select>
 <label>Nome dello studente</label>
 <input id="MIRRORBUDDY_STUDENT_NAME" placeholder="Mario"/>
+<label>Sensibilità "basta" (quando interrompere Buddy)</label>
+<select id="MIRRORBUDDY_BARGE_RMS">
+ <option value="0.030">Alta — si ferma al primo accenno di voce</option>
+ <option value="0.045">Media (consigliata)</option>
+ <option value="0.060">Bassa — serve una voce più decisa (ambienti rumorosi)</option>
+</select>
 <button onclick="save()">Salva</button>
 <p><small>La chiave Azure resta solo su questo robot (file .env locale).</small></p>
 <script>
@@ -221,6 +231,12 @@ async function load(){
  for(const k of ['MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME']){
   if(s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName']) document.getElementById(k).value=s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName'];
  }
+ if(typeof s.bargeRms==='number'){
+  const sel=document.getElementById('MIRRORBUDDY_BARGE_RMS');
+  let best=sel.options[0].value,bd=1e9;
+  for(const o of sel.options){const d=Math.abs(parseFloat(o.value)-s.bargeRms);if(d<bd){bd=d;best=o.value;}}
+  sel.value=best;
+ }
  try{
   const m=await (await fetch('./api/maestri')).json();
   const sel=document.getElementById('MIRRORBUDDY_MAESTRO_ID');
@@ -229,7 +245,7 @@ async function load(){
  }catch(e){}
 }
 async function save(){
- const ids=['AZURE_OPENAI_REALTIME_ENDPOINT','AZURE_OPENAI_REALTIME_API_KEY','AZURE_OPENAI_REALTIME_DEPLOYMENT','MIRRORBUDDY_MAESTRO_ID','MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME'];
+ const ids=['AZURE_OPENAI_REALTIME_ENDPOINT','AZURE_OPENAI_REALTIME_API_KEY','AZURE_OPENAI_REALTIME_DEPLOYMENT','MIRRORBUDDY_MAESTRO_ID','MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME','MIRRORBUDDY_BARGE_RMS'];
  const body={};ids.forEach(i=>{const v=document.getElementById(i).value.trim();if(v)body[i]=v;});
  const r=await (await fetch('./api/config',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)})).json();
  load();

--- a/robot/reachy_mini_mirrorbuddy/settings_ui.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_ui.py
@@ -14,6 +14,7 @@ import logging
 from pathlib import Path
 
 from .config import config
+from .settings_page import PAGE
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ def mount_settings_routes(app, instance_path: str | None) -> None:
 
     @app.get("/", response_class=HTMLResponse)
     async def index() -> str:  # noqa: D401 - route
-        return _PAGE
+        return PAGE
 
     @app.get("/api/status")
     async def status() -> JSONResponse:
@@ -159,108 +160,3 @@ def _write_env(env_path: Path, updates: dict[str, str]) -> None:
     existing.update(updates)
     body = "\n".join(f"{k}={v}" for k, v in existing.items()) + "\n"
     env_path.write_text(body, encoding="utf-8")
-
-
-_PAGE = """<!doctype html>
-<html lang="it">
-<head>
-<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>MirrorBuddy Robot — Impostazioni</title>
-<style>
- body{font-family:system-ui,sans-serif;max-width:640px;margin:2rem auto;padding:0 1rem;color:#1a1a2e}
- h1{font-size:1.4rem} label{display:block;margin:.6rem 0 .2rem;font-weight:600;font-size:.9rem}
- input,select{width:100%;padding:.5rem;border:1px solid #ccc;border-radius:8px;font-size:1rem}
- button{margin-top:1rem;padding:.6rem 1.2rem;border:0;border-radius:8px;background:#5b47e0;color:#fff;font-size:1rem;cursor:pointer}
- .status{padding:.6rem;border-radius:8px;margin:.5rem 0;font-size:.9rem}
- .ok{background:#e4f8ec;color:#0a7a3d} .warn{background:#fff3e0;color:#a35b00}
- small{color:#666}
-</style>
-</head>
-<body>
-<h1>🤖 MirrorBuddy Robot</h1>
-<div id="status" class="status warn">Carico…</div>
-
-<h2 style="font-size:1.1rem;margin-top:1.4rem">👤 Profilo del bambino</h2>
-<div id="pairState" class="status warn">Non collegato a nessun profilo.</div>
-<label>Codice di collegamento (dalle Impostazioni di MirrorBuddy del genitore)</label>
-<input id="pairCode" inputmode="numeric" maxlength="6" placeholder="123456"/>
-<button onclick="pair()">Collega al profilo</button>
-<p><small>Il robot userà nome, materie e impostazioni di accessibilità del bambino loggato. Nessuna password lascia il computer del genitore.</small></p>
-
-<h2 style="font-size:1.1rem;margin-top:1.4rem">🔧 Configurazione robot</h2>
-<label>Endpoint Azure Realtime</label>
-<input id="AZURE_OPENAI_REALTIME_ENDPOINT" placeholder="https://<risorsa>.openai.azure.com/"/>
-<label>Azure API key</label>
-<input id="AZURE_OPENAI_REALTIME_API_KEY" type="password" placeholder="(rimane solo sul robot)"/>
-<label>Deployment realtime</label>
-<input id="AZURE_OPENAI_REALTIME_DEPLOYMENT" placeholder="gpt-realtime"/>
-<label>Maestro (chi impersona Buddy)</label>
-<select id="MIRRORBUDDY_MAESTRO_ID"><option value="">— default (italiano) —</option></select>
-<label>Profilo DSA</label>
-<select id="MIRRORBUDDY_DSA_PROFILE">
- <option value="cerebral">Paralisi cerebrale</option>
- <option value="dyslexia">Dislessia</option>
- <option value="dyscalculia">Discalculia</option>
- <option value="adhd">ADHD</option>
- <option value="autism">Autismo</option>
- <option value="motor">Motorio</option>
- <option value="visual">Visivo</option>
- <option value="auditory">Uditivo</option>
- <option value="default">Nessuno</option>
-</select>
-<label>Nome dello studente</label>
-<input id="MIRRORBUDDY_STUDENT_NAME" placeholder="Mario"/>
-<label>Sensibilità "basta" (quando interrompere Buddy)</label>
-<select id="MIRRORBUDDY_BARGE_RMS">
- <option value="0.030">Alta — si ferma al primo accenno di voce</option>
- <option value="0.045">Media (consigliata)</option>
- <option value="0.060">Bassa — serve una voce più decisa (ambienti rumorosi)</option>
-</select>
-<button onclick="save()">Salva</button>
-<p><small>La chiave Azure resta solo su questo robot (file .env locale).</small></p>
-<script>
-async function load(){
- const s=await (await fetch('./api/status')).json();
- const box=document.getElementById('status');
- if(s.ready){box.className='status ok';box.textContent='✅ Pronto';}
- else{box.className='status warn';box.textContent='⚠️ Manca: '+(s.missing||[]).join(', ');}
- const ps=document.getElementById('pairState');
- if(s.paired){ps.className='status ok';ps.textContent='✅ Collegato al profilo del bambino.';}
- else{ps.className='status warn';ps.textContent='Non collegato a nessun profilo.';}
- for(const k of ['MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME']){
-  if(s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName']) document.getElementById(k).value=s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName'];
- }
- if(typeof s.bargeRms==='number'){
-  const sel=document.getElementById('MIRRORBUDDY_BARGE_RMS');
-  let best=sel.options[0].value,bd=1e9;
-  for(const o of sel.options){const d=Math.abs(parseFloat(o.value)-s.bargeRms);if(d<bd){bd=d;best=o.value;}}
-  sel.value=best;
- }
- try{
-  const m=await (await fetch('./api/maestri')).json();
-  const sel=document.getElementById('MIRRORBUDDY_MAESTRO_ID');
-  (m.maestri||[]).forEach(x=>{const o=document.createElement('option');o.value=x.id;o.textContent=x.name+' — '+x.subject+' ('+x.voice+')';sel.appendChild(o);});
-  if(s.maestroId) sel.value=s.maestroId;
- }catch(e){}
-}
-async function save(){
- const ids=['AZURE_OPENAI_REALTIME_ENDPOINT','AZURE_OPENAI_REALTIME_API_KEY','AZURE_OPENAI_REALTIME_DEPLOYMENT','MIRRORBUDDY_MAESTRO_ID','MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME','MIRRORBUDDY_BARGE_RMS'];
- const body={};ids.forEach(i=>{const v=document.getElementById(i).value.trim();if(v)body[i]=v;});
- const r=await (await fetch('./api/config',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)})).json();
- load();
- alert(r.ok?'Salvato!':'Errore: '+(r.error||'?'));
-}
-async function pair(){
- const code=document.getElementById('pairCode').value.trim();
- if(!code){alert('Inserisci il codice');return;}
- const r=await (await fetch('./api/pair',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({code})})).json();
- if(r.ok){document.getElementById('pairCode').value='';}
- load();
- alert(r.ok?'Collegato al profilo del bambino!':'Errore: '+(r.error||'?'));
-}
-load();
-</script>
-</body>
-</html>
-"""

--- a/robot/tests/test_config_barge.py
+++ b/robot/tests/test_config_barge.py
@@ -1,0 +1,53 @@
+"""Tests for the field-tunable local barge-in thresholds in Config.
+
+These are surfaced as robot configuration (settings UI + instance ``.env``) so the
+"basta" sensitivity can be adjusted per environment without a redeploy. They must be
+read *after* the instance ``.env`` loads, so we validate defaults, overrides, the
+minimum-frame clamp, and graceful fallback on invalid input.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reachy_mini_mirrorbuddy.config import Config  # noqa: E402
+
+_BARGE_ENV = ("MIRRORBUDDY_BARGE_RMS", "MIRRORBUDDY_BARGE_FRAMES")
+
+
+def _clear(monkeypatch) -> None:
+    for k in _BARGE_ENV:
+        monkeypatch.delenv(k, raising=False)
+
+
+class TestBargeConfig:
+    def test_defaults(self, monkeypatch):
+        _clear(monkeypatch)
+        c = Config()
+        assert c.BARGE_RMS_THRESHOLD == 0.045
+        assert c.BARGE_SUSTAIN_FRAMES == 3
+
+    def test_env_overrides(self, monkeypatch):
+        _clear(monkeypatch)
+        monkeypatch.setenv("MIRRORBUDDY_BARGE_RMS", "0.03")
+        monkeypatch.setenv("MIRRORBUDDY_BARGE_FRAMES", "5")
+        c = Config()
+        assert c.BARGE_RMS_THRESHOLD == 0.03
+        assert c.BARGE_SUSTAIN_FRAMES == 5
+
+    def test_frames_clamped_to_minimum(self, monkeypatch):
+        _clear(monkeypatch)
+        monkeypatch.setenv("MIRRORBUDDY_BARGE_FRAMES", "0")
+        c = Config()
+        assert c.BARGE_SUSTAIN_FRAMES == 1
+
+    def test_invalid_values_fall_back_to_defaults(self, monkeypatch):
+        _clear(monkeypatch)
+        monkeypatch.setenv("MIRRORBUDDY_BARGE_RMS", "not-a-number")
+        monkeypatch.setenv("MIRRORBUDDY_BARGE_FRAMES", "abc")
+        c = Config()
+        assert c.BARGE_RMS_THRESHOLD == 0.045
+        assert c.BARGE_SUSTAIN_FRAMES == 3


### PR DESCRIPTION
## Cosa
Rende la sensibilità dell'interruzione "basta" un **parametro di configurazione** del robottino, invece di una lettura env ad-hoc.

- `Config` espone `BARGE_RMS_THRESHOLD` / `BARGE_SUSTAIN_FRAMES`, letti in `reload()` **dopo** il caricamento del `.env` di istanza (helper `_float`/`_int`: valori non validi → default; frame ≥ 1).
- `main.py` li passa a `AudioIO`; `AudioIO` accetta le soglie esplicite (fallback env mantenuto per uso standalone).
- **Settings UI**: nuovo selettore "Sensibilità basta" (alta/media/bassa) salvato nel `.env` di istanza; `/api/status` restituisce i valori correnti.
- README + docstring aggiornati.
- Test: default, override, clamp, fallback su valori invalidi.

## Perché
Roberto vuole poter regolare quanto in fretta Buddy si ferma a "basta" dalla configurazione del robot, senza redeploy — critico per non stressare il bambino.

## Test
33 test robot verdi, ruff pulito.