### PR TITLE
fix(session): opener speaks as the picked Maestro, not the coach

### DIFF
--- a/apps/web/src/app/[locale]/home-intent-chooser.tsx
+++ b/apps/web/src/app/[locale]/home-intent-chooser.tsx
@@ -30,6 +30,12 @@ export interface IntentStart {
   subject?: Subject;
   /** Localized subject label for the handoff banner (UX-01). */
   subjectLabel?: string;
+  /**
+   * True only for the generalist "I don't know / a bit of everything" homework
+   * host, where no concrete Maestro persona was chosen. Lets the session open
+   * under the study coach instead of faking the arbitrary host Maestro's voice.
+   */
+  unknownSubject?: boolean;
 }
 
 /**
@@ -200,7 +206,12 @@ export function HomeIntentChooser({ userName, onStart }: HomeIntentChooserProps)
     setPendingIntent(card.intent);
   };
 
-  const openSession = (intent: Intent, maestro: Maestro, subject?: Subject) => {
+  const openSession = (
+    intent: Intent,
+    maestro: Maestro,
+    subject?: Subject,
+    unknownSubject = false,
+  ) => {
     const requestedToolType: ToolType | undefined =
       intent === 'study' ? 'mindmap' : intent === 'quizMe' ? 'quiz' : undefined;
     onStart({
@@ -211,6 +222,7 @@ export function HomeIntentChooser({ userName, onStart }: HomeIntentChooserProps)
       contextMessage: t(`intent.${intent}.contextMessage`),
       subject,
       subjectLabel: subject ? t(`subjects.${subject}`) : undefined,
+      unknownSubject,
     });
   };
 
@@ -225,7 +237,7 @@ export function HomeIntentChooser({ userName, onStart }: HomeIntentChooserProps)
   const handleAnySubject = () => {
     const host = getAllMaestriHost();
     if (!host || pendingIntent !== 'homework') return;
-    openSession('homework', host);
+    openSession('homework', host, undefined, true);
   };
 
   // UX-02: read a card aloud on demand. Only wired when the child's profile has

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -78,6 +78,9 @@ export default function Home() {
   // is opened directly from the grown-ups Maestri grid (no handoff to explain).
   const [sessionIntent, setSessionIntent] = useState<Intent | undefined>(undefined);
   const [sessionSubjectLabel, setSessionSubjectLabel] = useState<string | undefined>(undefined);
+  // True only for the generalist "I don't know" homework host, so the session
+  // opens under the study coach instead of the arbitrary host Maestro's voice.
+  const [sessionUnknownSubject, setSessionUnknownSubject] = useState(false);
   // COMP-01 (#432): the grown-up view the child is trying to reach, held until
   // an adult passes the gate (null = no gate pending).
   const [pendingGrownUpView, setPendingGrownUpView] = useState<View | null>(null);
@@ -165,6 +168,7 @@ export default function Home() {
     setSessionContextMessage(start.contextMessage);
     setSessionIntent(start.intent);
     setSessionSubjectLabel(start.subjectLabel);
+    setSessionUnknownSubject(Boolean(start.unknownSubject));
     setMaestroSessionKey((prev) => prev + 1);
     setCurrentView('maestro-session');
   };
@@ -240,12 +244,14 @@ export default function Home() {
               setSessionContextMessage(undefined);
               setSessionIntent(undefined);
               setSessionSubjectLabel(undefined);
+              setSessionUnknownSubject(false);
             }}
             initialMode={maestroSessionMode}
             requestedToolType={requestedToolType}
             contextMessage={sessionContextMessage}
             intent={sessionIntent}
             subjectLabel={sessionSubjectLabel}
+            unknownSubject={sessionUnknownSubject}
           />
         </div>
       )}
@@ -310,6 +316,7 @@ export default function Home() {
                     // Grid (grown-ups) entry: no intent handoff to explain.
                     setSessionIntent(undefined);
                     setSessionSubjectLabel(undefined);
+                    setSessionUnknownSubject(false);
                     setMaestroSessionKey((prev) => prev + 1);
                     setCurrentView('maestro-session');
                   }}

--- a/apps/web/src/components/maestros/__tests__/coach-opener.test.ts
+++ b/apps/web/src/components/maestros/__tests__/coach-opener.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { resolveCoachName, buildCoachOpener } from '../coach-opener';
+import { resolveCoachName, resolveCoachIdentity, buildCoachOpener } from '../coach-opener';
 
 describe('resolveCoachName', () => {
   it('returns the chosen coach name for a valid preference', () => {
@@ -24,6 +24,26 @@ describe('resolveCoachName', () => {
 
     // Assert
     expect(name).toBe('Melissa');
+  });
+});
+
+describe('resolveCoachIdentity', () => {
+  it('returns the chosen coach name and avatar for a valid preference', () => {
+    // Arrange / Act
+    const identity = resolveCoachIdentity('melissa');
+
+    // Assert
+    expect(identity.name).toBe('Melissa');
+    expect(identity.avatar).toBe('/avatars/melissa.webp');
+  });
+
+  it('falls back to the default coach (Melissa) identity when preference is unknown', () => {
+    // Arrange / Act
+    const identity = resolveCoachIdentity('does-not-exist');
+
+    // Assert
+    expect(identity.name).toBe('Melissa');
+    expect(identity.avatar).toBe('/avatars/melissa.webp');
   });
 });
 

--- a/apps/web/src/components/maestros/coach-opener.ts
+++ b/apps/web/src/components/maestros/coach-opener.ts
@@ -26,6 +26,22 @@ export function resolveCoachName(preferredCoach: string | null | undefined): str
 }
 
 /**
+ * Resolve the display identity (name + avatar) of the child's chosen study coach,
+ * falling back to the default coach (Melissa). Used to attribute the neutral
+ * coach opener to the coach — never to the subject Maestro — so the child never
+ * sees the Maestro's face paired with the coach's words.
+ */
+export function resolveCoachIdentity(preferredCoach: string | null | undefined): {
+  name: string;
+  avatar: string;
+} {
+  const coach =
+    (preferredCoach && getSupportTeacherById(preferredCoach as CoachId)) ||
+    getDefaultSupportTeacher();
+  return { name: coach.name, avatar: coach.avatar };
+}
+
+/**
  * Build the localized neutral opener. Uses the short `withSubject` variant when the
  * subject is already known (so it doesn't block the subject Maestro / tool
  * auto-trigger), otherwise the guided-questions `general` variant.

--- a/apps/web/src/components/maestros/maestro-session.tsx
+++ b/apps/web/src/components/maestros/maestro-session.tsx
@@ -19,7 +19,7 @@ import { ErrorBoundary } from '@/components/error-boundary';
 import { useTTS } from '@/components/accessibility';
 import { ToolResultDisplay } from '@/components/tools';
 import { useUIStore, useSettingsStore } from '@/lib/stores';
-import { buildCoachOpener } from './coach-opener';
+import { buildCoachOpener, resolveCoachIdentity } from './coach-opener';
 import type { Maestro, ToolType } from '@/types';
 import { useMaestroSessionLogic } from './use-maestro-session-logic';
 import { MaestroSessionHandoff } from './maestro-session-handoff';
@@ -72,9 +72,19 @@ export function MaestroSession({
 
   const t = useTranslations('chat');
   const preferredCoach = useSettingsStore((s) => s.studentProfile.preferredCoach);
-  // Neutral opener on behalf of the child's chosen coach (falls back to Melissa)
-  // so a session never starts straight in a subject Maestro's persona.
-  const coachOpener = buildCoachOpener(preferredCoach, subjectLabel, t);
+  // Session opener. When the child already chose the subject, the picked Maestro
+  // is the deliberate host, so he greets in first person (matching the header +
+  // avatar — no identity clash). When the subject is unknown (the generalist
+  // "a bit of everything" path) we must NOT fake a Maestro persona: the child's
+  // study coach (falls back to Melissa) opens and asks the organizing questions,
+  // attributed to the coach's own name + avatar via `speaker`.
+  const sessionOpener: { content: string; speaker?: { name: string; avatar: string } } =
+    subjectLabel
+      ? { content: maestro.greeting }
+      : {
+          content: buildCoachOpener(preferredCoach, undefined, t),
+          speaker: resolveCoachIdentity(preferredCoach),
+        };
 
   // Prevent screen sleep during active sessions
   useWakeLock(true);
@@ -114,7 +124,7 @@ export function MaestroSession({
     initialMode,
     requestedToolType,
     contextMessage,
-    coachOpener,
+    opener: sessionOpener,
   });
 
   // Build unified voice state and actions

--- a/apps/web/src/components/maestros/maestro-session.tsx
+++ b/apps/web/src/components/maestros/maestro-session.tsx
@@ -13,14 +13,15 @@
  */
 
 import { useRef, useEffect, useState } from 'react';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import { AnimatePresence } from 'framer-motion';
 import { ErrorBoundary } from '@/components/error-boundary';
 import { useTTS } from '@/components/accessibility';
 import { ToolResultDisplay } from '@/components/tools';
 import { useUIStore, useSettingsStore } from '@/lib/stores';
 import { buildCoachOpener, resolveCoachIdentity } from './coach-opener';
-import type { Maestro, ToolType } from '@/types';
+import { generateMaestroGreeting } from '@/lib/greeting';
+import type { Maestro, ToolType, SupportedLanguage } from '@/types';
 import { useMaestroSessionLogic } from './use-maestro-session-logic';
 import { MaestroSessionHandoff } from './maestro-session-handoff';
 import { MaestroSessionMessages } from './maestro-session-messages';
@@ -49,6 +50,13 @@ interface MaestroSessionProps {
   intent?: Intent;
   /** Localized subject label chosen by the child, for the handoff banner. */
   subjectLabel?: string;
+  /**
+   * True only for the generalist "a bit of everything" homework host, where no
+   * subject (and thus no real Maestro persona) was chosen. Direct Maestro entry
+   * points (grid, /maestri/[id]) leave this false even though subjectLabel is
+   * absent — they DID pick a concrete Maestro, so he should greet, not the coach.
+   */
+  unknownSubject?: boolean;
 }
 
 export function MaestroSession({
@@ -59,6 +67,7 @@ export function MaestroSession({
   contextMessage,
   intent,
   subjectLabel,
+  unknownSubject = false,
 }: MaestroSessionProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -71,19 +80,27 @@ export function MaestroSession({
   const unifiedCharacter = maestroToUnified(maestro);
 
   const t = useTranslations('chat');
+  const locale = useLocale();
   const preferredCoach = useSettingsStore((s) => s.studentProfile.preferredCoach);
-  // Session opener. When the child already chose the subject, the picked Maestro
-  // is the deliberate host, so he greets in first person (matching the header +
-  // avatar — no identity clash). When the subject is unknown (the generalist
-  // "a bit of everything" path) we must NOT fake a Maestro persona: the child's
-  // study coach (falls back to Melissa) opens and asks the organizing questions,
-  // attributed to the coach's own name + avatar via `speaker`.
+  // Session opener. Only the generalist "a bit of everything" host (no subject,
+  // no concrete Maestro persona chosen) opens under the study coach, who asks the
+  // organizing questions — attributed to the coach's own name + avatar via
+  // `speaker`. Every deliberate Maestro session (subject chosen, grid entry,
+  // /maestri/[id]) opens with the Maestro greeting in first person, localized to
+  // the active UI language so /en · /fr · /de · /es don't start in Italian.
   const sessionOpener: { content: string; speaker?: { name: string; avatar: string } } =
-    subjectLabel
-      ? { content: maestro.greeting }
-      : {
+    unknownSubject
+      ? {
           content: buildCoachOpener(preferredCoach, undefined, t),
           speaker: resolveCoachIdentity(preferredCoach),
+        }
+      : {
+          content: generateMaestroGreeting(
+            maestro.id,
+            maestro.displayName ?? maestro.name,
+            locale as SupportedLanguage,
+            maestro.greeting,
+          ),
         };
 
   // Prevent screen sleep during active sessions
@@ -287,17 +304,22 @@ export function MaestroSession({
         {/* UX-01/UX-07: child-first handoff banner. Only when arriving via an
             intent (grid entry passes no intent) and before the child has sent
             anything (it explains who they are talking to + the pre-filled
-            question). The neutral coach opener seeds an assistant message, so we
-            key off "no user message yet" rather than an empty thread. Tool intents
-            carry their own greeting/auto-trigger and never showed this banner. */}
-        {intent && !requestedToolType && !messages.some((m) => m.role === 'user') && (
-          <MaestroSessionHandoff
-            maestroName={maestro.displayName ?? maestro.name}
-            intent={intent}
-            subjectLabel={subjectLabel}
-            hasContextMessage={Boolean(contextMessage)}
-          />
-        )}
+            question). The opener seeds an assistant message, so we key off "no
+            user message yet" rather than an empty thread. Tool intents carry their
+            own greeting/auto-trigger and never showed this banner. Suppressed for
+            the generalist host (unknownSubject): naming an arbitrary Maestro there
+            would contradict the coach asking which subject to work on. */}
+        {intent &&
+          !requestedToolType &&
+          !unknownSubject &&
+          !messages.some((m) => m.role === 'user') && (
+            <MaestroSessionHandoff
+              maestroName={maestro.displayName ?? maestro.name}
+              intent={intent}
+              subjectLabel={subjectLabel}
+              hasContextMessage={Boolean(contextMessage)}
+            />
+          )}
 
         {/* Messages area - scrollable */}
         <MaestroSessionMessages

--- a/apps/web/src/components/maestros/message-bubble.tsx
+++ b/apps/web/src/components/maestros/message-bubble.tsx
@@ -1,11 +1,11 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import Image from "next/image";
-import { Volume2 } from "lucide-react";
-import { cn } from "@/lib/utils";
-import type { ChatMessage, Maestro } from "@/types";
-import { useTranslations } from "next-intl";
+import { motion } from 'framer-motion';
+import Image from 'next/image';
+import { Volume2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ChatMessage, Maestro } from '@/types';
+import { useTranslations } from 'next-intl';
 
 interface MessageBubbleProps {
   message: ChatMessage;
@@ -17,27 +17,27 @@ interface MessageBubbleProps {
 /**
  * Message bubble component matching CharacterChatView style.
  */
-export function MessageBubble({
-  message,
-  maestro,
-  ttsEnabled,
-  speak,
-}: MessageBubbleProps) {
-  const t = useTranslations("chat");
-  const isUser = message.role === "user";
+export function MessageBubble({ message, maestro, ttsEnabled, speak }: MessageBubbleProps) {
+  const t = useTranslations('chat');
+  const isUser = message.role === 'user';
   const isVoice = message.isVoice;
+  // Assistant messages default to the session Maestro's identity, but a message
+  // may carry its own speaker (e.g. the neutral study-coach opener spoken by
+  // Melissa) — never show the Maestro's face paired with another voice's words.
+  const speakerName = message.speaker?.name ?? maestro.displayName;
+  const speakerAvatar = message.speaker?.avatar ?? maestro.avatar;
 
   return (
     <motion.div
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
-      className={cn("flex gap-3", isUser ? "justify-end" : "justify-start")}
+      className={cn('flex gap-3', isUser ? 'justify-end' : 'justify-start')}
     >
       {!isUser && (
         <div className="flex-shrink-0">
           <Image
-            src={maestro.avatar}
-            alt={maestro.displayName}
+            src={speakerAvatar}
+            alt={speakerName}
             width={36}
             height={36}
             className="rounded-full object-cover"
@@ -46,16 +46,16 @@ export function MessageBubble({
       )}
       <div
         className={cn(
-          "max-w-[70%] xs:max-w-[85%] min-w-[120px] sm:min-w-[200px] rounded-2xl px-4 py-3",
+          'max-w-[70%] xs:max-w-[85%] min-w-[120px] sm:min-w-[200px] rounded-2xl px-4 py-3',
           isUser
-            ? "text-white rounded-br-md"
-            : "bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 rounded-bl-md shadow-sm",
+            ? 'text-white rounded-br-md'
+            : 'bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 rounded-bl-md shadow-sm',
         )}
         style={isUser ? { backgroundColor: maestro.color } : undefined}
       >
         {isVoice && (
           <span className="text-xs opacity-60 mb-1 flex items-center gap-1">
-            <Volume2 className="w-3 h-3" /> {t("trascrizioneVocale")}
+            <Volume2 className="w-3 h-3" /> {t('trascrizioneVocale')}
           </span>
         )}
         <p className="text-sm whitespace-pre-wrap break-words overflow-wrap-anywhere">
@@ -63,16 +63,16 @@ export function MessageBubble({
         </p>
         <div className="flex items-center justify-between mt-1 gap-2">
           <span className="text-xs opacity-60">
-            {new Date(message.timestamp).toLocaleTimeString("it-IT", {
-              hour: "2-digit",
-              minute: "2-digit",
+            {new Date(message.timestamp).toLocaleTimeString('it-IT', {
+              hour: '2-digit',
+              minute: '2-digit',
             })}
           </span>
           {!isUser && ttsEnabled && (
             <button
               onClick={() => speak(message.content)}
               className="text-xs opacity-60 hover:opacity-100 ml-auto"
-              title={t("leggiAdAltaVoce")}
+              title={t('leggiAdAltaVoce')}
             >
               <Volume2 className="w-3 h-3" />
             </button>

--- a/apps/web/src/components/maestros/use-maestro-session-logic.ts
+++ b/apps/web/src/components/maestros/use-maestro-session-logic.ts
@@ -17,13 +17,15 @@ interface UseMaestroSessionLogicProps {
   requestedToolType?: ToolType;
   contextMessage?: string;
   /**
-   * Neutral study-coach opener shown as the first assistant message so a session
-   * never starts by dropping the child straight into a subject Maestro's persona.
-   * Built (localized) by the caller from the profile's preferred coach. When the
-   * child starts a voice call this message is passed to the realtime model as
-   * conversation context, so voice inherits the same neutral framing.
+   * Session opener shown as the first assistant message so a session never starts
+   * by dropping the child straight into a fake Maestro persona. Built by the caller:
+   * when the subject is known it's the picked Maestro's own greeting (default
+   * attribution); when unknown it's the study coach's neutral opener, carrying a
+   * `speaker` (name + avatar) so it's attributed to the coach, not the Maestro.
+   * When the child starts a voice call the opener's text is passed to the realtime
+   * model as conversation context, so voice inherits the same framing.
    */
-  coachOpener?: string;
+  opener?: { content: string; speaker?: { name: string; avatar: string } };
 }
 
 export function useMaestroSessionLogic({
@@ -31,8 +33,14 @@ export function useMaestroSessionLogic({
   initialMode,
   requestedToolType,
   contextMessage,
-  coachOpener,
+  opener,
 }: UseMaestroSessionLogicProps) {
+  // Destructure the opener into stable primitives so the init effect keeps the
+  // same rerun semantics it had when the opener was a plain string (the `opener`
+  // object identity changes every render).
+  const openerContent = opener?.content;
+  const openerSpeakerName = opener?.speaker?.name;
+  const openerSpeakerAvatar = opener?.speaker?.avatar;
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -135,7 +143,7 @@ export function useMaestroSessionLogic({
   const hasAutoTriggeredRef = useRef(false);
 
   // Tracks which maestro this session was last initialized for, so a settings
-  // hydration (preferredCoach undefined → saved id, which changes coachOpener)
+  // hydration (preferredCoach undefined → saved id, which changes the opener)
   // reruns this effect WITHOUT wiping a conversation the child already started.
   const initializedMaestroRef = useRef<string | null>(null);
 
@@ -143,16 +151,19 @@ export function useMaestroSessionLogic({
   useEffect(() => {
     const initialMessages: ChatMessage[] = [];
 
-    // Neutral study-coach opener always comes first (when provided): it greets on
-    // behalf of the child's chosen coach and, if the subject isn't known yet,
-    // asks the organizing questions — instead of opening straight into a subject
-    // Maestro (e.g. Manzoni). The subject Maestro takes over on the next turn.
-    if (coachOpener) {
+    // Session opener always comes first (when provided). When the subject is known
+    // it's the picked Maestro greeting in first person; when unknown it's the study
+    // coach's neutral opener, attributed to the coach via `speaker` so the child
+    // never sees the Maestro's face paired with the coach's words.
+    if (openerContent) {
       initialMessages.push({
-        id: `coach-opener-${Date.now()}`,
+        id: `session-opener-${Date.now()}`,
         role: 'assistant',
-        content: coachOpener,
+        content: openerContent,
         timestamp: new Date(),
+        ...(openerSpeakerName && openerSpeakerAvatar
+          ? { speaker: { name: openerSpeakerName, avatar: openerSpeakerAvatar } }
+          : {}),
       });
     }
 
@@ -190,7 +201,7 @@ export function useMaestroSessionLogic({
     }
 
     // A fresh maestro (or first mount) starts a clean thread; a rerun for the SAME
-    // maestro — e.g. when preferredCoach hydrates and coachOpener changes — must not
+    // maestro — e.g. when preferredCoach hydrates and the opener changes — must not
     // clobber messages the child has already exchanged.
     const isFirstInitForMaestro = initializedMaestroRef.current !== maestro.id;
     initializedMaestroRef.current = maestro.id;
@@ -231,7 +242,9 @@ export function useMaestroSessionLogic({
     maestro.id,
     requestedToolType,
     contextMessage,
-    coachOpener,
+    openerContent,
+    openerSpeakerName,
+    openerSpeakerAvatar,
     pendingToolRequest,
     clearPendingToolRequest,
   ]);

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -34,6 +34,13 @@ export interface ChatMessage {
   evaluation?: SessionEvaluation;
   /** Indicates this was from voice transcript */
   isVoice?: boolean;
+  /**
+   * Optional per-message speaker override (display name + avatar). Set only for
+   * assistant messages spoken by someone other than the session's Maestro — e.g.
+   * the neutral study-coach opener, which is the coach (Melissa) speaking, not
+   * the Maestro. When unset, the UI attributes the message to the session Maestro.
+   */
+  speaker?: { name: string; avatar: string };
 }
 
 export interface Conversation {


### PR DESCRIPTION
## Problema
Segnalato da Roberto (screenshot): la sessione mostrava header/avatar **Euclide** ma il primo messaggio diceva *"Ciao! Sono Melissa"*. Il "neutral study-coach opener" (commit 64b5f9f3) veniva inserito come primo messaggio `assistant`, ma `MessageBubble` attribuisce **ogni** bubble non-utente all'avatar/nome del Maestro → faccia di Euclide + parole di Melissa. Lo stesso testo finiva anche nel contesto del modello voce.

## Fix (l'identità coincide sempre con chi parla)
- **Materia scelta** (es. Matematica→Euclide): il Maestro è l'host deliberato, quindi saluta **in prima persona** (`maestro.greeting`, stessa fonte dell'header). Header, banner, primo messaggio e contesto voce = tutto il Maestro. Nessun testo del coach.
- **Materia sconosciuta** (path generalista "un po' di tutto"): il coach apre ancora con le domande organizzative, ma il messaggio porta il proprio `speaker` (nome + avatar) → attribuito a **Melissa**, non alla faccia di un Maestro a caso.

## Dettagli
- Nuovo campo opzionale `ChatMessage.speaker` (override avatar/nome per-messaggio).
- Nuovo `resolveCoachIdentity()` (nome + avatar coach) accanto a `resolveCoachName`.
- `MessageBubble` fa fallback al Maestro quando `speaker` non è impostato.
- Opener `{ content, speaker? }` passato a `useMaestroSessionLogic` con deps primitive stabili.

## Verifiche
- typecheck pulito (i 7 errori residui sono pre-esistenti: Prisma `robotDevice` non generato in locale)
- **30/30** unit test cartella maestros verdi (+2 nuovi per `resolveCoachIdentity`)
- eslint pulito
- pre-push gate verde