### PR TITLE
fix(session): restore handoff banner for generalist path (unblock v0.22.2 promote)

### DIFF
--- a/apps/web/messages/de/chat.json
+++ b/apps/web/messages/de/chat.json
@@ -569,6 +569,7 @@
     "intentHandoff": {
       "headline": "Ich habe dich zu Prof. {name} für {intent} gebracht.",
       "headlineSubject": "Ich habe dich zu Prof. {name} für {subject} gebracht.",
+      "headlineGeneralist": "Ich bin {name} und helfe dir bei den Hausaufgaben. Mit welchem Fach möchtest du anfangen?",
       "contextHint": "Ich habe die Frage schon für dich geschrieben: Drück Enter, wenn du bereit bist, oder ändere sie, wie du willst.",
       "intent": {
         "homework": "die Hausaufgaben",

--- a/apps/web/messages/en/chat.json
+++ b/apps/web/messages/en/chat.json
@@ -569,6 +569,7 @@
     "intentHandoff": {
       "headline": "I brought you to Prof. {name} for {intent}.",
       "headlineSubject": "I brought you to Prof. {name} for {subject}.",
+      "headlineGeneralist": "I'm {name}, and I'll help you with your homework. Which subject would you like to start with?",
       "contextHint": "I've already written the question for you: press enter when you're ready, or change it however you like.",
       "intent": {
         "homework": "homework",

--- a/apps/web/messages/es/chat.json
+++ b/apps/web/messages/es/chat.json
@@ -569,6 +569,7 @@
     "intentHandoff": {
       "headline": "Te he llevado con el Prof. {name} para {intent}.",
       "headlineSubject": "Te he llevado con el Prof. {name} para {subject}.",
+      "headlineGeneralist": "Soy {name} y te ayudo con los deberes. ¿Por qué asignatura quieres empezar?",
       "contextHint": "Ya he escrito la pregunta por ti: pulsa enter cuando estés listo, o cámbiala como quieras.",
       "intent": {
         "homework": "los deberes",

--- a/apps/web/messages/fr/chat.json
+++ b/apps/web/messages/fr/chat.json
@@ -569,6 +569,7 @@
     "intentHandoff": {
       "headline": "Je t'ai emmené chez le Prof. {name} pour {intent}.",
       "headlineSubject": "Je t'ai emmené chez le Prof. {name} pour {subject}.",
+      "headlineGeneralist": "Je suis {name} et je t'aide avec tes devoirs. Par quelle matière veux-tu commencer ?",
       "contextHint": "J'ai déjà écrit la question pour toi : appuie sur entrée quand tu es prêt, ou modifie-la comme tu veux.",
       "intent": {
         "homework": "les devoirs",

--- a/apps/web/messages/it/chat.json
+++ b/apps/web/messages/it/chat.json
@@ -200,6 +200,7 @@
     "intentHandoff": {
       "headline": "Ti ho portato dal Prof. {name} per {intent}.",
       "headlineSubject": "Ti ho portato dal Prof. {name} per {subject}.",
+      "headlineGeneralist": "Sono {name} e ti do una mano con i compiti. Da quale materia vuoi partire?",
       "contextHint": "Ho già scritto la domanda per te: premi invio quando sei pronto, oppure cambiala come vuoi.",
       "intent": {
         "homework": "i compiti",

--- a/apps/web/src/components/maestros/maestro-session-handoff.tsx
+++ b/apps/web/src/components/maestros/maestro-session-handoff.tsx
@@ -15,6 +15,13 @@ interface MaestroSessionHandoffProps {
   subjectLabel?: string;
   /** Whether the input was pre-filled with a context message (UX-07). */
   hasContextMessage: boolean;
+  /**
+   * Generalist "a bit of everything" path: no concrete Maestro was chosen, so
+   * `maestroName` carries the study coach's name and the banner greets AS the
+   * coach (no "Prof.", no arbitrary host) to stay consistent with the coach
+   * opener the child actually hears/reads.
+   */
+  generalist?: boolean;
 }
 
 /**
@@ -35,6 +42,7 @@ export function MaestroSessionHandoff({
   intent,
   subjectLabel,
   hasContextMessage,
+  generalist = false,
 }: MaestroSessionHandoffProps) {
   const t = useTranslations('chat');
   const { speak, enabled: ttsEnabled } = useTTS();
@@ -43,9 +51,11 @@ export function MaestroSessionHandoff({
   if (dismissed) return null;
 
   const intentLabel = t(`intentHandoff.intent.${intent}`);
-  const headline = subjectLabel
-    ? t('intentHandoff.headlineSubject', { name: maestroName, subject: subjectLabel })
-    : t('intentHandoff.headline', { name: maestroName, intent: intentLabel });
+  const headline = generalist
+    ? t('intentHandoff.headlineGeneralist', { name: maestroName })
+    : subjectLabel
+      ? t('intentHandoff.headlineSubject', { name: maestroName, subject: subjectLabel })
+      : t('intentHandoff.headline', { name: maestroName, intent: intentLabel });
   const hint = hasContextMessage ? t('intentHandoff.contextHint') : null;
 
   const spokenText = [headline, hint].filter(Boolean).join('. ');

--- a/apps/web/src/components/maestros/maestro-session.tsx
+++ b/apps/web/src/components/maestros/maestro-session.tsx
@@ -306,20 +306,17 @@ export function MaestroSession({
             anything (it explains who they are talking to + the pre-filled
             question). The opener seeds an assistant message, so we key off "no
             user message yet" rather than an empty thread. Tool intents carry their
-            own greeting/auto-trigger and never showed this banner. Suppressed for
-            the generalist host (unknownSubject): naming an arbitrary Maestro there
-            would contradict the coach asking which subject to work on. */}
-        {intent &&
-          !requestedToolType &&
-          !unknownSubject &&
-          !messages.some((m) => m.role === 'user') && (
-            <MaestroSessionHandoff
-              maestroName={maestro.displayName ?? maestro.name}
-              intent={intent}
-              subjectLabel={subjectLabel}
-              hasContextMessage={Boolean(contextMessage)}
-            />
-          )}
+            own greeting/auto-trigger and never showed this banner. Shown for the
+            generalist host too (accessibility: the banner is the text announcement
+            of the handoff, which DSA/Deaf personas rely on). */}
+        {intent && !requestedToolType && !messages.some((m) => m.role === 'user') && (
+          <MaestroSessionHandoff
+            maestroName={maestro.displayName ?? maestro.name}
+            intent={intent}
+            subjectLabel={subjectLabel}
+            hasContextMessage={Boolean(contextMessage)}
+          />
+        )}
 
         {/* Messages area - scrollable */}
         <MaestroSessionMessages

--- a/apps/web/src/components/maestros/maestro-session.tsx
+++ b/apps/web/src/components/maestros/maestro-session.tsx
@@ -311,10 +311,15 @@ export function MaestroSession({
             of the handoff, which DSA/Deaf personas rely on). */}
         {intent && !requestedToolType && !messages.some((m) => m.role === 'user') && (
           <MaestroSessionHandoff
-            maestroName={maestro.displayName ?? maestro.name}
+            maestroName={
+              unknownSubject
+                ? (sessionOpener.speaker?.name ?? maestro.displayName ?? maestro.name)
+                : (maestro.displayName ?? maestro.name)
+            }
             intent={intent}
             subjectLabel={subjectLabel}
             hasContextMessage={Boolean(contextMessage)}
+            generalist={unknownSubject}
           />
         )}
 


### PR DESCRIPTION
## Perché
Il fix identità v0.22.2 (Euclide/Melissa) sopprimeva il banner `maestro-session-handoff` nel percorso generalista (`unknownSubject`, "un po' di tutto"). Quel banner è l'annuncio testuale accessibile dell'handoff su cui contano le persona DSA/sordo/motorio.

La soppressione ha rotto l'E2E full-suite `home-intent-dsa-personas.spec.ts:200` (Luca, solo tastiera) su main → Deployment Gate: failure → staging/auto-promote saltati → v0.22.2 non è mai andata in produzione (prod ferma a 0.22.1).

## Cosa
- Ripristino il banner per tutti i percorsi intent (incluso il generalista).
- `unknownSubject` continua a governare solo l'identità dell'opener (coach Melissa vs saluto del Maestro) — il vero fix del mismatch Euclide/Melissa resta invariato.

## Test
Ripristina il comportamento atteso da `home-intent-dsa-personas.spec.ts:200`. Gli altri due rossi del run release (`home-intent-a11y.spec.ts:171` progress-axe, `locale-switching.spec.ts:146`) erano flaky: non fallirono nel run identico e08380d, solo nel run release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
