### PR TITLE
chore: add gbrain search guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,65 @@ Bash guard blocks: standalone `npm run lint|typecheck|build|test:unit`, `gh run 
 ## Verify-Before-Done
 
 Never claim done without `/verify-done` (or `./scripts/health-check.sh` + `npm run ci:summary`). Paste output. Red = not done. Same for TaskUpdate completed.
+
+## GBrain Search Guidance (configured by /sync-gbrain)
+
+<!-- gstack-gbrain-search-guidance:start -->
+
+GBrain is set up and synced on this machine. The agent should prefer gbrain
+over Grep when the question is semantic or when you don't know the exact
+identifier yet.
+
+**This worktree is pinned to a worktree-scoped code source** via the
+`.gbrain-source` file in the repo root (kubectl-style context).
+`gbrain code-def`, `code-refs`, `code-callers`, `code-callees`, `search`, and
+`query` from anywhere under this worktree route to that source by default —
+no `--source` flag needed (gbrain >= 0.41.38.0; on older gbrain the call-graph
+commands need `--source "$(cat .gbrain-source)"`). Conductor sibling worktrees
+of the same repo each have their own pin and their own indexed pages, so
+semantic results match the code on disk here.
+
+Call-graph queries (`code-callers`/`code-callees`) also need the graph to be
+built first — run `/sync-gbrain --dream` (or `--full`) if they return
+`count: 0`. This only works if this source's gbrain schema pack extracts code
+symbols; on a non-code-aware pack `--dream` completes but the graph stays empty
+and reports a WARN. `code-def`/`code-refs` need the same extraction.
+
+Two indexed corpora available via the `gbrain` CLI:
+
+- This worktree's code (auto-pinned via `.gbrain-source`).
+- `~/.gstack/` curated memory (registered as `gstack-brain-<user>` source via
+  the existing federation pipeline).
+
+Prefer gbrain when:
+
+- "Where is X handled?" / semantic intent, no exact string yet:
+  `gbrain search "<terms>"` or `gbrain query "<question>"`
+- "Where is symbol Y defined?" / symbol-based code questions:
+  `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
+- "What calls Y?" / "What does Y depend on?":
+  `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
+- "What did we decide last time?" / past plans, retros, learnings:
+  `gbrain search "<terms>" --source gstack-brain-<user>`
+
+Grep is still right for known exact strings, regex, multiline patterns, and
+file globs. Run `/sync-gbrain` after meaningful code changes; for ongoing
+auto-sync across all worktrees, run `gbrain autopilot --install` once per
+machine — gbrain's daemon handles incremental refresh on a schedule.
+
+Safety: don't run `/sync-gbrain` while `gbrain autopilot` is active — the
+orchestrator refuses destructive source ops when it detects a running autopilot
+to avoid racing it (#1734). Prefer registering user repos with `gbrain sources
+add --path <dir>` (no `--url`): URL-managed sources can auto-reclone, and the
+sync code walk for them requires an explicit `--allow-reclone` opt-in.
+
+**Known local limitation (this machine):** on repos where the gbrain source
+was registered under a custom name before the `gstack-code-<slug>` convention
+existed (most of Roberto's repos), `/sync-gbrain`'s own code-import stage
+fails with a path-overlap error even though the `.gbrain-source` pin above
+works fine for reads. Use `/sync-gbrain --no-code` on those repos to skip the
+broken stage cleanly; code freshness is handled separately by a nightly
+`gbrain-refresh-code` launchd job. Rebuild the call graph manually with
+`gbrain dream --source $(cat .gbrain-source)` when needed.
+
+<!-- gstack-gbrain-search-guidance:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,9 +75,13 @@ Never claim done without `/verify-done` (or `./scripts/health-check.sh` + `npm r
 
 <!-- gstack-gbrain-search-guidance:start -->
 
-GBrain is set up and synced on this machine. The agent should prefer gbrain
-over Grep when the question is semantic or when you don't know the exact
-identifier yet.
+Use this section only when both `command -v gbrain` succeeds and a readable
+`.gbrain-source` file exists in the repository root. If either prerequisite is
+missing, ignore this section and use the repository's normal search tools;
+do not install or configure gbrain automatically.
+
+When those prerequisites are present, prefer gbrain over Grep when the question
+is semantic or when you don't know the exact identifier yet.
 
 **This worktree is pinned to a worktree-scoped code source** via the
 `.gbrain-source` file in the repo root (kubectl-style context).
@@ -94,11 +98,11 @@ built first — run `/sync-gbrain --dream` (or `--full`) if they return
 symbols; on a non-code-aware pack `--dream` completes but the graph stays empty
 and reports a WARN. `code-def`/`code-refs` need the same extraction.
 
-Two indexed corpora available via the `gbrain` CLI:
+Indexed corpora may include:
 
 - This worktree's code (auto-pinned via `.gbrain-source`).
-- `~/.gstack/` curated memory (registered as `gstack-brain-<user>` source via
-  the existing federation pipeline).
+- `~/.gstack/` curated memory, when `gbrain sources list` shows a
+  `gstack-brain-<user>` source registered by the federation pipeline.
 
 Prefer gbrain when:
 
@@ -121,14 +125,5 @@ orchestrator refuses destructive source ops when it detects a running autopilot
 to avoid racing it (#1734). Prefer registering user repos with `gbrain sources
 add --path <dir>` (no `--url`): URL-managed sources can auto-reclone, and the
 sync code walk for them requires an explicit `--allow-reclone` opt-in.
-
-**Known local limitation (this machine):** on repos where the gbrain source
-was registered under a custom name before the `gstack-code-<slug>` convention
-existed (most of Roberto's repos), `/sync-gbrain`'s own code-import stage
-fails with a path-overlap error even though the `.gbrain-source` pin above
-works fine for reads. Use `/sync-gbrain --no-code` on those repos to skip the
-broken stage cleanly; code freshness is handled separately by a nightly
-`gbrain-refresh-code` launchd job. Rebuild the call graph manually with
-`gbrain dream --source $(cat .gbrain-source)` when needed.
 
 <!-- gstack-gbrain-search-guidance:end -->


### PR DESCRIPTION
## Summary
- add gbrain search guidance to CLAUDE.md

## Context
Publishes the existing local commit through the repository-required pull request path.