### PR TITLE
fix(deploy): pin Vercel CLI to validated version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ concurrency:
 
 env:
   NODE_VERSION: "20"
+  VERCEL_CLI_VERSION: "56.3.2"
 
 jobs:
   # =========================================================================
@@ -616,7 +617,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Vercel CLI
-        run: npm install -g vercel@latest
+        run: npm install -g "vercel@${VERCEL_CLI_VERSION}"
 
       - name: Validate VERCEL_TOKEN is set
         id: vercel_token_check
@@ -1981,7 +1982,7 @@ jobs:
           echo "✅ VERCEL_TOKEN is configured (length: ${{ secrets.VERCEL_TOKEN && 'present' || 'missing' }})"
 
       - name: Install Vercel CLI
-        run: npm install -g vercel@latest
+        run: npm install -g "vercel@${VERCEL_CLI_VERSION}"
 
       - name: Pull Vercel Environment
         run: |
@@ -2153,7 +2154,7 @@ jobs:
           echo "Staging URL: $STAGING_URL"
 
       - name: Install Vercel CLI
-        run: npm install -g vercel@latest
+        run: npm install -g "vercel@${VERCEL_CLI_VERSION}"
 
       - name: Pre-promote staging health check
         run: |

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -18,6 +18,9 @@ permissions:
   deployments: write
   issues: write
 
+env:
+  VERCEL_CLI_VERSION: "56.3.2"
+
 jobs:
   promote:
     name: "🚀 Promote Staging → Production"
@@ -37,7 +40,7 @@ jobs:
           node-version: "20"
 
       - name: Install Vercel CLI
-        run: npm install -g vercel@latest
+        run: npm install -g "vercel@${VERCEL_CLI_VERSION}"
 
       - name: Validate VERCEL_TOKEN
         run: |

--- a/apps/web/src/__tests__/workflows/vercel-cli-version.test.ts
+++ b/apps/web/src/__tests__/workflows/vercel-cli-version.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import YAML from 'yaml';
+import { describe, expect, it } from 'vitest';
+
+const LAST_KNOWN_GOOD_VERCEL_CLI = '56.3.2';
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+}
+
+interface Workflow {
+  env?: Record<string, string>;
+  jobs: Record<string, { steps: WorkflowStep[] }>;
+}
+
+function readWorkflow(fileName: string): Workflow {
+  return YAML.parse(
+    readFileSync(join(process.cwd(), '.github/workflows', fileName), 'utf-8'),
+  ) as Workflow;
+}
+
+function vercelInstallCommands(workflow: Workflow): string[] {
+  return Object.values(workflow.jobs).flatMap((job) =>
+    job.steps
+      .filter((step) => step.name === 'Install Vercel CLI')
+      .map((step) => step.run)
+      .filter((command): command is string => command !== undefined),
+  );
+}
+
+describe('Vercel CLI workflow version', () => {
+  it.each(['ci.yml', 'promote-to-production.yml'])(
+    'pins the validated CLI version in %s',
+    (fileName) => {
+      const workflow = readWorkflow(fileName);
+
+      expect(workflow.env?.VERCEL_CLI_VERSION).toBe(LAST_KNOWN_GOOD_VERCEL_CLI);
+      expect(vercelInstallCommands(workflow)).not.toHaveLength(0);
+      expect(vercelInstallCommands(workflow)).toEqual(
+        expect.arrayContaining(['npm install -g "vercel@${VERCEL_CLI_VERSION}"']),
+      );
+      expect(JSON.stringify(workflow)).not.toContain('vercel@latest');
+    },
+  );
+});


### PR DESCRIPTION
## Root cause

The application and deployment inputs were unchanged from the last successful deployment. The CI job drifted from Vercel CLI `56.3.2` to `58.4.4` because workflows installed `vercel@latest`.

- `56.3.2`: uploaded 5,350 files / 10.4 MB and deployed successfully
- `58.4.4`: uploaded 1,258 files / 1.3 MB and failed with `ENOENT ... node_modules/.prisma/client/default.js`

## Fix

- pin Vercel CLI `56.3.2` in CI and manual promotion workflows
- add a workflow regression test that rejects `vercel@latest`

## Verification

- regression test fails before the pin and passes after it
- targeted Vitest and ESLint pass
- local pre-push Vercel simulation passes