### PR TITLE
fix(robot+settings): unblock robot stop and surface pairing-code errors

### DIFF
--- a/apps/web/messages/de/settings.json
+++ b/apps/web/messages/de/settings.json
@@ -1307,7 +1307,13 @@
       "step3": "Der Roboter startet bereits mit dem Profil deines Kindes personalisiert.",
       "noRobotYet": "Noch keinen Roboter?",
       "buyCta": "Einen Reachy Mini kaufen",
-      "buyNote": "Reachy Mini Lite ab etwa 299 $, Wireless-Version ab etwa 449 $, auf reachy-mini.org."
+      "buyNote": "Reachy Mini Lite ab etwa 299 $, Wireless-Version ab etwa 449 $, auf reachy-mini.org.",
+      "errorTitle": "Code konnte nicht erstellt werden",
+      "errorAuth": "Deine Sitzung ist abgelaufen: Melde dich erneut an und versuche es nochmal.",
+      "errorRateLimit": "Zu viele Codes erstellt. Versuche es in einer Stunde erneut.",
+      "errorGeneric": "Etwas ist schiefgelaufen (Fehler {status}). Bitte versuche es gleich erneut.",
+      "errorNetwork": "Keine Verbindung zum Server. Prüfe dein Netzwerk und versuche es erneut.",
+      "retry": "Erneut versuchen"
     }
   }
 }

--- a/apps/web/messages/en/settings.json
+++ b/apps/web/messages/en/settings.json
@@ -1307,7 +1307,13 @@
       "step3": "The robot starts already personalised with your child's profile.",
       "noRobotYet": "Don't have a robot yet?",
       "buyCta": "Buy a Reachy Mini",
-      "buyNote": "Reachy Mini Lite from about $299, Wireless version from about $449, at reachy-mini.org."
+      "buyNote": "Reachy Mini Lite from about $299, Wireless version from about $449, at reachy-mini.org.",
+      "errorTitle": "Could not generate the code",
+      "errorAuth": "Your session expired: sign in again and retry.",
+      "errorRateLimit": "Too many codes generated. Try again in an hour.",
+      "errorGeneric": "Something went wrong (error {status}). Please try again shortly.",
+      "errorNetwork": "No connection to the server. Check your network and retry.",
+      "retry": "Retry"
     }
   }
 }

--- a/apps/web/messages/es/settings.json
+++ b/apps/web/messages/es/settings.json
@@ -1307,7 +1307,13 @@
       "step3": "El robot arranca ya personalizado con el perfil de tu hijo.",
       "noRobotYet": "¿Aún no tienes un robot?",
       "buyCta": "Comprar un Reachy Mini",
-      "buyNote": "Reachy Mini Lite desde unos 299 $, versión Wireless desde unos 449 $, en reachy-mini.org."
+      "buyNote": "Reachy Mini Lite desde unos 299 $, versión Wireless desde unos 449 $, en reachy-mini.org.",
+      "errorTitle": "No he podido generar el código",
+      "errorAuth": "Tu sesión ha caducado: vuelve a entrar e inténtalo de nuevo.",
+      "errorRateLimit": "Demasiados códigos generados. Inténtalo dentro de una hora.",
+      "errorGeneric": "Algo ha fallado (error {status}). Inténtalo de nuevo en un momento.",
+      "errorNetwork": "Sin conexión con el servidor. Comprueba la red e inténtalo de nuevo.",
+      "retry": "Reintentar"
     }
   }
 }

--- a/apps/web/messages/fr/settings.json
+++ b/apps/web/messages/fr/settings.json
@@ -1307,7 +1307,13 @@
       "step3": "Le robot démarre déjà personnalisé avec le profil de votre enfant.",
       "noRobotYet": "Vous n'avez pas encore de robot ?",
       "buyCta": "Acheter un Reachy Mini",
-      "buyNote": "Reachy Mini Lite à partir d'environ 299 $, version Wireless à partir d'environ 449 $, sur reachy-mini.org."
+      "buyNote": "Reachy Mini Lite à partir d'environ 299 $, version Wireless à partir d'environ 449 $, sur reachy-mini.org.",
+      "errorTitle": "Impossible de générer le code",
+      "errorAuth": "Votre session a expiré : reconnectez-vous et réessayez.",
+      "errorRateLimit": "Trop de codes générés. Réessayez dans une heure.",
+      "errorGeneric": "Une erreur est survenue (erreur {status}). Réessayez bientôt.",
+      "errorNetwork": "Aucune connexion au serveur. Vérifiez votre réseau et réessayez.",
+      "retry": "Réessayer"
     }
   }
 }

--- a/apps/web/messages/it/settings.json
+++ b/apps/web/messages/it/settings.json
@@ -1307,7 +1307,13 @@
       "step3": "Il robot parte già personalizzato con il profilo di tuo figlio.",
       "noRobotYet": "Non hai ancora un robot?",
       "buyCta": "Acquista un Reachy Mini",
-      "buyNote": "Reachy Mini Lite da circa 299 $, versione Wireless da circa 449 $, su reachy-mini.org."
+      "buyNote": "Reachy Mini Lite da circa 299 $, versione Wireless da circa 449 $, su reachy-mini.org.",
+      "errorTitle": "Non sono riuscito a generare il codice",
+      "errorAuth": "La sessione è scaduta: rientra e riprova.",
+      "errorRateLimit": "Troppi codici generati. Riprova tra un'ora.",
+      "errorGeneric": "Qualcosa è andato storto (errore {status}). Riprova tra poco.",
+      "errorNetwork": "Nessuna connessione al server. Controlla la rete e riprova.",
+      "retry": "Riprova"
     }
   }
 }

--- a/apps/web/src/components/settings/sections/robot-pairing-card.test.tsx
+++ b/apps/web/src/components/settings/sections/robot-pairing-card.test.tsx
@@ -3,23 +3,23 @@
  * Covers the explainer/buy affordances (visible to everyone, even without a
  * robot) and the pairing-code generation flow.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import { userEvent } from "@testing-library/user-event";
-import { RobotPairingCard } from "./robot-pairing-card";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { RobotPairingCard } from './robot-pairing-card';
 
-vi.mock("next-intl", () => ({
+vi.mock('next-intl', () => ({
   // Identity translator: assert against the raw keys.
   useTranslations: () => (key: string) => key,
 }));
 
 const csrfFetch = vi.fn();
-vi.mock("@/lib/auth", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/auth")>();
+vi.mock('@/lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth')>();
   return { ...actual, csrfFetch: (...args: unknown[]) => csrfFetch(...args) };
 });
 
-vi.mock("@/lib/logger/client", () => ({
+vi.mock('@/lib/logger/client', () => ({
   clientLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
@@ -31,55 +31,98 @@ beforeEach(() => {
   }) as unknown as typeof fetch;
 });
 
-describe("RobotPairingCard", () => {
-  it("explains what the robot is and lists its features to everyone", async () => {
+describe('RobotPairingCard', () => {
+  it('explains what the robot is and lists its features to everyone', async () => {
     render(<RobotPairingCard />);
 
-    expect(screen.getByText("whatIsTitle")).toBeInTheDocument();
-    expect(screen.getByText("whatIsBody")).toBeInTheDocument();
+    expect(screen.getByText('whatIsTitle')).toBeInTheDocument();
+    expect(screen.getByText('whatIsBody')).toBeInTheDocument();
     for (const key of [
-      "featureEyes",
-      "featureVoice",
-      "featureCamera",
-      "featureMovement",
-      "featureStop",
+      'featureEyes',
+      'featureVoice',
+      'featureCamera',
+      'featureMovement',
+      'featureStop',
     ]) {
       expect(screen.getByText(key)).toBeInTheDocument();
     }
-    await waitFor(() =>
-      expect(screen.getByText("noRobots")).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('noRobots')).toBeInTheDocument());
   });
 
-  it("offers a safe external buy link for people without a robot", () => {
+  it('offers a safe external buy link for people without a robot', () => {
     render(<RobotPairingCard />);
 
-    const buy = screen.getByRole("link", { name: /buyCta/ });
-    expect(buy).toHaveAttribute("href", "https://www.reachy-mini.org/buy.html");
-    expect(buy).toHaveAttribute?.("target", "_blank");
-    expect(buy).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    const buy = screen.getByRole('link', { name: /buyCta/ });
+    expect(buy).toHaveAttribute('href', 'https://www.reachy-mini.org/buy.html');
+    expect(buy).toHaveAttribute?.('target', '_blank');
+    expect(buy).toHaveAttribute('rel', expect.stringContaining('noopener'));
   });
 
-  it("shows the three connection steps", () => {
+  it('shows the three connection steps', () => {
     render(<RobotPairingCard />);
-    expect(screen.getByText("step1")).toBeInTheDocument();
-    expect(screen.getByText("step2")).toBeInTheDocument();
-    expect(screen.getByText("step3")).toBeInTheDocument();
+    expect(screen.getByText('step1')).toBeInTheDocument();
+    expect(screen.getByText('step2')).toBeInTheDocument();
+    expect(screen.getByText('step3')).toBeInTheDocument();
   });
 
-  it("generates a pairing code on demand", async () => {
+  it('generates a pairing code on demand', async () => {
     csrfFetch.mockResolvedValue({
       ok: true,
-      json: async () => ({ code: "123456", expiresAt: new Date().toISOString() }),
+      json: async () => ({ code: '123456', expiresAt: new Date().toISOString() }),
     });
     render(<RobotPairingCard />);
 
-    await userEvent.click(screen.getByText("generateCode"));
+    await userEvent.click(screen.getByText('generateCode'));
 
-    await waitFor(() => expect(screen.getByText("123456")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('123456')).toBeInTheDocument());
     expect(csrfFetch).toHaveBeenCalledWith(
-      "/api/devices/pair-code",
-      expect.objectContaining({ method: "POST" }),
+      '/api/devices/pair-code',
+      expect.objectContaining({ method: 'POST' }),
     );
+  });
+
+  it('tells the parent why the code could not be generated (rate limited)', async () => {
+    csrfFetch.mockResolvedValue({ ok: false, status: 429, json: async () => ({}) });
+    render(<RobotPairingCard />);
+
+    await userEvent.click(screen.getByText('generateCode'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('errorRateLimit');
+  });
+
+  it('asks the parent to sign in again when the session is gone', async () => {
+    csrfFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({}) });
+    render(<RobotPairingCard />);
+
+    await userEvent.click(screen.getByText('generateCode'));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('errorAuth');
+  });
+
+  it('reports a network failure instead of failing silently', async () => {
+    csrfFetch.mockRejectedValue(new Error('offline'));
+    render(<RobotPairingCard />);
+
+    await userEvent.click(screen.getByText('generateCode'));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('errorNetwork');
+  });
+
+  it('clears a previous error once a code is generated', async () => {
+    csrfFetch.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+    render(<RobotPairingCard />);
+
+    await userEvent.click(screen.getByText('generateCode'));
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+
+    csrfFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ code: '654321', expiresAt: new Date().toISOString() }),
+    });
+    await userEvent.click(screen.getByText('generateCode'));
+
+    await waitFor(() => expect(screen.getByText('654321')).toBeInTheDocument());
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/settings/sections/robot-pairing-card.tsx
+++ b/apps/web/src/components/settings/sections/robot-pairing-card.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 /**
  * RobotPairingCard — Settings › Integrations
@@ -9,27 +9,14 @@
  * redeeming the code. Serves the "MirrorBuddy with a body" flow.
  */
 
-import { useState, useEffect, useCallback } from "react";
-import { useTranslations } from "next-intl";
-import {
-  Bot,
-  Loader2,
-  Trash2,
-  KeyRound,
-  Copy,
-  Check,
-} from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { csrfFetch } from "@/lib/auth";
-import { clientLogger as logger } from "@/lib/logger/client";
-import { RobotPairingExplainer } from "./robot-pairing-explainer";
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import { Bot, Loader2, Trash2, KeyRound, Copy, Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { csrfFetch } from '@/lib/auth';
+import { clientLogger as logger } from '@/lib/logger/client';
+import { RobotPairingExplainer } from './robot-pairing-explainer';
 
 interface DeviceSummary {
   id: string;
@@ -45,22 +32,23 @@ interface PairCode {
 }
 
 export function RobotPairingCard() {
-  const t = useTranslations("settings.robotPairing");
+  const t = useTranslations('settings.robotPairing');
   const [devices, setDevices] = useState<DeviceSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
   const [code, setCode] = useState<PairCode | null>(null);
   const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
-      const res = await fetch("/api/devices", { credentials: "include" });
+      const res = await fetch('/api/devices', { credentials: 'include' });
       if (res.ok) {
         const data = await res.json();
         setDevices(data.devices ?? []);
       }
     } catch (error) {
-      logger.error("Failed to load robots", { error: String(error) });
+      logger.error('Failed to load robots', { error: String(error) });
     } finally {
       setLoading(false);
     }
@@ -73,30 +61,40 @@ export function RobotPairingCard() {
   const generate = useCallback(async () => {
     setGenerating(true);
     setCode(null);
+    setError(null);
     try {
-      const res = await csrfFetch("/api/devices/pair-code", {
-        method: "POST",
+      const res = await csrfFetch('/api/devices/pair-code', {
+        method: 'POST',
         body: JSON.stringify({}),
       });
-      if (res.ok) setCode(await res.json());
+      if (res.ok) {
+        setCode(await res.json());
+        return;
+      }
+      logger.error('Pairing code request rejected', { status: res.status });
+      if (res.status === 401 || res.status === 403) {
+        setError(t('errorAuth'));
+      } else if (res.status === 429) {
+        setError(t('errorRateLimit'));
+      } else {
+        setError(t('errorGeneric', { status: res.status }));
+      }
     } catch (error) {
-      logger.error("Failed to generate pairing code", { error: String(error) });
+      logger.error('Failed to generate pairing code', { error: String(error) });
+      setError(t('errorNetwork'));
     } finally {
       setGenerating(false);
     }
-  }, []);
+  }, [t]);
 
-  const revoke = useCallback(
-    async (id: string) => {
-      try {
-        const res = await csrfFetch(`/api/devices/${id}`, { method: "DELETE" });
-        if (res.ok) setDevices((d) => d.filter((x) => x.id !== id));
-      } catch (error) {
-        logger.error("Failed to revoke robot", { error: String(error) });
-      }
-    },
-    [],
-  );
+  const revoke = useCallback(async (id: string) => {
+    try {
+      const res = await csrfFetch(`/api/devices/${id}`, { method: 'DELETE' });
+      if (res.ok) setDevices((d) => d.filter((x) => x.id !== id));
+    } catch (error) {
+      logger.error('Failed to revoke robot', { error: String(error) });
+    }
+  }, []);
 
   const copyCode = useCallback(async () => {
     if (!code) return;
@@ -114,21 +112,21 @@ export function RobotPairingCard() {
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Bot className="w-5 h-5" />
-          {t("title")}
+          {t('title')}
         </CardTitle>
-        <CardDescription>{t("description")}</CardDescription>
+        <CardDescription>{t('description')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
         <RobotPairingExplainer />
 
         <section className="space-y-3" aria-labelledby="robot-howto">
           <h4 id="robot-howto" className="text-sm font-semibold">
-            {t("howItWorksTitle")}
+            {t('howItWorksTitle')}
           </h4>
           <ol className="list-decimal list-inside space-y-1 text-sm text-muted-foreground">
-            <li>{t("step1")}</li>
-            <li>{t("step2")}</li>
-            <li>{t("step3")}</li>
+            <li>{t('step1')}</li>
+            <li>{t('step2')}</li>
+            <li>{t('step3')}</li>
           </ol>
           <Button onClick={generate} disabled={generating}>
             {generating ? (
@@ -136,43 +134,44 @@ export function RobotPairingCard() {
             ) : (
               <KeyRound className="w-4 h-4 mr-2" />
             )}
-            {t("generateCode")}
+            {t('generateCode')}
           </Button>
         </section>
 
+        {error && (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-500/40 bg-red-500/5 p-4 space-y-1"
+          >
+            <p className="text-sm font-semibold text-red-700 dark:text-red-300">
+              {t('errorTitle')}
+            </p>
+            <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+          </div>
+        )}
+
         {code && (
           <div className="rounded-lg border border-accent-themed/40 bg-accent-themed/5 p-4 space-y-2">
-            <p className="text-sm text-muted-foreground">{t("codeHint")}</p>
+            <p className="text-sm text-muted-foreground">{t('codeHint')}</p>
             <div className="flex items-center gap-3">
-              <span className="text-3xl font-mono font-bold tracking-[0.3em]">
-                {code.code}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={copyCode}
-                aria-label={t("copy")}
-              >
-                {copied ? (
-                  <Check className="w-4 h-4" />
-                ) : (
-                  <Copy className="w-4 h-4" />
-                )}
+              <span className="text-3xl font-mono font-bold tracking-[0.3em]">{code.code}</span>
+              <Button variant="outline" size="sm" onClick={copyCode} aria-label={t('copy')}>
+                {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
               </Button>
             </div>
-            <p className="text-xs text-muted-foreground">{t("codeExpires")}</p>
+            <p className="text-xs text-muted-foreground">{t('codeExpires')}</p>
           </div>
         )}
 
         <div className="space-y-2">
-          <h4 className="text-sm font-medium">{t("pairedRobots")}</h4>
+          <h4 className="text-sm font-medium">{t('pairedRobots')}</h4>
           {loading ? (
             <div className="flex items-center gap-2 text-muted-foreground">
               <Loader2 className="w-4 h-4 animate-spin" />
-              <span>{t("loading")}</span>
+              <span>{t('loading')}</span>
             </div>
           ) : devices.length === 0 ? (
-            <p className="text-sm text-muted-foreground">{t("noRobots")}</p>
+            <p className="text-sm text-muted-foreground">{t('noRobots')}</p>
           ) : (
             <ul className="space-y-2">
               {devices.map((d) => (
@@ -181,22 +180,20 @@ export function RobotPairingCard() {
                   className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-700 p-3"
                 >
                   <div>
-                    <p className="text-sm font-medium">
-                      {d.label || t("unnamedRobot")}
-                    </p>
+                    <p className="text-sm font-medium">{d.label || t('unnamedRobot')}</p>
                     <p className="text-xs text-muted-foreground">
                       {d.pairedAt
-                        ? t("pairedOn", {
+                        ? t('pairedOn', {
                             date: new Date(d.pairedAt).toLocaleDateString(),
                           })
-                        : t("pendingPairing")}
+                        : t('pendingPairing')}
                     </p>
                   </div>
                   <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => revoke(d.id)}
-                    aria-label={t("unpair")}
+                    aria-label={t('unpair')}
                   >
                     <Trash2 className="w-4 h-4 text-red-500" />
                   </Button>
@@ -206,7 +203,7 @@ export function RobotPairingCard() {
           )}
         </div>
 
-        <p className="text-xs text-muted-foreground">{t("privacyNote")}</p>
+        <p className="text-xs text-muted-foreground">{t('privacyNote')}</p>
       </CardContent>
     </Card>
   );

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -22,6 +22,7 @@ from .config import config
 from .controller import Controller
 from .mirrorbuddy_client import MirrorBuddyClient, neutral_buddy
 from .movements import Movements, temperament_for
+from .startup import wait_for_config
 
 logger = logging.getLogger(__name__)
 
@@ -71,13 +72,16 @@ def run(
             logger.warning("Failed to mount settings UI: %s", e)
 
     # Wait for required configuration (Azure creds) if a settings UI is available.
+    # The wait MUST stay interruptible: the daemon asks the app to stop by setting
+    # app_stop_event, and an app that ignores it hangs in "stopping" forever — which
+    # then blocks every other app on the robot from starting.
     missing = config.missing()
     if missing:
         if settings_app is not None:
             logger.info("Waiting for configuration via settings UI: %s", ", ".join(missing))
-            while config.missing():
-                time.sleep(0.5)
-                config.reload()
+            if not wait_for_config(config, app_stop_event):
+                logger.info("Stop requested while waiting for configuration; exiting.")
+                return
         else:
             logger.error("Missing required configuration: %s", ", ".join(missing))
             sys.exit(1)

--- a/robot/reachy_mini_mirrorbuddy/startup.py
+++ b/robot/reachy_mini_mirrorbuddy/startup.py
@@ -1,0 +1,39 @@
+"""Startup helpers that must stay importable without the robot SDK.
+
+Kept separate from ``main`` so the logic can be unit-tested on a laptop (``main``
+pulls in the Reachy Mini SDK, sounddevice and scipy, none of which exist there).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Protocol
+
+
+class _ConfigLike(Protocol):
+    def missing(self) -> list[str]: ...
+    def reload(self) -> None: ...
+
+
+def wait_for_config(
+    config: _ConfigLike,
+    app_stop_event: threading.Event | None,
+    poll_interval: float = 0.5,
+) -> bool:
+    """Park until the required configuration appears on the settings page.
+
+    Returns False if the daemon asked the app to stop while waiting. The wait MUST
+    stay interruptible: an app that ignores ``app_stop_event`` hangs the daemon in
+    "stopping" forever, which then blocks every other app on the robot from starting.
+    """
+    while config.missing():
+        if app_stop_event is not None and app_stop_event.is_set():
+            return False
+        if app_stop_event is not None:
+            # Wake immediately on stop instead of sleeping through it.
+            app_stop_event.wait(poll_interval)
+        else:
+            time.sleep(poll_interval)
+        config.reload()
+    return True

--- a/robot/tests/test_wait_for_config.py
+++ b/robot/tests/test_wait_for_config.py
@@ -1,0 +1,73 @@
+"""Tests for the interruptible "waiting for credentials" loop.
+
+When the Azure credentials are missing, the app parks itself until someone types
+them on the settings page. That wait must still honour the daemon's stop request:
+an app that ignores it stays in "stopping" forever and blocks every other app on
+the robot from starting (observed on a real Reachy Mini).
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reachy_mini_mirrorbuddy.startup import wait_for_config  # noqa: E402
+
+
+class _FakeConfig:
+    """Config stub whose `missing()` answer is driven by the test."""
+
+    def __init__(self, missing: list[str]) -> None:
+        self._missing = missing
+        self.reloads = 0
+
+    def missing(self) -> list[str]:
+        return self._missing
+
+    def reload(self) -> None:
+        self.reloads += 1
+
+
+def test_returns_immediately_when_config_is_already_present():
+    assert wait_for_config(_FakeConfig([]), threading.Event()) is True
+
+
+def test_stops_waiting_when_the_daemon_asks_the_app_to_stop():
+    cfg = _FakeConfig(["AZURE_OPENAI_REALTIME_API_KEY"])
+    stop = threading.Event()
+    result: list[bool] = []
+
+    worker = threading.Thread(
+        target=lambda: result.append(wait_for_config(cfg, stop, poll_interval=0.05))
+    )
+    worker.start()
+    time.sleep(0.15)
+    assert worker.is_alive(), "the app should park while credentials are missing"
+
+    stop.set()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive(), "the wait must unblock as soon as a stop is requested"
+    assert result == [False]
+
+
+def test_proceeds_once_the_credentials_are_entered():
+    cfg = _FakeConfig(["AZURE_OPENAI_REALTIME_API_KEY"])
+    stop = threading.Event()
+    result: list[bool] = []
+
+    worker = threading.Thread(
+        target=lambda: result.append(wait_for_config(cfg, stop, poll_interval=0.05))
+    )
+    worker.start()
+    time.sleep(0.15)
+
+    cfg._missing = []  # the parent typed the Azure credentials on the settings page
+    worker.join(timeout=2)
+
+    assert result == [True]
+    assert cfg.reloads > 0, "the loop must re-read the instance .env while waiting"


### PR DESCRIPTION
## Problema

Due bug trovati mentre si diagnosticava "il robot non parte / l'app non genera il codice", sul robot reale (Reachy Mini, daemon 1.9.0).

### 1. Il robot si blocca in `stopping` per sempre
Senza credenziali Azure l'app parcheggia in attesa che qualcuno le digiti sulla pagina impostazioni. Quel `while` **non guardava mai `app_stop_event`**: quando il daemon chiede lo stop, l'app non esce.

Effetto osservato sul robot: stato `stopping` permanente, `start-app` → 400 "An app is already running", `stop-current-app` → 400 "No app is currently running". Ogni altra app (`reachy_mini_giocone`, `reachy_mini_conversation_app`) non parte più. Serve un power cycle.

Fix: `startup.wait_for_config()` — importabile senza SDK, quindi testabile — esce con `False` appena arriva lo stop.

### 2. "Genera codice di collegamento" falliva in silenzio
`robot-pairing-card.tsx` faceva `if (res.ok) setCode(...)`: 401, 429 o 500 producevano lo stesso nulla di un click a vuoto, quindi nessun modo di sapere perché. Ora un `role="alert"` con la causa (sessione scaduta / troppi codici / errore N / rete), in 5 lingue.

Il backend è sano: riprodotto in locale end-to-end (login → `/api/devices/pair-code` → `200 {"code":"666981"}`).

## Verifica

- `pytest robot/tests/` → 36 passed
- Prova di mutazione robot: togliendo il controllo su `app_stop_event` il test **si pianta all'infinito**, esattamente come in produzione
- `npm run test:unit -- robot-pairing-card` → 8 passed; mutando il render dell'errore 4 falliscono
- `npm run i18n:check` → PASS (7813 chiavi × 5 locali)
- typecheck + build PASS