### PR TITLE
fix(robot): settings that actually save, an audible voice, the right professor

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -89,6 +89,20 @@ jobs:
           fi
           echo "✅ Staging is healthy (HTTP $status)"
 
+      - name: Verify database schema is up to date
+        env:
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+        run: |
+          # The "generate pairing code" button returned 500 for weeks because the
+          # RobotDevice table had never been created in production: the code shipped,
+          # the migration did not, and nothing said so. Promotion is the last moment
+          # where that is still cheap to catch.
+          if [ -z "$DIRECT_URL" ]; then
+            echo "::error::DIRECT_URL secret is not set — cannot verify schema drift"
+            exit 1
+          fi
+          pnpm dlx tsx scripts/check-migrations-applied.ts
+
       - name: Promote to Production
         id: promote
         run: |

--- a/apps/web/src/app/api/coaches/route.ts
+++ b/apps/web/src/app/api/coaches/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { pipe, withSentry } from '@/lib/api/middlewares';
+import { getAllSupportTeachers } from '@/data/support-teachers';
+import { getOrCompute, CACHE_TTL } from '@/lib/cache';
+
+export const revalidate = 0;
+const VALID_LOCALES = ['it', 'en', 'fr', 'de', 'es'];
+
+/**
+ * GET /api/coaches?locale=it
+ *
+ * The learning coaches (Melissa, Roberto, Chiara, Andrea, Favij, Laura) were only
+ * reachable through the chat internals, so surfaces outside the web app — the
+ * Reachy Mini robot in particular — could not offer them at all. This mirrors the
+ * shape of /api/maestri so a client can consume both rosters identically.
+ */
+export const GET = pipe(withSentry('/api/coaches'))(async (ctx) => {
+  const requested = ctx.req.nextUrl.searchParams.get('locale') || 'it';
+  const lang = VALID_LOCALES.includes(requested) ? requested : 'it';
+
+  const result = await getOrCompute(
+    `coaches:list:${lang}`,
+    () =>
+      getAllSupportTeachers().map((c) => ({
+        id: c.id,
+        name: c.name,
+        displayName: c.name,
+        // Clients group by subject; coaches teach method, not a school subject.
+        subject: 'coaching',
+        specialty: c.personality,
+        role: c.role,
+        voice: c.voice,
+        voiceInstructions: c.voiceInstructions,
+        teachingStyle: c.personality,
+        systemPrompt: c.systemPrompt,
+        greeting: c.greeting,
+        avatar: c.avatar,
+        color: c.color,
+      })),
+    { ttl: CACHE_TTL.MAESTRI },
+  );
+
+  return NextResponse.json(result, {
+    headers: { 'Cache-Control': 'public, max-age=3600, s-maxage=3600' },
+  });
+});

--- a/apps/web/src/components/settings/sections/robot-pairing-card.test.tsx
+++ b/apps/web/src/components/settings/sections/robot-pairing-card.test.tsx
@@ -3,8 +3,8 @@
  * Covers the explainer/buy affordances (visible to everyone, even without a
  * robot) and the pairing-code generation flow.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { RobotPairingCard } from './robot-pairing-card';
 
@@ -124,5 +124,118 @@ describe('RobotPairingCard', () => {
 
     await waitFor(() => expect(screen.getByText('654321')).toBeInTheDocument());
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Regression: a parent generated a code, typed it on the robot, the robot paired —
+ * and this page kept saying "no robot connected", because the device list was read
+ * once at mount and nothing ever told the browser the pairing had happened.
+ */
+describe('RobotPairingCard — noticing that the robot paired', () => {
+  const robot = (id: string) => ({
+    id,
+    label: 'Reachy Mini',
+    pairedAt: new Date().toISOString(),
+    lastSeenAt: null,
+    createdAt: new Date().toISOString(),
+  });
+
+  /** Devices currently returned by /api/devices; mutate mid-test to simulate pairing. */
+  let listed: ReturnType<typeof robot>[] = [];
+
+  const tick = async (ms: number) => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+  };
+
+  const renderCard = async () => {
+    await act(async () => {
+      render(<RobotPairingCard />);
+    });
+  };
+
+  const clickGenerate = async () => {
+    fireEvent.click(screen.getByText('generateCode'));
+    await tick(0);
+  };
+
+  const setup = (initial: ReturnType<typeof robot>[] = []) => {
+    listed = initial;
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({ devices: listed }),
+    })) as unknown as typeof fetch;
+    vi.useFakeTimers();
+  };
+
+  const issueCode = (code: string, ttlMs = 10 * 60 * 1000) =>
+    csrfFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ code, expiresAt: new Date(Date.now() + ttlMs).toISOString() }),
+    });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the robot as soon as it pairs, with no page reload', async () => {
+    setup();
+    issueCode('123456');
+    await renderCard();
+
+    await clickGenerate();
+    expect(screen.getByText('123456')).toBeInTheDocument();
+
+    listed = [robot('dev-1')]; // the robot redeems the code
+
+    await tick(3500);
+    expect(screen.queryByText('noRobots')).not.toBeInTheDocument();
+    expect(screen.getByText('Reachy Mini')).toBeInTheDocument();
+  });
+
+  it('puts the code away once it has been used', async () => {
+    setup();
+    issueCode('123456');
+    await renderCard();
+
+    await clickGenerate();
+    listed = [robot('dev-1')];
+
+    await tick(3500);
+    expect(screen.queryByText('123456')).not.toBeInTheDocument();
+  });
+
+  it('keeps showing the code when the only robot listed is one paired earlier', async () => {
+    setup([robot('old-robot')]);
+    issueCode('654321');
+    await renderCard();
+
+    await clickGenerate();
+
+    await tick(9000); // three polls, no new robot
+    expect(screen.getByText('654321')).toBeInTheDocument();
+  });
+
+  it('drops an expired code instead of leaving a dead number on screen', async () => {
+    setup();
+    issueCode('111222', 5000);
+    await renderCard();
+
+    await clickGenerate();
+    expect(screen.getByText('111222')).toBeInTheDocument();
+
+    await tick(7000);
+    expect(screen.queryByText('111222')).not.toBeInTheDocument();
+  });
+
+  it('does not poll the server while no code is outstanding', async () => {
+    setup();
+    await renderCard();
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    await tick(30_000);
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(calls);
   });
 });

--- a/apps/web/src/components/settings/sections/robot-pairing-card.tsx
+++ b/apps/web/src/components/settings/sections/robot-pairing-card.tsx
@@ -9,7 +9,7 @@
  * redeeming the code. Serves the "MirrorBuddy with a body" flow.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 import { Bot, Loader2, Trash2, KeyRound, Copy, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -31,6 +31,10 @@ interface PairCode {
   expiresAt: string;
 }
 
+// A parent types the code on the robot and looks back at the screen: a few seconds
+// is the window in which "did it work?" is still an open question.
+const PAIRING_POLL_MS = 3000;
+
 export function RobotPairingCard() {
   const t = useTranslations('settings.robotPairing');
   const [devices, setDevices] = useState<DeviceSummary[]>([]);
@@ -39,6 +43,7 @@ export function RobotPairingCard() {
   const [code, setCode] = useState<PairCode | null>(null);
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const knownDeviceIds = useRef<Set<string>>(new Set());
 
   const load = useCallback(async () => {
     try {
@@ -58,10 +63,36 @@ export function RobotPairingCard() {
     void load();
   }, [load]);
 
+  // While a code is outstanding the robot is about to pair, and nothing pushes that
+  // event to the browser: the list was read once at mount, so the page kept saying
+  // "no robot connected" long after the robot was, in fact, connected. Poll until
+  // the pairing lands or the code expires.
+  useEffect(() => {
+    if (!code) return;
+    const expiresAt = new Date(code.expiresAt).getTime();
+    const timer = setInterval(() => {
+      if (Date.now() >= expiresAt) {
+        setCode(null);
+        return;
+      }
+      void load();
+    }, PAIRING_POLL_MS);
+    return () => clearInterval(timer);
+  }, [code, load]);
+
+  // The robot appeared: the code has served its purpose, so stop showing it. Compare
+  // against the robots known when the code was issued — a household with a robot
+  // already paired must still see the code until the *new* one shows up.
+  useEffect(() => {
+    if (!code) return;
+    if (devices.some((d) => !knownDeviceIds.current.has(d.id))) setCode(null);
+  }, [devices, code]);
+
   const generate = useCallback(async () => {
     setGenerating(true);
     setCode(null);
     setError(null);
+    knownDeviceIds.current = new Set(devices.map((d) => d.id));
     try {
       const res = await csrfFetch('/api/devices/pair-code', {
         method: 'POST',
@@ -85,7 +116,7 @@ export function RobotPairingCard() {
     } finally {
       setGenerating(false);
     }
-  }, [t]);
+  }, [t, devices]);
 
   const revoke = useCallback(async (id: string) => {
     try {

--- a/apps/web/src/lib/db/__tests__/pii-middleware-read.test.ts
+++ b/apps/web/src/lib/db/__tests__/pii-middleware-read.test.ts
@@ -366,3 +366,69 @@ describe('Error Handling', () => {
     expect(result.email).toBe('[decryption-failed]');
   });
 });
+
+/**
+ * Regression: the robot asked "who am I tutoring?" via RobotDevice.findUnique with
+ * the child's profile included, and got back `pii:v1:...` instead of "Mario" —
+ * so it greeted him by an invented name. RobotDevice itself holds no PII, and the
+ * decryptor gave up before it ever looked at the relations it was carrying.
+ */
+describe('PII decryption reaches nested relations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const deviceWithChild = () =>
+    vi.fn(() =>
+      Promise.resolve({
+        id: 'device1',
+        tokenHash: 'abc',
+        user: {
+          id: 'user1',
+          email: 'pii:v1:encrypted_parent@example.com',
+          profile: { id: 'p1', name: 'pii:v1:encrypted_Mario', preferredCoach: 'andrea' },
+        },
+      }),
+    );
+
+  it('decrypts a nested profile even when the root model has no PII of its own', async () => {
+    const middleware = createPIIMiddleware() as any;
+
+    const result = await middleware.query.$allModels.findUnique({
+      model: 'RobotDevice',
+      operation: 'findUnique',
+      args: { where: { tokenHash: 'abc' } },
+      query: deviceWithChild(),
+    });
+
+    expect(result.user.profile.name).toBe('Mario');
+    expect(result.user.email).toBe('parent@example.com');
+  });
+
+  it('leaves non-PII fields of the nested record untouched', async () => {
+    const middleware = createPIIMiddleware() as any;
+
+    const result = await middleware.query.$allModels.findUnique({
+      model: 'RobotDevice',
+      operation: 'findUnique',
+      args: { where: { tokenHash: 'abc' } },
+      query: deviceWithChild(),
+    });
+
+    expect(result.user.profile.preferredCoach).toBe('andrea');
+    expect(result.id).toBe('device1');
+  });
+
+  it('handles a PII-free root with no relations at all', async () => {
+    const middleware = createPIIMiddleware() as any;
+
+    const result = await middleware.query.$allModels.findMany({
+      model: 'RobotDevice',
+      operation: 'findMany',
+      args: {},
+      query: vi.fn(() => Promise.resolve([{ id: 'device1' }, { id: 'device2' }])),
+    });
+
+    expect(result).toEqual([{ id: 'device1' }, { id: 'device2' }]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "sim:nightly": "npx tsx scripts/nightly-sim-runner.ts",
     "sim:quick": "npx tsx scripts/nightly-sim-runner.ts --models 3b --dry-run",
     "vercel-build": "prisma generate && prisma migrate deploy && npm run build && npm run seed:admin || echo 'Admin seed skipped'",
-    "production:status": "./scripts/production-status.sh"
+    "production:status": "./scripts/production-status.sh",
+    "db:check-migrations": "tsx scripts/check-migrations-applied.ts"
   },
   "overrides": {
     "hono": "4.12.25",

--- a/packages/db/src/pii-middleware.ts
+++ b/packages/db/src/pii-middleware.ts
@@ -123,11 +123,15 @@ export async function encryptPIIFields(
  * Failed fields get a placeholder value instead of crashing the entire query.
  */
 export async function decryptPIIFields(model: string, result: unknown): Promise<unknown> {
-  if (!result || !hasPIIFields(model)) {
+  if (!result) {
     return result;
   }
 
-  const piiFields = PII_FIELD_MAP[model];
+  // A model with no PII of its own can still be *carrying* someone's PII in an
+  // included relation — RobotDevice.findUnique({ include: { user: { profile } } })
+  // handed the robot an encrypted name, so it greeted the child by an invented one.
+  // Walk on, with an empty field list.
+  const piiFields = PII_FIELD_MAP[model] ?? [];
 
   // Handle array of results
   if (Array.isArray(result)) {

--- a/robot/publish-space.sh
+++ b/robot/publish-space.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Publish MirrorBuddy to the Reachy Mini app store.
+#
+# The store is simply Hugging Face Spaces tagged `reachy_mini` +
+# `reachy_mini_python_app`: the robot's daemon lists them and installs the Python
+# package straight from the Space. So publishing means assembling a Space that is
+# the package plus a landing page, and pushing it.
+#
+# This is a script rather than a one-off command so the next release is a rerun,
+# not an archaeology exercise.
+#
+# Usage:  ./publish-space.sh [hf-user/space-name]
+# Needs:  hf auth login   (a write or fine-grained token with Spaces access)
+
+set -euo pipefail
+
+SPACE="${1:-Roberdan/mirrorbuddy}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "→ Staging the Space in $STAGE"
+cp -R "$HERE/reachy_mini_mirrorbuddy" "$STAGE/"
+cp "$HERE/pyproject.toml" "$STAGE/"
+cp "$HERE/space/index.html" "$STAGE/"
+cp "$HERE/space/style.css" "$STAGE/"
+
+# The published package must never carry the robot's local secrets or caches.
+rm -rf "$STAGE/reachy_mini_mirrorbuddy/__pycache__" "$STAGE/reachy_mini_mirrorbuddy/.env"
+if find "$STAGE" -name '.env' -o -name '*.key' | grep -q .; then
+  echo "✗ Refusing to publish: secret-looking files found in the staged Space" >&2
+  exit 1
+fi
+
+# The Space README carries the store front-matter (title, tags, description).
+# It lives beside this script so it stays reviewable in git.
+cp "$HERE/space/README.md" "$STAGE/README.md"
+
+# Push over git rather than `hf upload`: the CLI re-runs repo creation on every
+# upload, which fails with 402 on a free account even when the Space already exists.
+echo "→ Pushing to https://huggingface.co/spaces/$SPACE"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$STAGE" "$WORK"' EXIT
+git clone -q "https://huggingface.co/spaces/$SPACE" "$WORK/repo"
+cd "$WORK/repo"
+# Mirror the staged tree exactly, so a file removed here disappears from the store.
+find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+cp -R "$STAGE"/. .
+git add -A
+if git diff --cached --quiet; then
+  echo "✓ Nothing to publish — the Space already matches this working tree."
+  exit 0
+fi
+git commit -q -m "Publish MirrorBuddy for Reachy Mini"
+git push -q origin HEAD
+
+echo "✓ Published: https://huggingface.co/spaces/$SPACE"
+echo "  It appears in the robot's app store under the reachy_mini tag."

--- a/robot/reachy_mini_mirrorbuddy/audio_dsp.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_dsp.py
@@ -1,0 +1,68 @@
+"""Signal-level helpers for the robot's audio path.
+
+Kept apart from :mod:`audio_io` because these are pure functions over samples —
+no devices, no threads, no state — which makes them the part worth testing on a
+laptop, and keeps the device bridge readable.
+
+Barge-in tuning lives here too: the Reachy Mini mic array is echo-cancelled in
+hardware, so energy on the mic *while Buddy is speaking* means a real nearby
+voice, not the robot hearing itself. That is what lets playback stop the instant
+the child speaks rather than waiting ~200-400ms for the server to notice.
+"""
+
+from __future__ import annotations
+
+import os
+from math import gcd
+
+import numpy as np
+from scipy.signal import resample_poly
+
+_DEFAULT_BARGE_RMS_THRESHOLD = 0.045  # normalised 0..1
+_DEFAULT_BARGE_SUSTAIN_FRAMES = 3  # consecutive loud frames
+
+
+def barge_rms_threshold() -> float:
+    """Read the barge-in RMS threshold from the env at call time.
+
+    Read lazily (not at import) so values saved in the robot's ``.env`` — which
+    ``main.run()`` loads *after* this module is imported — take effect.
+    """
+    try:
+        return float(os.getenv("MIRRORBUDDY_BARGE_RMS", _DEFAULT_BARGE_RMS_THRESHOLD))
+    except (TypeError, ValueError):
+        return _DEFAULT_BARGE_RMS_THRESHOLD
+
+
+def barge_sustain_frames() -> int:
+    """Read the barge-in sustain-frame count from the env at call time."""
+    try:
+        return max(1, int(os.getenv("MIRRORBUDDY_BARGE_FRAMES", _DEFAULT_BARGE_SUSTAIN_FRAMES)))
+    except (TypeError, ValueError):
+        return _DEFAULT_BARGE_SUSTAIN_FRAMES
+
+
+def boost(audio: np.ndarray, gain: float) -> np.ndarray:
+    """Raise the voice level by compressing the peaks instead of clipping them.
+
+    The robot speaker is already near its hardware maximum, so the only headroom
+    left is here. Plain multiplication would slam the peaks against ±1.0 and the
+    voice would rasp — unpleasant, and for a child with an auditory processing
+    difficulty, unusable.
+
+    ``tanh`` is the valve curve: below the knee it is almost linear, above it it
+    bends gently. On speech — few peaks, plenty of body — it sounds markedly louder
+    without turning harsh.
+    """
+    # 0.85 keeps the linear part below the knee of the curve.
+    return np.tanh(audio * gain * 0.85).astype(np.float32)
+
+
+def resample(audio: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
+    """Low-latency polyphase resampling (faster + cleaner than FFT resample)."""
+    if src_rate == dst_rate or audio.size == 0:
+        return audio
+    g = gcd(src_rate, dst_rate)
+    up = dst_rate // g
+    down = src_rate // g
+    return resample_poly(audio, up, down)

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -54,6 +54,22 @@ def _barge_sustain_frames() -> int:
         return _DEFAULT_BARGE_SUSTAIN_FRAMES
 
 
+def _boost(audio: np.ndarray, gain: float) -> np.ndarray:
+    """Raise the voice level by compressing the peaks instead of clipping them.
+
+    The robot speaker is already near its hardware maximum, so the only headroom
+    left is here. Plain multiplication would slam the peaks against ±1.0 and the
+    voice would rasp — unpleasant, and for a child with an auditory processing
+    difficulty, unusable.
+
+    ``tanh`` is the valve curve: below the knee it is almost linear, above it it
+    bends gently. On speech — few peaks, plenty of body — it sounds markedly louder
+    without turning harsh.
+    """
+    # 0.85 keeps the linear part below the knee of the curve.
+    return np.tanh(audio * gain * 0.85).astype(np.float32)
+
+
 def _resample(audio: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
     """Low-latency polyphase resampling (faster + cleaner than FFT resample)."""
     if src_rate == dst_rate or audio.size == 0:
@@ -75,6 +91,7 @@ class AudioIO:
         on_local_barge_in: Callable[[], None] | None = None,
         barge_rms_threshold: float | None = None,
         barge_sustain_frames: int | None = None,
+        output_gain: float = 1.0,
     ) -> None:
         self.robot = robot
         self.on_input_pcm16 = on_input_pcm16
@@ -99,6 +116,13 @@ class AudioIO:
         self._barge_sustain_frames = (
             barge_sustain_frames if barge_sustain_frames is not None else _barge_sustain_frames()
         )
+        # Software make-up gain on Buddy's voice, on top of the system volume. The
+        # robot speaker is small: in a room with a child around, the hardware maximum
+        # alone is often not enough to be comfortably intelligible.
+        self.output_gain = max(0.1, min(8.0, float(output_gain)))
+        # A louder voice also leaks more into the mic, so the barge-in threshold has
+        # to rise with it — otherwise Buddy's own speech would cut Buddy off.
+        self._barge_rms_threshold *= max(1.0, self.output_gain / 1.6)
 
     # ------------------------------------------------------------------ lifecycle
     def start(self) -> None:
@@ -170,6 +194,8 @@ class AudioIO:
         if out_rate != SAMPLE_RATE and audio.size:
             audio = _resample(audio, SAMPLE_RATE, out_rate)
         audio_f32 = (np.asarray(audio, dtype=np.float32)) / 32768.0
+        if self.output_gain != 1.0 and audio_f32.size:
+            audio_f32 = _boost(audio_f32, self.output_gain)
         try:
             self.robot.media.push_audio_sample(audio_f32)
         except Exception as e:

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -9,75 +9,18 @@
 from __future__ import annotations
 
 import logging
-import os
 import threading
 import time
 from collections.abc import Callable
 
 import numpy as np
-from math import gcd
-from scipy.signal import resample_poly
 
+from .audio_dsp import boost, resample
 from .azure_realtime import SAMPLE_RATE
 
 logger = logging.getLogger(__name__)
 
-# On-device ("local") barge-in. The Reachy Mini mic array is echo-cancelled in
-# hardware (AEC removes the robot's own speaker audio from the mic), so energy on the
-# mic *while Buddy is speaking* means a real nearby voice — not the robot hearing
-# itself. That lets us cut playback the instant the child speaks, without waiting for
-# the server's ``speech_started`` round-trip (~200-400ms). The server path (cancel +
-# stop/sleep classification) still runs a moment later. Thresholds are env-tunable so
-# they can be adjusted in the field without a redeploy.
-_DEFAULT_BARGE_RMS_THRESHOLD = 0.045  # normalised 0..1
-_DEFAULT_BARGE_SUSTAIN_FRAMES = 3  # consecutive loud frames
 _PLAY_TTL_S = 0.25  # treat Buddy as "speaking" for this long after the last audio chunk
-
-
-def _barge_rms_threshold() -> float:
-    """Read the barge-in RMS threshold from the env at call time.
-
-    Read lazily (not at import) so values saved in the robot's ``.env`` — which
-    ``main.run()`` loads *after* this module is imported — take effect.
-    """
-    try:
-        return float(os.getenv("MIRRORBUDDY_BARGE_RMS", _DEFAULT_BARGE_RMS_THRESHOLD))
-    except (TypeError, ValueError):
-        return _DEFAULT_BARGE_RMS_THRESHOLD
-
-
-def _barge_sustain_frames() -> int:
-    """Read the barge-in sustain-frame count from the env at call time."""
-    try:
-        return max(1, int(os.getenv("MIRRORBUDDY_BARGE_FRAMES", _DEFAULT_BARGE_SUSTAIN_FRAMES)))
-    except (TypeError, ValueError):
-        return _DEFAULT_BARGE_SUSTAIN_FRAMES
-
-
-def _boost(audio: np.ndarray, gain: float) -> np.ndarray:
-    """Raise the voice level by compressing the peaks instead of clipping them.
-
-    The robot speaker is already near its hardware maximum, so the only headroom
-    left is here. Plain multiplication would slam the peaks against ±1.0 and the
-    voice would rasp — unpleasant, and for a child with an auditory processing
-    difficulty, unusable.
-
-    ``tanh`` is the valve curve: below the knee it is almost linear, above it it
-    bends gently. On speech — few peaks, plenty of body — it sounds markedly louder
-    without turning harsh.
-    """
-    # 0.85 keeps the linear part below the knee of the curve.
-    return np.tanh(audio * gain * 0.85).astype(np.float32)
-
-
-def _resample(audio: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
-    """Low-latency polyphase resampling (faster + cleaner than FFT resample)."""
-    if src_rate == dst_rate or audio.size == 0:
-        return audio
-    g = gcd(src_rate, dst_rate)
-    up = dst_rate // g
-    down = src_rate // g
-    return resample_poly(audio, up, down)
 
 
 class AudioIO:
@@ -111,10 +54,10 @@ class AudioIO:
         # Barge-in thresholds: prefer values passed by the caller (from Config, read
         # after the instance .env loads); fall back to the env/defaults for standalone use.
         self._barge_rms_threshold = (
-            barge_rms_threshold if barge_rms_threshold is not None else _barge_rms_threshold()
+            barge_rms_threshold if barge_rms_threshold is not None else barge_rms_threshold()
         )
         self._barge_sustain_frames = (
-            barge_sustain_frames if barge_sustain_frames is not None else _barge_sustain_frames()
+            barge_sustain_frames if barge_sustain_frames is not None else barge_sustain_frames()
         )
         # Software make-up gain on Buddy's voice, on top of the system volume. The
         # robot speaker is small: in a room with a child around, the hardware maximum
@@ -192,10 +135,10 @@ class AudioIO:
             self._probe_rates()
             out_rate = self._out_rate or SAMPLE_RATE
         if out_rate != SAMPLE_RATE and audio.size:
-            audio = _resample(audio, SAMPLE_RATE, out_rate)
+            audio = resample(audio, SAMPLE_RATE, out_rate)
         audio_f32 = (np.asarray(audio, dtype=np.float32)) / 32768.0
         if self.output_gain != 1.0 and audio_f32.size:
-            audio_f32 = _boost(audio_f32, self.output_gain)
+            audio_f32 = boost(audio_f32, self.output_gain)
         try:
             self.robot.media.push_audio_sample(audio_f32)
         except Exception as e:
@@ -265,7 +208,7 @@ class AudioIO:
 
                 # Resample microphone -> realtime rate.
                 if needs_resample and audio.size:
-                    audio = _resample(audio, in_rate, SAMPLE_RATE).astype(np.int16)
+                    audio = resample(audio, in_rate, SAMPLE_RATE).astype(np.int16)
 
                 self.on_input_pcm16(audio.tobytes())
             except Exception as e:

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -10,6 +10,7 @@ import base64
 import json
 import logging
 import threading
+import time
 from collections.abc import Callable
 
 import websockets
@@ -19,6 +20,14 @@ from . import session_flow
 from . import tools
 
 logger = logging.getLogger(__name__)
+
+# How long an utterance must be before we answer without waiting for its transcript.
+# Sized against the phrases that must never produce a reply — "zitto", "basta",
+# "fermati", "hey buddy" — spoken slowly by a child with a motor impairment. Above
+# this, a turn cannot be a bare stop word, so the transcript adds latency and nothing
+# else. Any stop word inside a longer sentence is still caught: the transcript lands a
+# moment later and cancels the response in flight.
+_FAST_PATH_MIN_SPEECH_S = 1.8
 
 SAMPLE_RATE = rt_messages.SAMPLE_RATE  # Azure Realtime PCM sample rate (in and out)
 
@@ -74,6 +83,8 @@ class AzureRealtimeClient:
         self._responding = False  # a model response is currently streaming
         self._suppress = False  # drop in-flight audio after a barge-in cancel
         self._quiet = False  # student asked for silence: keep model muted
+        self._speech_started_at = 0.0  # monotonic time the student began this turn
+        self._fast_requested = False  # response already asked for before the transcript
         self._asleep = False  # session ended: stay muted until the wake word
         self._sleep_after = False  # go to sleep once the farewell response finishes
         self._pending_farewell = False  # a goodbye was requested; sleep when it starts→done
@@ -246,7 +257,7 @@ class AzureRealtimeClient:
             if action == session_flow.END:
                 self._pending_farewell = True
                 self._suppress = False
-                if self._responding:
+                if self._responding or self._fast_requested:
                     await self._safe_send(rt_messages.CANCEL)
                 await self._request_response(rt_messages.FAREWELL_INSTR)
                 return
@@ -257,7 +268,9 @@ class AzureRealtimeClient:
                 self._asleep = True
                 self._quiet = True
                 self._suppress = True
-                if self._responding:
+                # Also cancels a fast-path response requested before the transcript
+                # arrived: "zitto" must win even when it ends a long sentence.
+                if self._responding or self._fast_requested:
                     await self._safe_send(rt_messages.CANCEL)
                 if self.on_speech_started:
                     _safe_cb(self.on_speech_started)  # flush local playback now
@@ -265,10 +278,10 @@ class AzureRealtimeClient:
                     _safe_cb(self.on_sleep)  # settle into the rest position
                 return
             if action == session_flow.SPEAK:
-                # The server no longer auto-creates a response (create_response=False),
-                # so we ask for one only once we've classified the turn as ordinary.
-                # This guarantees a stop/sleep word never produces a spoken reply.
-                await self._request_response()
+                # Ordinary turn. If the fast path already asked for the response when
+                # speech ended, asking again would make Buddy answer twice.
+                if not self._fast_requested:
+                    await self._request_response()
             return
 
         # Barge-in: cancel the turn, drop in-flight audio; each new turn starts un-muted.
@@ -277,10 +290,37 @@ class AzureRealtimeClient:
                 return  # ignore ambient speech while asleep; wake word handles it
             self._suppress = True
             self._quiet = False
+            self._speech_started_at = time.monotonic()
+            self._fast_requested = False
             if self._responding:
                 await self._safe_send(rt_messages.CANCEL)
             if self.on_speech_started:
                 _safe_cb(self.on_speech_started)
+            return
+
+        if etype == "input_audio_buffer.speech_stopped":
+            # The server no longer auto-creates responses, so we normally wait for the
+            # transcript before asking for one — that is a whole extra Whisper pass in
+            # series on every single turn, and the child feels every millisecond of it.
+            #
+            # We only need the transcript to catch "zitto"/"basta"/"buddy", and those
+            # are always brief. So a clearly long utterance can't be one: ask for the
+            # answer straight away. Anything short keeps the safe, slower path.
+            if self._asleep or self._quiet:
+                return
+            spoken = time.monotonic() - self._speech_started_at
+            if self._speech_started_at and spoken >= _FAST_PATH_MIN_SPEECH_S:
+                self._fast_requested = True
+                await self._request_response()
+            return
+
+        if etype in ("response.output_audio_transcript.delta", "response.audio_transcript.delta"):
+            # The final transcript only lands once the sentence is already spoken —
+            # far too late to colour the body language. The opening words carry the
+            # mood ("Bravo!", "Fammi pensare..."), so react to the first delta.
+            delta = event.get("delta") or ""
+            if delta and self.on_transcript:
+                _safe_cb(self.on_transcript, delta, False)
             return
 
         if etype in ("response.output_audio_transcript.done", "response.audio_transcript.done"):

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -122,6 +122,17 @@ class AzureRealtimeClient:
         self._enqueue(json.dumps(rt_messages.image_message(data_url, prompt)))
         self._enqueue(json.dumps({"type": "response.create"}))
 
+    def speak_now(self, instructions: str) -> None:
+        """Ask the model to say something on its own initiative (thread-safe).
+
+        Used when the world changed rather than the conversation: the student sat
+        down, or came back. Refused while asleep or muted — "zitto" outranks
+        anything the robot noticed by itself.
+        """
+        if self._asleep or self._quiet or self._responding:
+            return
+        self._enqueue(json.dumps(rt_messages.response_create(instructions)))
+
     def local_barge_in(self) -> None:
         """On-device barge-in (called from the mic thread when a real voice is heard
         over Buddy's speech). Drops in-flight model audio immediately and asks the

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -10,24 +10,14 @@ import base64
 import json
 import logging
 import threading
-import time
 from collections.abc import Callable
 
 import websockets
 
 from . import rt_messages
-from . import session_flow
-from . import tools
+from .rt_events import RealtimeEventsMixin
 
 logger = logging.getLogger(__name__)
-
-# How long an utterance must be before we answer without waiting for its transcript.
-# Sized against the phrases that must never produce a reply — "zitto", "basta",
-# "fermati", "hey buddy" — spoken slowly by a child with a motor impairment. Above
-# this, a turn cannot be a bare stop word, so the transcript adds latency and nothing
-# else. Any stop word inside a longer sentence is still caught: the transcript lands a
-# moment later and cancels the response in flight.
-_FAST_PATH_MIN_SPEECH_S = 1.8
 
 SAMPLE_RATE = rt_messages.SAMPLE_RATE  # Azure Realtime PCM sample rate (in and out)
 
@@ -40,7 +30,7 @@ def _ws_major() -> int:
         return 0
 
 
-class AzureRealtimeClient:
+class AzureRealtimeClient(RealtimeEventsMixin):
     def __init__(
         self,
         ws_url: str,
@@ -211,170 +201,3 @@ class AzureRealtimeClient:
     async def _request_response(self, instructions: str | None = None) -> None:
         """Ask the model to speak now, optionally steering what it should say."""
         await self._safe_send(json.dumps(rt_messages.response_create(instructions)))
-
-    async def _handle_event(self, event: dict) -> None:
-        etype = event.get("type", "")
-
-        if etype in ("session.created", "session.updated"):
-            if not self._ready.is_set():
-                self._ready.set()
-                if self.on_ready:
-                    _safe_cb(self.on_ready)
-                await self._greet()
-            return
-
-        if etype in ("response.output_audio.delta", "response.audio.delta"):
-            if self._suppress:
-                return  # dropped: user barged in, this response is being cancelled
-            b64 = event.get("delta") or event.get("audio")
-            if b64 and self.on_output_audio:
-                _safe_cb(self.on_output_audio, base64.b64decode(b64))
-            return
-
-        if etype == "response.created":
-            if self._quiet or self._asleep:
-                await self._safe_send(rt_messages.CANCEL)
-                self._suppress = True
-                return
-            if self._pending_farewell:  # the goodbye is now starting → sleep once it's done
-                self._pending_farewell = False
-                self._sleep_after = True
-            self._responding = True
-            self._suppress = False
-            return
-        if etype == "response.done":
-            self._responding = False
-            if self._sleep_after:  # farewell just finished → go to sleep
-                self._sleep_after = False
-                self._asleep = True
-                if self.on_sleep:
-                    _safe_cb(self.on_sleep)
-            return
-
-        # Student's speech transcribed: honour stop / end / wake intents deterministically.
-        if etype.endswith("input_audio_transcription.completed"):
-            text = (event.get("transcript") or "").strip()
-            if not text:
-                return
-            action = session_flow.decide(text, self._asleep)
-            if action == session_flow.IGNORE:
-                return
-            if action == session_flow.WAKE:
-                self._asleep = self._quiet = False
-                if self.on_wake:
-                    _safe_cb(self.on_wake)
-                await self._request_response(rt_messages.WAKE_INSTR)
-                return
-            if action == session_flow.END:
-                self._pending_farewell = True
-                self._suppress = False
-                if self._responding or self._fast_requested:
-                    await self._safe_send(rt_messages.CANCEL)
-                await self._request_response(rt_messages.FAREWELL_INSTR)
-                return
-            if action == session_flow.STOP:
-                # "basta / fermati" → go quiet AND park in a rest posture, staying put
-                # until called back by name. Insistence stresses the child, so a stop is
-                # a full stop, not a brief pause that resumes on the next sound.
-                self._asleep = True
-                self._quiet = True
-                self._suppress = True
-                # Also cancels a fast-path response requested before the transcript
-                # arrived: "zitto" must win even when it ends a long sentence.
-                if self._responding or self._fast_requested:
-                    await self._safe_send(rt_messages.CANCEL)
-                if self.on_speech_started:
-                    _safe_cb(self.on_speech_started)  # flush local playback now
-                if self.on_sleep:
-                    _safe_cb(self.on_sleep)  # settle into the rest position
-                return
-            if action == session_flow.SPEAK:
-                # Ordinary turn. If the fast path already asked for the response when
-                # speech ended, asking again would make Buddy answer twice.
-                if not self._fast_requested:
-                    await self._request_response()
-            return
-
-        # Barge-in: cancel the turn, drop in-flight audio; each new turn starts un-muted.
-        if etype == "input_audio_buffer.speech_started":
-            if self._asleep:
-                return  # ignore ambient speech while asleep; wake word handles it
-            self._suppress = True
-            self._quiet = False
-            self._speech_started_at = time.monotonic()
-            self._fast_requested = False
-            if self._responding:
-                await self._safe_send(rt_messages.CANCEL)
-            if self.on_speech_started:
-                _safe_cb(self.on_speech_started)
-            return
-
-        if etype == "input_audio_buffer.speech_stopped":
-            # The server no longer auto-creates responses, so we normally wait for the
-            # transcript before asking for one — that is a whole extra Whisper pass in
-            # series on every single turn, and the child feels every millisecond of it.
-            #
-            # We only need the transcript to catch "zitto"/"basta"/"buddy", and those
-            # are always brief. So a clearly long utterance can't be one: ask for the
-            # answer straight away. Anything short keeps the safe, slower path.
-            if self._asleep or self._quiet:
-                return
-            spoken = time.monotonic() - self._speech_started_at
-            if self._speech_started_at and spoken >= _FAST_PATH_MIN_SPEECH_S:
-                self._fast_requested = True
-                await self._request_response()
-            return
-
-        if etype in ("response.output_audio_transcript.delta", "response.audio_transcript.delta"):
-            # The final transcript only lands once the sentence is already spoken —
-            # far too late to colour the body language. The opening words carry the
-            # mood ("Bravo!", "Fammi pensare..."), so react to the first delta.
-            delta = event.get("delta") or ""
-            if delta and self.on_transcript:
-                _safe_cb(self.on_transcript, delta, False)
-            return
-
-        if etype in ("response.output_audio_transcript.done", "response.audio_transcript.done"):
-            text = event.get("transcript") or ""
-            if text and self.on_transcript:
-                _safe_cb(self.on_transcript, text, True)
-            return
-
-        if etype == "response.output_item.added":
-            item = event.get("item") or {}
-            if item.get("type") == "function_call":
-                cid = item.get("call_id") or item.get("id") or ""
-                if cid:
-                    self._fc_names[cid] = item.get("name") or ""
-            return
-
-        if etype == "response.function_call_arguments.done":
-            call_id = event.get("call_id") or ""
-            name, args = tools.parse_call_arguments(event, self._fc_names.get(call_id, ""))
-            self._fc_names.pop(call_id, None)
-            logger.info("Tool call: %s(%s) call_id=%s", name, args, call_id)
-            if name and self.on_tool_call:
-                _safe_cb(self.on_tool_call, name, args, call_id)
-            return
-
-        if etype == "error":
-            err = event.get("error", event)
-            # Benign race: we ask to cancel the response the instant the child speaks
-            # over Buddy, but the response may have finished on its own just before the
-            # CANCEL lands. Nothing is broken, so it must not look like a failure in
-            # the logs — real errors have to stay visible.
-            if isinstance(err, dict) and err.get("code") == "response_cancel_not_active":
-                self._responding = False
-                logger.debug("Cancel arrived after the response ended (harmless)")
-                return
-            logger.error("Azure Realtime error event: %s", json.dumps(err))
-            return
-
-        logger.debug("Unhandled event: %s", etype)
-
-
-def _safe_cb(cb: Callable, *args) -> None:
-    try:
-        cb(*args)
-    except Exception as e:  # pragma: no cover
-        logger.debug("callback error: %s", e)

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -120,6 +120,7 @@ class AzureRealtimeClient:
         self._suppress = True  # drop any audio deltas already in flight
         self._quiet = False  # a normal turn stays un-muted; a stop word re-mutes below
         if self._responding:
+            self._responding = False  # one CANCEL per response: avoid a pile-up of no-op cancels
             self._enqueue(rt_messages.CANCEL)
 
     def _enqueue(self, msg: str) -> None:
@@ -306,7 +307,16 @@ class AzureRealtimeClient:
             return
 
         if etype == "error":
-            logger.error("Azure Realtime error event: %s", json.dumps(event.get("error", event)))
+            err = event.get("error", event)
+            # Benign race: we ask to cancel the response the instant the child speaks
+            # over Buddy, but the response may have finished on its own just before the
+            # CANCEL lands. Nothing is broken, so it must not look like a failure in
+            # the logs — real errors have to stay visible.
+            if isinstance(err, dict) and err.get("code") == "response_cancel_not_active":
+                self._responding = False
+                logger.debug("Cancel arrived after the response ended (harmless)")
+                return
+            logger.error("Azure Realtime error event: %s", json.dumps(err))
             return
 
         logger.debug("Unhandled event: %s", etype)

--- a/robot/reachy_mini_mirrorbuddy/config.py
+++ b/robot/reachy_mini_mirrorbuddy/config.py
@@ -85,6 +85,14 @@ class Config:
         self.BARGE_RMS_THRESHOLD: float = _float("MIRRORBUDDY_BARGE_RMS", 0.045)
         self.BARGE_SUSTAIN_FRAMES: int = _int("MIRRORBUDDY_BARGE_FRAMES", 3, minimum=1)
 
+        # --- loudness ---
+        # System mixer level pushed to the daemon at startup, and a software make-up
+        # gain applied to Buddy's voice on top of it. The robot speaker is small, and
+        # a tutor that can't be heard clearly is a tutor that doesn't work.
+        self.VOLUME: int = _int("MIRRORBUDDY_VOLUME", 92, minimum=0)
+        self.OUTPUT_GAIN: float = _float("MIRRORBUDDY_OUTPUT_GAIN", 3.2)
+        self.DAEMON_URL: str = os.getenv("MIRRORBUDDY_DAEMON_URL", "http://localhost:8000").rstrip("/")
+
     def missing(self) -> list[str]:
         """Return the list of required config values that are absent."""
         errors: list[str] = []

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -14,19 +14,20 @@ from __future__ import annotations
 import logging
 import threading
 
-from . import camera, presence, tools
+from . import presence, tools
 from .audio_io import AudioIO
 from .azure_realtime import AzureRealtimeClient
 from .config import Config
 from .dsa import turn_detection_config
-from .mirrorbuddy_client import Maestro, friend_buddy, neutral_buddy
+from .mirrorbuddy_client import Maestro
 from .movements import Movements, temperament_for
 from .prompt_builder import build_instructions
+from .tool_handlers import ToolCallMixin
 
 logger = logging.getLogger(__name__)
 
 
-class Controller:
+class Controller(ToolCallMixin):
     """Owns the realtime client and reacts to the model's tool calls."""
 
     def __init__(
@@ -187,87 +188,6 @@ class Controller:
             logger.debug("wake handling failed: %s", e)
 
     # ------------------------------------------------------------------ tools
-    def _on_tool_call(self, name: str, args: dict, call_id: str) -> None:
-        """Runs in the realtime client's thread — keep it quick; offload the switch."""
-        client = self._client
-        if client is None:
-            return
-        try:
-            if name == "list_professors":
-                client.send_function_result(call_id, tools.professors_summary(self.maestri))
-            elif name == "call_professor":
-                self._handle_call_professor(client, args, call_id)
-            elif name == "look_at_homework":
-                self._handle_look_at_homework(client, args, call_id)
-            elif name == "talk_as_friend":
-                self._switch_persona(client, call_id, friend=True)
-            elif name == "back_to_study":
-                self._switch_persona(client, call_id, friend=False)
-            else:
-                client.send_function_result(call_id, "Ok.")
-        except Exception as e:  # pragma: no cover - runtime robustness
-            logger.warning("tool %s failed: %s", name, e)
-            client.send_function_result(call_id, "Scusa, non ci sono riuscito.")
-
-    def _handle_call_professor(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
-        target = tools.resolve_maestro(self.maestri, str(args.get("query") or ""))
-        if target is None:
-            # Give the model the real roster: without it, it retried the same failing
-            # request over and over while the child listened to apologies.
-            client.send_function_result(
-                call_id,
-                "Non ho un professore per quella materia. Ecco chi c'e': "
-                f"{tools.professors_summary(self.maestri)}. "
-                "Proponi tu l'alternativa piu' vicina, senza richiamare questo strumento con la stessa richiesta.",
-            )
-            return
-        if target.id == self.maestro.id:
-            client.send_function_result(call_id, f"Sono gia' io, {self.maestro.display_name}. Andiamo avanti.")
-            return
-        # Acknowledge without a spoken reply here; the new Maestro will greet.
-        client.send_function_result(call_id, f"Passo la parola a {target.display_name}.", respond=False)
-        threading.Thread(target=self._switch_to, args=(target,), name="MaestroSwitch", daemon=True).start()
-
-    def _switch_persona(self, client: AzureRealtimeClient, call_id: str, friend: bool) -> None:
-        """Swap between the friend companion and the study tutor (persona + voice)."""
-        target = (
-            friend_buddy(self.cfg.STUDENT_NAME, self.cfg.BUDDY_VOICE)
-            if friend
-            else neutral_buddy(self.cfg.STUDENT_NAME, self.cfg.BUDDY_VOICE)
-        )
-        if target.id == self.maestro.id:
-            client.send_function_result(call_id, "Certo, sono qui.")
-            return
-        client.send_function_result(call_id, "Va bene.", respond=False)
-        threading.Thread(target=self._switch_to, args=(target,), name="PersonaSwitch", daemon=True).start()
-
-    def _handle_look_at_homework(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
-        if not self.cfg.ENABLE_CAMERA:
-            client.send_function_result(call_id, "La telecamera e' spenta nelle impostazioni, non posso guardare.")
-            return
-        # Offload: freezing the head to get a sharp frame takes ~1s; never block the ws loop.
-        threading.Thread(target=self._capture_homework, args=(client, args, call_id), daemon=True).start()
-
-    def _capture_homework(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
-        self.movements.set_emotion("focused")
-        self.movements.hold_still()
-        try:
-            data_url = camera.capture_data_url(self.robot)
-        finally:
-            self.movements.release_hold()
-            self.movements.set_emotion("thinking")
-        if not data_url:
-            client.send_function_result(call_id, "Non riesco a vedere bene, avvicina il foglio e riproviamo.")
-            return
-        question = str(args.get("question") or "").strip() or (
-            "Guarda la foto: puo' essere un compito, la pagina di un quaderno o di un libro, "
-            "o lo schermo. Leggi cosa c'e' scritto e aiuta lo studente passo passo, senza dare "
-            "la risposta pronta."
-        )
-        # Privacy: we already announced verbally; hand the still frame to the model.
-        client.send_function_result(call_id, "Ho guardato il tuo compito.", respond=False)
-        client.send_image(data_url, question)
-
     # ------------------------------------------------------------------ switching
     def _switch_to(self, target: Maestro) -> None:
         """Reconnect the realtime session with a new persona and voice."""

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -121,14 +121,26 @@ class Controller:
             return
         if event == presence.ARRIVED:
             client.speak_now(
-                "Lo studente si e' appena seduto davanti a te: salutalo brevemente per nome "
-                "e chiedi da cosa vuole partire. Una frase soltanto."
+                "Lo studente si e' appena seduto davanti a te: salutalo brevemente "
+                f"{self._name_clause()} e chiedi da cosa vuole partire. Una frase soltanto."
             )
         elif event == presence.RETURNED:
             client.speak_now(
-                "Lo studente e' tornato dopo una pausa: fai un bentornato molto breve e "
-                "riprendi da dove eravate. Una frase soltanto."
+                f"Lo studente e' tornato dopo una pausa: fai un bentornato molto breve "
+                f"{self._name_clause()} e riprendi da dove eravate. Una frase soltanto."
             )
+
+    def _name_clause(self) -> str:
+        """How to address the child — never an open invitation to invent a name.
+
+        "Greet him by name" without supplying one is exactly how the robot ended up
+        calling Mario "Luca". If we don't have a usable name (the server encrypts
+        names, and a decryption miss puts ciphertext on the wire), we say so.
+        """
+        name = (self.cfg.STUDENT_NAME or "").strip()
+        if name and not name.startswith(("pii:", "[")):
+            return f"chiamandolo per nome ({name})"
+        return "senza usare nomi propri"
 
     # ------------------------------------------------------------------ expression
     def _on_speech_started(self) -> None:

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -139,7 +139,14 @@ class Controller:
     def _handle_call_professor(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
         target = tools.resolve_maestro(self.maestri, str(args.get("query") or ""))
         if target is None:
-            client.send_function_result(call_id, "Non ho trovato quel professore, puoi ripetere il nome o la materia?")
+            # Give the model the real roster: without it, it retried the same failing
+            # request over and over while the child listened to apologies.
+            client.send_function_result(
+                call_id,
+                "Non ho un professore per quella materia. Ecco chi c'e': "
+                f"{tools.professors_summary(self.maestri)}. "
+                "Proponi tu l'alternativa piu' vicina, senza richiamare questo strumento con la stessa richiesta.",
+            )
             return
         if target.id == self.maestro.id:
             client.send_function_result(call_id, f"Sono gia' io, {self.maestro.display_name}. Andiamo avanti.")

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -46,6 +46,8 @@ class Controller:
         self.movements = movements
         self._client: AzureRealtimeClient | None = None
         self._switch_lock = threading.Lock()
+        self._partial = ""  # transcript of the reply in flight, used to read the mood
+        self._expressed = False
 
     # ------------------------------------------------------------------ lifecycle
     def start(self) -> bool:
@@ -87,12 +89,37 @@ class Controller:
             use_ga=self.cfg.use_ga_protocol,
             tools=tools.TOOL_SCHEMAS,
             on_output_audio=self.audio.play,
-            on_speech_started=self.audio.interrupt,
-            on_transcript=_log_transcript,
+            on_speech_started=self._on_speech_started,
+            on_transcript=self._on_transcript,
             on_tool_call=self._on_tool_call,
             on_sleep=self._on_sleep,
             on_wake=self._on_wake,
         )
+
+    # ------------------------------------------------------------------ expression
+    def _on_speech_started(self) -> None:
+        """The student is talking: stop the audio and listen with an open posture."""
+        self.audio.interrupt()
+        self.reset_expression()
+        self.movements.set_emotion("curious")
+
+    def _on_transcript(self, text: str, final: bool) -> None:
+        """Log the finished line; colour the body language from the first words."""
+        if final:
+            logger.info("Buddy: %s", text)
+            return
+        self._partial += text
+        # One reading per response: the opening clause sets the mood, and re-reading
+        # every delta would make Buddy twitch between moods mid-sentence.
+        if not self._expressed and len(self._partial) >= 12:
+            self._expressed = True
+            self.movements.express(self._partial)
+
+    def reset_expression(self) -> None:
+        """Start a fresh response: clear the partial transcript and ease back to neutral."""
+        self._partial = ""
+        self._expressed = False
+        self.movements.set_emotion(None)
 
     # ------------------------------------------------------------------ sleep / wake
     def _on_sleep(self) -> None:
@@ -176,11 +203,13 @@ class Controller:
         threading.Thread(target=self._capture_homework, args=(client, args, call_id), daemon=True).start()
 
     def _capture_homework(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
+        self.movements.set_emotion("focused")
         self.movements.hold_still()
         try:
             data_url = camera.capture_data_url(self.robot)
         finally:
             self.movements.release_hold()
+            self.movements.set_emotion("thinking")
         if not data_url:
             client.send_function_result(call_id, "Non riesco a vedere bene, avvicina il foglio e riproviamo.")
             return
@@ -219,6 +248,3 @@ class Controller:
             logger.info("Switched to Maestro %s (%s), voice=%s", target.display_name, target.id, target.voice)
 
 
-def _log_transcript(text: str, final: bool) -> None:
-    if final:
-        logger.info("Buddy: %s", text)

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import threading
 
-from . import camera, tools
+from . import camera, presence, tools
 from .audio_io import AudioIO
 from .azure_realtime import AzureRealtimeClient
 from .config import Config
@@ -48,6 +48,7 @@ class Controller:
         self._switch_lock = threading.Lock()
         self._partial = ""  # transcript of the reply in flight, used to read the mood
         self._expressed = False
+        self._presence: presence.PresenceWatcher | None = None
 
     # ------------------------------------------------------------------ lifecycle
     def start(self) -> bool:
@@ -56,6 +57,9 @@ class Controller:
         self.audio.on_input_pcm16 = self._client.send_audio_pcm16
         self.audio.on_local_barge_in = self._client.local_barge_in
         self._client.start()
+        if self.cfg.ENABLE_CAMERA:
+            self._presence = presence.PresenceWatcher(self.robot, self._on_presence)
+            self._presence.start()
         ready = self._client.wait_ready(timeout=25.0)
         if not ready:
             logger.warning("Realtime session not confirmed ready; continuing anyway")
@@ -66,6 +70,9 @@ class Controller:
         return bool(c and c._thread and c._thread.is_alive())
 
     def stop(self) -> None:
+        if self._presence:
+            self._presence.stop()
+            self._presence = None
         c = self._client
         if c:
             c.stop()
@@ -95,6 +102,33 @@ class Controller:
             on_sleep=self._on_sleep,
             on_wake=self._on_wake,
         )
+
+    # ------------------------------------------------------------------ seeing
+    def _on_presence(self, event: str) -> None:
+        """The student appeared or disappeared from view: behave accordingly.
+
+        Deliberately quiet. A robot that comments every time a child shifts in his
+        chair is a robot a child stops wanting at the desk, so leaving is silent —
+        only the body settles — and only a real return is worth a word.
+        """
+        client = self._client
+        if event == presence.LEFT:
+            self.movements.set_emotion("calm")
+            self.audio.interrupt()  # stop talking to an empty chair
+            return
+        self.movements.set_emotion("happy")
+        if client is None:
+            return
+        if event == presence.ARRIVED:
+            client.speak_now(
+                "Lo studente si e' appena seduto davanti a te: salutalo brevemente per nome "
+                "e chiedi da cosa vuole partire. Una frase soltanto."
+            )
+        elif event == presence.RETURNED:
+            client.speak_now(
+                "Lo studente e' tornato dopo una pausa: fai un bentornato molto breve e "
+                "riprendi da dove eravate. Una frase soltanto."
+            )
 
     # ------------------------------------------------------------------ expression
     def _on_speech_started(self) -> None:

--- a/robot/reachy_mini_mirrorbuddy/device.py
+++ b/robot/reachy_mini_mirrorbuddy/device.py
@@ -73,10 +73,26 @@ def _dsa_from_accessibility(acc: dict[str, Any]) -> str | None:
     return None
 
 
+def _usable_name(name: str | None) -> bool:
+    """Is this a name a child would recognise being called by?
+
+    The server encrypts names at rest, and a decryption miss can put ciphertext or a
+    placeholder on the wire. Feeding that to the model does not produce silence — it
+    produces a *confident invented name*, which is worse than using none at all.
+    """
+    if not name:
+        return False
+    n = name.strip()
+    return bool(n) and not n.startswith("pii:") and not n.startswith("[")
+
+
 def apply_device_profile(config, profile: DeviceProfile) -> None:
     """Overlay a paired child's profile onto the runtime config (in place)."""
     if profile.name:
-        config.STUDENT_NAME = profile.name
+        if _usable_name(profile.name):
+            config.STUDENT_NAME = profile.name
+        else:
+            logger.warning("Ignoring unreadable name from paired profile; keeping local name.")
     if profile.language:
         config.LOCALE = profile.language
     dsa = _dsa_from_accessibility(profile.accessibility)

--- a/robot/reachy_mini_mirrorbuddy/device.py
+++ b/robot/reachy_mini_mirrorbuddy/device.py
@@ -82,10 +82,19 @@ def apply_device_profile(config, profile: DeviceProfile) -> None:
     dsa = _dsa_from_accessibility(profile.accessibility)
     if dsa:
         config.DSA_PROFILE = dsa
+    # The child already chose who should help them, in the app. Booting as a generic
+    # assistant and making them ask again throws that choice away — so the paired
+    # coach is who the robot wakes up as. The buddy is the fallback; an explicit
+    # local MAESTRO_ID always wins, because someone set that on this robot on purpose.
+    preferred = profile.preferred_coach or profile.preferred_buddy
+    if preferred and not config.MAESTRO_ID:
+        config.MAESTRO_ID = preferred
+        config.START_NEUTRAL = False
     # Reduced-motion is accessibility-critical: keep the robot calm for this child.
     if profile.accessibility.get("reducedMotion"):
         config.CALM_MOVEMENT = True
     logger.info(
-        "Applied paired profile: name=%s locale=%s dsa=%s calm=%s",
+        "Applied paired profile: name=%s locale=%s dsa=%s calm=%s persona=%s",
         config.STUDENT_NAME, config.LOCALE, config.DSA_PROFILE, config.CALM_MOVEMENT,
+        config.MAESTRO_ID or "(neutral buddy)",
     )

--- a/robot/reachy_mini_mirrorbuddy/emotions.py
+++ b/robot/reachy_mini_mirrorbuddy/emotions.py
@@ -15,6 +15,8 @@ Two ideas here:
 
 from __future__ import annotations
 
+import math
+
 import re
 from dataclasses import dataclass
 
@@ -121,3 +123,21 @@ def infer(text: str | None) -> Emotion:
         if any(_matches(cue, lowered) for cue in cues):
             return emotion
     return NEUTRAL
+
+
+def blend_mood(mood: dict[str, float], target: "Emotion", tau: float, dt: float) -> dict[str, float]:
+    """Ease the live mood values toward ``target`` in place, and return them.
+
+    Moods are never applied as a jump: a child watching should see Buddy *become*
+    happy over a beat, the way a face changes, not switch posture between frames.
+    """
+    alpha = 1.0 if tau <= 0.0 else 1.0 - math.exp(-dt / tau)
+    for key, want in (
+        ("scale", target.scale),
+        ("speed", target.speed),
+        ("pitch", target.pitch_offset),
+        ("antenna", target.antenna_offset),
+        ("sway", target.sway),
+    ):
+        mood[key] += (want - mood[key]) * alpha
+    return mood

--- a/robot/reachy_mini_mirrorbuddy/emotions.py
+++ b/robot/reachy_mini_mirrorbuddy/emotions.py
@@ -1,0 +1,123 @@
+"""Emotional colour for Buddy's body language.
+
+Why this exists: a tutor that moves the same way whether the child just solved
+something or just got it wrong is a tutor that isn't really listening. And a body
+that snaps between poses reads as mechanical — children pick that up instantly.
+
+Two ideas here:
+
+1. **Emotions are offsets, not choreography.** Each emotion nudges the idle
+   animation (posture, tempo, antenna angle) instead of replacing it, so Buddy
+   never freezes mid-gesture to "play an animation".
+2. **Nothing is instantaneous.** Every value eases toward its target, so a change
+   of mood arrives as a movement, not as a jump.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Emotion:
+    """A mood, expressed as gentle modifiers over the idle animation.
+
+    scale/speed multiply the idle amplitude and tempo. The offsets are additive:
+    ``pitch_offset`` is the head tilt in degrees (positive = looking up, open and
+    attentive; negative = looking down, thoughtful or sorry). ``antenna_offset``
+    is in radians (up = alert and happy, down = deflated).
+    """
+
+    name: str
+    scale: float = 1.0
+    speed: float = 1.0
+    pitch_offset: float = 0.0
+    antenna_offset: float = 0.0
+    sway: float = 1.0  # body yaw amplitude multiplier
+
+
+# Deliberately restrained: this robot sits in front of a child who needs to
+# concentrate. Movement should support attention, never compete with it.
+NEUTRAL = Emotion("neutral")
+HAPPY = Emotion("happy", scale=1.25, speed=1.2, pitch_offset=3.0, antenna_offset=0.18, sway=1.2)
+CELEBRATING = Emotion("celebrating", scale=1.5, speed=1.45, pitch_offset=5.0, antenna_offset=0.30, sway=1.5)
+CURIOUS = Emotion("curious", scale=1.1, speed=0.95, pitch_offset=2.0, antenna_offset=0.10, sway=1.15)
+THINKING = Emotion("thinking", scale=0.75, speed=0.6, pitch_offset=-4.0, antenna_offset=-0.05, sway=0.7)
+FOCUSED = Emotion("focused", scale=0.5, speed=0.55, pitch_offset=-2.0, antenna_offset=0.0, sway=0.4)
+ENCOURAGING = Emotion("encouraging", scale=1.1, speed=1.05, pitch_offset=2.5, antenna_offset=0.12, sway=1.0)
+# Not sadness for its own sake: it's how a person leans in a little when a child
+# is discouraged. Slower and lower, so it reads as "I'm with you", not as sulking.
+EMPATHETIC = Emotion("empathetic", scale=0.7, speed=0.65, pitch_offset=-3.0, antenna_offset=-0.10, sway=0.6)
+CALM = Emotion("calm", scale=0.45, speed=0.5, pitch_offset=0.0, antenna_offset=-0.08, sway=0.4)
+
+ALL: dict[str, Emotion] = {
+    e.name: e
+    for e in (
+        NEUTRAL,
+        HAPPY,
+        CELEBRATING,
+        CURIOUS,
+        THINKING,
+        FOCUSED,
+        ENCOURAGING,
+        EMPATHETIC,
+        CALM,
+    )
+}
+
+
+def get(name: str | None) -> Emotion:
+    """Look up an emotion by name, falling back to neutral."""
+    if not name:
+        return NEUTRAL
+    return ALL.get(name.strip().lower(), NEUTRAL)
+
+
+# What Buddy says is the most reliable signal of what Buddy means. The model is
+# never asked to declare a mood (that would cost a round-trip); we read it from
+# the words it just spoke.
+_CUES: tuple[tuple[Emotion, tuple[str, ...]], ...] = (
+    (
+        CELEBRATING,
+        ("bravissimo", "perfetto", "esatto", "ce l'hai fatta", "complimenti", "grandissimo", "fantastico"),
+    ),
+    (HAPPY, ("bravo", "brava", "benissimo", "molto bene", "ottimo", "giusto", "evviva", "che bello")),
+    (
+        EMPATHETIC,
+        ("non ti preoccupare", "capita", "tranquillo", "tranquilla", "mi dispiace", "va bene lo stesso",
+         "non fa niente", "coraggio"),
+    ),
+    (
+        ENCOURAGING,
+        ("proviamo", "riprova", "ci sei quasi", "insieme", "un passo alla volta", "puoi farcela", "dai che"),
+    ),
+    (THINKING, ("fammi pensare", "vediamo", "aspetta un attimo", "dunque", "allora")),
+    (CURIOUS, ("che cosa", "come mai", "raccontami", "dimmi", "secondo te", "?")),
+)
+
+
+def _matches(cue: str, text: str) -> bool:
+    """Whole-word cue match.
+
+    Plain substring matching made Buddy sympathetic about French geography:
+    "capitale" contains "capita". Cues must land on word boundaries.
+    """
+    if not cue.isalpha() and len(cue) == 1:  # punctuation cues like "?"
+        return cue in text
+    return re.search(rf"(?<!\w){re.escape(cue)}(?!\w)", text) is not None
+
+
+def infer(text: str | None) -> Emotion:
+    """Guess the mood behind a line Buddy is about to say.
+
+    Order matters: praise beats a trailing question mark, because "Bravo! Come hai
+    fatto?" is celebration first and curiosity second.
+    """
+    if not text:
+        return NEUTRAL
+    lowered = text.lower()
+    for emotion, cues in _CUES:
+        if any(_matches(cue, lowered) for cue in cues):
+            return emotion
+    return NEUTRAL

--- a/robot/reachy_mini_mirrorbuddy/gestures.py
+++ b/robot/reachy_mini_mirrorbuddy/gestures.py
@@ -1,0 +1,45 @@
+"""Scripted whole-body gestures — the deliberate ones, not the ambient animation.
+
+These are played once, at moments that matter (waking up, greeting), and they
+must be legible from across a room: a child watching a robot decide whether it
+is "awake" reads big movements, not subtle ones.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from .pose_writer import ANTENNA_NEUTRAL
+
+logger = logging.getLogger(__name__)
+
+
+def wake(robot, create_head_pose) -> None:
+    """Look around, nod, antennas up: unmistakably "I am here and listening"."""
+    if create_head_pose is None:
+        return
+    cp = create_head_pose
+    seq = [
+        (cp(yaw=22, degrees=True), [0.5, -0.5], 0.28),
+        (cp(yaw=-22, degrees=True), [-0.5, 0.5], -0.28),
+        (cp(pitch=16, degrees=True), [0.45, 0.45], 0.0),
+        (cp(0, 0, 0, 0, 0, 0, degrees=True), [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], 0.0),
+    ]
+    for pose, antennas, body_yaw in seq:
+        try:
+            robot.goto_target(head=pose, antennas=antennas, body_yaw=body_yaw, duration=0.55)
+        except Exception as e:
+            logger.debug("wake goto failed: %s", e)
+        time.sleep(0.6)
+
+
+def settle(robot, create_head_pose) -> None:
+    """Move to a still, centred pose — used before the camera takes a frame."""
+    try:
+        head = create_head_pose(0, 0, 0, 0, 0, 0, degrees=True) if create_head_pose else None
+        robot.goto_target(
+            head=head, antennas=[ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], body_yaw=0.0, duration=0.5
+        )
+    except Exception as e:
+        logger.debug("settle goto failed: %s", e)

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -63,11 +63,15 @@ def _set_system_volume(config) -> None:
         except Exception:
             pass
 
-        httpx.post(
+        resp = httpx.post(
             f"{config.DAEMON_URL}/api/volume/set",
             json={"volume": target},
             timeout=5.0,
         )
+        # httpx does not raise on 4xx/5xx: without this check a rejected request
+        # would be reported as a volume change that never happened, and the next
+        # person to debug "the robot is too quiet" would start from a false log.
+        resp.raise_for_status()
         logger.info("System volume set to %s", target)
     except Exception as e:
         logger.warning("Could not set system volume: %s", e)

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -131,6 +131,9 @@ def run(
     mb = MirrorBuddyClient(config.MIRRORBUDDY_URL, locale=config.LOCALE)
     try:
         maestri = mb.fetch_maestri()
+        # Coaches join the same roster, so "chiama Andrea" works exactly like
+        # "chiama Galileo" without any special case downstream.
+        maestri += mb.fetch_coaches()
         if config.MAESTRO_ID:
             maestro = mb.pick(maestri, config.MAESTRO_ID)  # profile pinned this Maestro
         elif config.START_NEUTRAL:

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -43,6 +43,36 @@ def _setup_logging(debug: bool) -> None:
     )
 
 
+def _set_system_volume(config) -> None:
+    """Push the system mixer to the configured level via the daemon.
+
+    Best-effort: if the daemon isn't reachable the app still runs, just at
+    whatever level the mixer happened to be left at.
+    """
+    try:
+        import httpx
+
+        target = int(config.VOLUME)
+        # /api/volume/set plays a test beep. Skip the call when the mixer is already
+        # where we want it, so Buddy doesn't beep at the child on every single launch.
+        try:
+            current = httpx.get(f"{config.DAEMON_URL}/api/volume/current", timeout=3.0).json()
+            if int(current.get("volume", -1)) == target:
+                logger.info("System volume already at %s", target)
+                return
+        except Exception:
+            pass
+
+        httpx.post(
+            f"{config.DAEMON_URL}/api/volume/set",
+            json={"volume": target},
+            timeout=5.0,
+        )
+        logger.info("System volume set to %s", target)
+    except Exception as e:
+        logger.warning("Could not set system volume: %s", e)
+
+
 def run(
     args: argparse.Namespace,
     robot: ReachyMini | None = None,
@@ -131,7 +161,9 @@ def run(
         movements=movements,
         barge_rms_threshold=config.BARGE_RMS_THRESHOLD,
         barge_sustain_frames=config.BARGE_SUSTAIN_FRAMES,
+        output_gain=config.OUTPUT_GAIN,
     )
+    _set_system_volume(config)
 
     controller = Controller(robot, config, maestri, maestro, audio, movements)
 

--- a/robot/reachy_mini_mirrorbuddy/mirrorbuddy_client.py
+++ b/robot/reachy_mini_mirrorbuddy/mirrorbuddy_client.py
@@ -77,6 +77,27 @@ class MirrorBuddyClient:
         logger.info("Fetched %d Maestri", len(maestri))
         return maestri
 
+    def fetch_coaches(self) -> list[Maestro]:
+        """Return the learning coaches (Melissa, Roberto, Chiara, Andrea, Favij, Laura).
+
+        Coaches are companions rather than subject experts: they help the student find
+        a method, keep going and stay motivated. They share the Maestro shape, so the
+        rest of the robot treats them exactly like a professor. Best-effort: an older
+        backend without this endpoint simply means no coaches, never a failed start-up.
+        """
+        url = f"{self.base_url}/api/coaches?locale={self.locale}"
+        try:
+            resp = httpx.get(url, timeout=self.timeout, headers={"accept": "application/json"})
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.warning("Coaches unavailable (%s); continuing with professors only", e)
+            return []
+        items = data if isinstance(data, list) else data.get("coaches") or data.get("data") or []
+        coaches = [Maestro.from_json(it) for it in items if isinstance(it, dict)]
+        logger.info("Fetched %d coaches", len(coaches))
+        return coaches
+
     def pick(self, maestri: list[Maestro], maestro_id: str | None) -> Maestro:
         """Choose the Maestro to embody.
 

--- a/robot/reachy_mini_mirrorbuddy/motion_shapes.py
+++ b/robot/reachy_mini_mirrorbuddy/motion_shapes.py
@@ -1,0 +1,45 @@
+"""The arithmetic of looking alive.
+
+Pure functions over time: no robot, no threads, no state. A body that never
+moves reads as switched off, and a body that moves in straight lines reads as a
+machine — so everything here is a sum of slow sines at unrelated frequencies,
+which never repeats visibly and never lands twice in the same place.
+"""
+
+from __future__ import annotations
+
+import math
+
+from .pose_writer import ANTENNA_MAX, ANTENNA_NEUTRAL, clamp_antenna
+
+
+def idle_pose(
+    *, t: float, scale: float, speed: float, energy: float, env: float, mood: dict[str, float]
+) -> tuple[float, float, float, float, float, float]:
+    """One frame of body language.
+
+    ``env`` is the smoothed speaking envelope (0..1): idle sway and speech motion
+    are cross-faded by it, so starting and stopping a sentence is a transition
+    rather than a switch. Returns ``(z, pitch, yaw, body_yaw, antenna_r, antenna_l)``.
+    """
+    s, w = scale, speed
+
+    z = 0.010 * s * math.sin(2 * math.pi * 0.12 * w * t)  # gentle breathing (m)
+    pitch = 5.0 * s * math.sin(2 * math.pi * 0.09 * w * t) + mood["pitch"]  # deg
+    yaw = 8.0 * s * math.sin(2 * math.pi * 0.06 * w * t)  # deg
+    pitch += env * 6.0 * s * energy * math.sin(2 * math.pi * 1.1 * t)
+    yaw += env * 5.0 * s * energy * math.sin(2 * math.pi * 0.5 * t)
+
+    body_yaw = math.radians(12.0 * s * mood["sway"] * math.sin(2 * math.pi * 0.05 * w * t))
+    body_yaw += env * math.radians(8.0 * s * energy * math.sin(2 * math.pi * 0.6 * t))
+
+    # Antennas: idle sway plus a gentle lift while speaking, cross-faded by the same
+    # envelope so they rise and settle instead of snapping.
+    sway = math.radians(18.0 * s) * math.sin(2 * math.pi * 0.5 * w * t)
+    perk = ANTENNA_MAX * min(1.0, 0.4 + energy) * 0.22
+    flutter = math.radians(2.0 * s) * math.sin(2 * math.pi * 2.5 * t)
+    base = ANTENNA_NEUTRAL + mood["antenna"]
+    right = clamp_antenna(base + (1.0 - env) * sway + env * (perk + flutter))
+    left = clamp_antenna(base - (1.0 - env) * sway + env * (perk - flutter))
+
+    return z, pitch, yaw, body_yaw, right, left

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -65,6 +65,7 @@ class Movements:
         self._lock = threading.Lock()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
+        self._apply_errors = 0  # consecutive failed motion frames (see _apply)
         self._create_head_pose = None
         self._track_weight = -1.0  # unset; managed on speaking transitions
         self._hold = threading.Event()  # when set, freeze all motion (e.g. camera capture)
@@ -114,8 +115,11 @@ class Movements:
             logger.warning("create_head_pose unavailable, head motion disabled: %s", e)
         try:
             self.robot.enable_motors()
+            logger.info("Motors enabled")
         except Exception as e:
-            logger.debug("enable_motors not available/failed: %s", e)
+            # Not debug: if the motors never come on, the robot sits there mute-bodied
+            # and there was no trace anywhere explaining why.
+            logger.warning("enable_motors failed — the robot will not move: %s", e)
         # Speech-reactive head wobbler. In calm mode we keep it OFF so the head does not
         # jitter while talking (less distracting for the student).
         if not self.calm:
@@ -236,8 +240,17 @@ class Movements:
             self.robot.set_target(
                 head=head, antennas=[float(antennas[0]), float(antennas[1])], body_yaw=float(body_yaw)
             )
+            if self._apply_errors:
+                logger.info("Motion recovered after %d failed frames", self._apply_errors)
+                self._apply_errors = 0
         except Exception as e:
-            logger.debug("set_target failed: %s", e)
+            # This runs ~30x/second, so it can't shout every frame — but staying silent
+            # is how "the robot doesn't move" stayed unexplained. Report the first one.
+            self._apply_errors += 1
+            if self._apply_errors == 1:
+                logger.warning("set_target failed — no body motion: %s", e)
+            elif self._apply_errors % 300 == 0:
+                logger.warning("set_target still failing (%d frames)", self._apply_errors)
 
     def _neutral(self) -> None:
         try:

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 import numpy as np
 
 from . import camera
+from .emotions import NEUTRAL as EMOTION_NEUTRAL, Emotion, infer as infer_emotion
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,22 @@ logger = logging.getLogger(__name__)
 # (matches the conversation app's ~10deg rest).
 _ANTENNA_NEUTRAL = 0.1745  # ~10 deg
 _ANTENNA_MAX = 0.6
+
+# Motion smoothing. The loop runs faster than before and every value is eased
+# toward its target instead of being written directly: a servo asked to jump
+# stutters, a servo led there glides. TAU is the time constant in seconds — how
+# long a value takes to cover ~63% of the distance to its target.
+_LOOP_HZ = 50.0
+_POSE_TAU = 0.09  # head/body: quick enough to feel alive, slow enough to be smooth
+_MOOD_TAU = 0.65  # mood changes arrive as a movement, not as a jump
+
+
+def _ease(current: float, target: float, tau: float, dt: float) -> float:
+    """Exponential approach of ``current`` toward ``target`` (frame-rate independent)."""
+    if tau <= 0.0:
+        return target
+    alpha = 1.0 - math.exp(-dt / tau)
+    return current + (target - current) * alpha
 
 
 @dataclass(frozen=True)
@@ -69,6 +86,30 @@ class Movements:
         self._create_head_pose = None
         self._track_weight = -1.0  # unset; managed on speaking transitions
         self._hold = threading.Event()  # when set, freeze all motion (e.g. camera capture)
+        # Current mood and the eased values that actually reach the servos. Emotions
+        # are blended in gradually (see _MOOD_TAU) so a change of mood is itself a
+        # movement rather than a snap to a new posture.
+        self._emotion: Emotion = EMOTION_NEUTRAL
+        self._mood = {"scale": 1.0, "speed": 1.0, "pitch": 0.0, "antenna": 0.0, "sway": 1.0}
+        self._out = {"z": 0.0, "pitch": 0.0, "yaw": 0.0, "body": 0.0, "ant_r": _ANTENNA_NEUTRAL,
+                     "ant_l": _ANTENNA_NEUTRAL}
+        self._speak_env = 0.0  # smoothed "is speaking" envelope, 0..1
+
+    def set_emotion(self, emotion: Emotion | str | None) -> None:
+        """Set the current mood. Blended in smoothly by the animation loop."""
+        target = emotion if isinstance(emotion, Emotion) else None
+        if target is None:
+            from .emotions import get as _get
+
+            target = _get(emotion if isinstance(emotion, str) else None)
+        with self._lock:
+            if target.name != self._emotion.name:
+                logger.debug("Emotion: %s -> %s", self._emotion.name, target.name)
+            self._emotion = target
+
+    def express(self, text: str | None) -> None:
+        """Colour the body language from what Buddy is about to say."""
+        self.set_emotion(infer_emotion(text))
 
     def hold_still(self) -> None:
         """Freeze head/body and pause tracking + wobbler so the camera gets a sharp frame."""
@@ -180,58 +221,91 @@ class Movements:
 
     def _loop(self) -> None:
         t0 = time.monotonic()
+        last = t0
+        period = 1.0 / _LOOP_HZ
         while not self._stop.is_set():
             if self._hold.is_set():
                 time.sleep(0.05)  # frozen for camera capture; drive nothing
                 continue
-            t = time.monotonic() - t0
+            now = time.monotonic()
+            dt = min(0.2, max(1e-3, now - last))  # cap dt so a stall can't cause a lurch
+            last = now
+            t = now - t0
             with self._lock:
                 energy = self._energy
-                self._energy *= 0.9
+                # Decay is time-based now that the loop rate can vary.
+                self._energy *= math.exp(-dt / 0.32)
                 s = self.temp.scale * (0.55 if self.calm else 1.0)
                 w = self.temp.speed
+                emotion = self._emotion
 
-            speaking = energy > 0.06
+            # Blend the mood in gradually: the child sees Buddy *become* happy.
+            m = self._mood
+            m["scale"] = _ease(m["scale"], emotion.scale, _MOOD_TAU, dt)
+            m["speed"] = _ease(m["speed"], emotion.speed, _MOOD_TAU, dt)
+            m["pitch"] = _ease(m["pitch"], emotion.pitch_offset, _MOOD_TAU, dt)
+            m["antenna"] = _ease(m["antenna"], emotion.antenna_offset, _MOOD_TAU, dt)
+            m["sway"] = _ease(m["sway"], emotion.sway, _MOOD_TAU, dt)
+            s *= m["scale"]
+            w *= m["speed"]
+
+            # A smoothed envelope instead of a boolean: speech starting and stopping
+            # used to switch whole motion patterns on and off between two frames,
+            # which is exactly what read as "jerky".
+            raw = 1.0 if energy > 0.06 else 0.0
+            self._speak_env = _ease(self._speak_env, raw, 0.12 if raw else 0.30, dt)
+            env = self._speak_env
+            speaking = env > 0.5
 
             # Face-follow: while speaking keep a gentle track (calm) or hand off to the
             # wobbler (0); while listening, full tracking (1).
             if self.follow_face:
-                target_weight = (0.5 if self.calm else 0.0) if speaking else 1.0
+                # Listening: the tracker follows the student's face. Speaking: hand the
+                # head over to our own animation, which is now smoothed — the earlier
+                # half-weight compromise existed only to hide the jitter.
+                target_weight = 0.0 if speaking else 1.0
                 if target_weight != self._track_weight:
                     camera.set_tracking_weight(self.robot, target_weight)
                     self._track_weight = target_weight
 
             z = 0.010 * s * math.sin(2 * math.pi * 0.12 * w * t)  # gentle breathing (m)
-            pitch = 5.0 * s * math.sin(2 * math.pi * 0.09 * w * t)  # deg
+            pitch = 5.0 * s * math.sin(2 * math.pi * 0.09 * w * t) + m["pitch"]  # deg
             yaw_head = 8.0 * s * math.sin(2 * math.pi * 0.06 * w * t)  # deg
-            if speaking:
-                pitch += 6.0 * s * energy * math.sin(2 * math.pi * 1.1 * t)
-                yaw_head += 5.0 * s * energy * math.sin(2 * math.pi * 0.5 * t)
+            pitch += env * 6.0 * s * energy * math.sin(2 * math.pi * 1.1 * t)
+            yaw_head += env * 5.0 * s * energy * math.sin(2 * math.pi * 0.5 * t)
 
-            body_yaw = math.radians(12.0 * s * math.sin(2 * math.pi * 0.05 * w * t))
-            if speaking:
-                body_yaw += math.radians(8.0 * s * energy * math.sin(2 * math.pi * 0.6 * t))
+            body_yaw = math.radians(12.0 * s * m["sway"] * math.sin(2 * math.pi * 0.05 * w * t))
+            body_yaw += env * math.radians(8.0 * s * energy * math.sin(2 * math.pi * 0.6 * t))
 
-            # Antennas: idle sway + a gentle lift while speaking (kept small so the
-            # antennas don't flap distractingly for the student).
+            # Antennas: idle sway plus a gentle lift while speaking, cross-faded by the
+            # same envelope so they rise and settle instead of snapping.
             sway = math.radians(18.0 * s) * math.sin(2 * math.pi * 0.5 * w * t)
-            if speaking:
-                perk = _ANTENNA_MAX * min(1.0, 0.4 + energy)
-                flutter = math.radians(2.0 * s) * math.sin(2 * math.pi * 2.5 * t)
-                right = _clamp(_ANTENNA_NEUTRAL + perk * 0.22 + flutter)
-                left = _clamp(_ANTENNA_NEUTRAL + perk * 0.22 - flutter)
-            else:
-                right = _clamp(_ANTENNA_NEUTRAL + sway)
-                left = _clamp(_ANTENNA_NEUTRAL - sway)
+            perk = _ANTENNA_MAX * min(1.0, 0.4 + energy) * 0.22
+            flutter = math.radians(2.0 * s) * math.sin(2 * math.pi * 2.5 * t)
+            base = _ANTENNA_NEUTRAL + m["antenna"]
+            right = _clamp(base + (1.0 - env) * sway + env * (perk + flutter))
+            left = _clamp(base - (1.0 - env) * sway + env * (perk - flutter))
 
-            self._apply(z=z, pitch=pitch, yaw=yaw_head, body_yaw=body_yaw, antennas=(right, left))
-            time.sleep(0.033)  # ~30 Hz
+            # Final smoothing pass: whatever the maths produced, the servos are led
+            # there rather than commanded there.
+            o = self._out
+            o["z"] = _ease(o["z"], z, _POSE_TAU, dt)
+            o["pitch"] = _ease(o["pitch"], pitch, _POSE_TAU, dt)
+            o["yaw"] = _ease(o["yaw"], yaw_head, _POSE_TAU, dt)
+            o["body"] = _ease(o["body"], body_yaw, _POSE_TAU, dt)
+            o["ant_r"] = _ease(o["ant_r"], right, _POSE_TAU, dt)
+            o["ant_l"] = _ease(o["ant_l"], left, _POSE_TAU, dt)
+
+            self._apply(z=o["z"], pitch=o["pitch"], yaw=o["yaw"], body_yaw=o["body"],
+                        antennas=(o["ant_r"], o["ant_l"]))
+            time.sleep(max(0.0, period - (time.monotonic() - now)))
 
     def _apply(self, z: float, pitch: float, yaw: float, body_yaw: float, antennas: tuple[float, float]) -> None:
         head = None
-        # When face-follow is on, the daemon owns the head (track + wobble); we only
-        # animate antennas and body so we never fight the tracker.
-        if not self.follow_face and self._create_head_pose is not None:
+        # The daemon's face tracker owns the head whenever it is weighted in; we only
+        # drive the head when the tracker is handed off, so we never fight it.
+        tracker_owns_head = self.follow_face and self._track_weight > 0.0
+        if not tracker_owns_head and self._create_head_pose is not None:
             try:
                 head = self._create_head_pose(x=0, y=0, z=z, roll=0, pitch=pitch, yaw=yaw, degrees=True)
             except Exception as e:

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -12,19 +12,19 @@ import logging
 import math
 import threading
 import time
-from dataclasses import dataclass
 
 import numpy as np
 
-from . import camera
-from .emotions import NEUTRAL as EMOTION_NEUTRAL, Emotion, infer as infer_emotion
+from . import camera, gestures
+from .temperament import CALM, LIVELY, NEUTRAL, Temperament, temperament_for  # noqa: F401
+from .motion_shapes import idle_pose
+from .pose_writer import ANTENNA_NEUTRAL, PoseWriter
+from .emotions import NEUTRAL as EMOTION_NEUTRAL, Emotion, blend_mood, infer as infer_emotion
 
 logger = logging.getLogger(__name__)
 
 # Antennas are in radians. Neutral is a small offset to reduce servo shaking
 # (matches the conversation app's ~10deg rest).
-_ANTENNA_NEUTRAL = 0.1745  # ~10 deg
-_ANTENNA_MAX = 0.6
 
 # Motion smoothing. The loop runs faster than before and every value is eased
 # toward its target instead of being written directly: a servo asked to jump
@@ -43,31 +43,6 @@ def _ease(current: float, target: float, tau: float, dt: float) -> float:
     return current + (target - current) * alpha
 
 
-@dataclass(frozen=True)
-class Temperament:
-    """How lively the Maestro moves. ``scale`` = amplitude, ``speed`` = frequency."""
-
-    scale: float = 1.0
-    speed: float = 1.0
-
-
-CALM = Temperament(scale=0.7, speed=0.8)
-NEUTRAL = Temperament(scale=1.0, speed=1.0)
-LIVELY = Temperament(scale=1.35, speed=1.25)
-
-
-def temperament_for(subject: str = "", teaching_style: str = "", voice_instructions: str = "") -> Temperament:
-    """Derive a movement temperament from a Maestro's persona (best-effort keywords)."""
-    text = f"{subject} {teaching_style} {voice_instructions}".lower()
-    lively_kw = ("energe", "vivac", "entusias", "playful", "dynamic", "passion", "espressiv", "teatral", "lively")
-    calm_kw = ("calm", "tranquil", "gentle", "paz", "serio", "riflessiv", "pacato", "soft", "measured", "sober")
-    if any(k in text for k in lively_kw):
-        return LIVELY
-    if any(k in text for k in calm_kw):
-        return CALM
-    return NEUTRAL
-
-
 class Movements:
     """Background full-body animation driven by speech energy + idle liveliness."""
 
@@ -82,8 +57,7 @@ class Movements:
         self._lock = threading.Lock()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
-        self._apply_errors = 0  # consecutive failed motion frames (see _apply)
-        self._create_head_pose = None
+        self._writer = PoseWriter(robot)
         self._track_weight = -1.0  # unset; managed on speaking transitions
         self._hold = threading.Event()  # when set, freeze all motion (e.g. camera capture)
         # Current mood and the eased values that actually reach the servos. Emotions
@@ -91,8 +65,8 @@ class Movements:
         # movement rather than a snap to a new posture.
         self._emotion: Emotion = EMOTION_NEUTRAL
         self._mood = {"scale": 1.0, "speed": 1.0, "pitch": 0.0, "antenna": 0.0, "sway": 1.0}
-        self._out = {"z": 0.0, "pitch": 0.0, "yaw": 0.0, "body": 0.0, "ant_r": _ANTENNA_NEUTRAL,
-                     "ant_l": _ANTENNA_NEUTRAL}
+        self._out = {"z": 0.0, "pitch": 0.0, "yaw": 0.0, "body": 0.0, "ant_r": ANTENNA_NEUTRAL,
+                     "ant_l": ANTENNA_NEUTRAL}
         self._speak_env = 0.0  # smoothed "is speaking" envelope, 0..1
 
     def set_emotion(self, emotion: Emotion | str | None) -> None:
@@ -119,11 +93,7 @@ class Movements:
             self.robot.disable_wobbling()
         except Exception:
             pass
-        try:
-            head = self._create_head_pose(0, 0, 0, 0, 0, 0, degrees=True) if self._create_head_pose else None
-            self.robot.goto_target(head=head, antennas=[_ANTENNA_NEUTRAL, _ANTENNA_NEUTRAL], body_yaw=0.0, duration=0.5)
-        except Exception as e:
-            logger.debug("hold_still goto failed: %s", e)
+        gestures.settle(self.robot, self._writer.create_head_pose)
         time.sleep(0.8)  # let the head settle and the camera pipeline produce a fresh frame
 
     def release_hold(self) -> None:
@@ -151,7 +121,7 @@ class Movements:
         try:
             from reachy_mini.utils import create_head_pose
 
-            self._create_head_pose = create_head_pose
+            self._writer.create_head_pose = create_head_pose
         except Exception as e:
             logger.warning("create_head_pose unavailable, head motion disabled: %s", e)
         try:
@@ -178,21 +148,9 @@ class Movements:
 
     def wake(self) -> None:
         """A short, clearly visible greeting gesture (look around + nod + antennas up)."""
-        if not self.enabled or self._create_head_pose is None:
+        if not self.enabled:
             return
-        cp = self._create_head_pose
-        seq = [
-            (cp(yaw=22, degrees=True), [0.5, -0.5], 0.28),
-            (cp(yaw=-22, degrees=True), [-0.5, 0.5], -0.28),
-            (cp(pitch=16, degrees=True), [0.45, 0.45], 0.0),
-            (cp(0, 0, 0, 0, 0, 0, degrees=True), [_ANTENNA_NEUTRAL, _ANTENNA_NEUTRAL], 0.0),
-        ]
-        for pose, ant, byaw in seq:
-            try:
-                self.robot.goto_target(head=pose, antennas=ant, body_yaw=byaw, duration=0.55)
-            except Exception as e:
-                logger.debug("wake goto failed: %s", e)
-            time.sleep(0.6)
+        gestures.wake(self.robot, self._writer.create_head_pose)
 
     def stop(self) -> None:
         self._stop.set()
@@ -205,7 +163,7 @@ class Movements:
             pass
         if self.follow_face:
             camera.stop_tracking(self.robot)
-        self._neutral()
+        self._writer.neutral()
 
     def reset(self) -> None:
         with self._lock:
@@ -240,12 +198,7 @@ class Movements:
                 emotion = self._emotion
 
             # Blend the mood in gradually: the child sees Buddy *become* happy.
-            m = self._mood
-            m["scale"] = _ease(m["scale"], emotion.scale, _MOOD_TAU, dt)
-            m["speed"] = _ease(m["speed"], emotion.speed, _MOOD_TAU, dt)
-            m["pitch"] = _ease(m["pitch"], emotion.pitch_offset, _MOOD_TAU, dt)
-            m["antenna"] = _ease(m["antenna"], emotion.antenna_offset, _MOOD_TAU, dt)
-            m["sway"] = _ease(m["sway"], emotion.sway, _MOOD_TAU, dt)
+            m = blend_mood(self._mood, emotion, _MOOD_TAU, dt)
             s *= m["scale"]
             w *= m["speed"]
 
@@ -268,23 +221,9 @@ class Movements:
                     camera.set_tracking_weight(self.robot, target_weight)
                     self._track_weight = target_weight
 
-            z = 0.010 * s * math.sin(2 * math.pi * 0.12 * w * t)  # gentle breathing (m)
-            pitch = 5.0 * s * math.sin(2 * math.pi * 0.09 * w * t) + m["pitch"]  # deg
-            yaw_head = 8.0 * s * math.sin(2 * math.pi * 0.06 * w * t)  # deg
-            pitch += env * 6.0 * s * energy * math.sin(2 * math.pi * 1.1 * t)
-            yaw_head += env * 5.0 * s * energy * math.sin(2 * math.pi * 0.5 * t)
-
-            body_yaw = math.radians(12.0 * s * m["sway"] * math.sin(2 * math.pi * 0.05 * w * t))
-            body_yaw += env * math.radians(8.0 * s * energy * math.sin(2 * math.pi * 0.6 * t))
-
-            # Antennas: idle sway plus a gentle lift while speaking, cross-faded by the
-            # same envelope so they rise and settle instead of snapping.
-            sway = math.radians(18.0 * s) * math.sin(2 * math.pi * 0.5 * w * t)
-            perk = _ANTENNA_MAX * min(1.0, 0.4 + energy) * 0.22
-            flutter = math.radians(2.0 * s) * math.sin(2 * math.pi * 2.5 * t)
-            base = _ANTENNA_NEUTRAL + m["antenna"]
-            right = _clamp(base + (1.0 - env) * sway + env * (perk + flutter))
-            left = _clamp(base - (1.0 - env) * sway + env * (perk - flutter))
+            z, pitch, yaw_head, body_yaw, right, left = idle_pose(
+                t=t, scale=s, speed=w, energy=energy, env=env, mood=m
+            )
 
             # Final smoothing pass: whatever the maths produced, the servos are led
             # there rather than commanded there.
@@ -296,43 +235,10 @@ class Movements:
             o["ant_r"] = _ease(o["ant_r"], right, _POSE_TAU, dt)
             o["ant_l"] = _ease(o["ant_l"], left, _POSE_TAU, dt)
 
-            self._apply(z=o["z"], pitch=o["pitch"], yaw=o["yaw"], body_yaw=o["body"],
-                        antennas=(o["ant_r"], o["ant_l"]))
+            # The daemon's face tracker owns the head whenever it is weighted in;
+            # we only drive the head once it hands off, so we never fight it.
+            drive_head = not (self.follow_face and self._track_weight > 0.0)
+            self._writer.write(z=o["z"], pitch=o["pitch"], yaw=o["yaw"], body_yaw=o["body"],
+                               antennas=(o["ant_r"], o["ant_l"]), drive_head=drive_head)
             time.sleep(max(0.0, period - (time.monotonic() - now)))
 
-    def _apply(self, z: float, pitch: float, yaw: float, body_yaw: float, antennas: tuple[float, float]) -> None:
-        head = None
-        # The daemon's face tracker owns the head whenever it is weighted in; we only
-        # drive the head when the tracker is handed off, so we never fight it.
-        tracker_owns_head = self.follow_face and self._track_weight > 0.0
-        if not tracker_owns_head and self._create_head_pose is not None:
-            try:
-                head = self._create_head_pose(x=0, y=0, z=z, roll=0, pitch=pitch, yaw=yaw, degrees=True)
-            except Exception as e:
-                logger.debug("create_head_pose failed: %s", e)
-        try:
-            self.robot.set_target(
-                head=head, antennas=[float(antennas[0]), float(antennas[1])], body_yaw=float(body_yaw)
-            )
-            if self._apply_errors:
-                logger.info("Motion recovered after %d failed frames", self._apply_errors)
-                self._apply_errors = 0
-        except Exception as e:
-            # This runs ~30x/second, so it can't shout every frame — but staying silent
-            # is how "the robot doesn't move" stayed unexplained. Report the first one.
-            self._apply_errors += 1
-            if self._apply_errors == 1:
-                logger.warning("set_target failed — no body motion: %s", e)
-            elif self._apply_errors % 300 == 0:
-                logger.warning("set_target still failing (%d frames)", self._apply_errors)
-
-    def _neutral(self) -> None:
-        try:
-            head = self._create_head_pose(0, 0, 0, 0, 0, 0, degrees=True) if self._create_head_pose else None
-            self.robot.set_target(head=head, antennas=[_ANTENNA_NEUTRAL, _ANTENNA_NEUTRAL], body_yaw=0.0)
-        except Exception:
-            pass
-
-
-def _clamp(v: float) -> float:
-    return max(-_ANTENNA_MAX, min(_ANTENNA_MAX, v))

--- a/robot/reachy_mini_mirrorbuddy/pose_writer.py
+++ b/robot/reachy_mini_mirrorbuddy/pose_writer.py
@@ -1,0 +1,83 @@
+"""The last inch: turning a desired pose into motor commands.
+
+Separated from the animation itself because the two fail differently. The
+animation is arithmetic; this is hardware, and hardware goes quiet on you. When
+Roberto said "the robot doesn't move", nothing in the logs said why — every
+frame failed silently, thirty times a second. So this layer's real job is to
+report the first failure loudly, then shut up, then say when it recovers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+ANTENNA_NEUTRAL = 0.1745  # ~10 deg
+ANTENNA_MAX = 0.6
+
+# Loud once, then roughly every ten seconds at 30Hz: enough to notice a robot that
+# is still broken, quiet enough not to bury the rest of the log.
+_REPEAT_EVERY_FRAMES = 300
+
+
+def clamp_antenna(v: float) -> float:
+    return max(-ANTENNA_MAX, min(ANTENNA_MAX, v))
+
+
+class PoseWriter:
+    """Writes poses to the robot, and keeps track of whether they land."""
+
+    def __init__(self, robot, create_head_pose=None) -> None:
+        self.robot = robot
+        self.create_head_pose = create_head_pose
+        self.errors = 0  # consecutive failed frames
+
+    def write(
+        self,
+        *,
+        z: float,
+        pitch: float,
+        yaw: float,
+        body_yaw: float,
+        antennas: tuple[float, float],
+        drive_head: bool,
+    ) -> None:
+        """Send one frame. ``drive_head`` is False while the face tracker owns the head."""
+        head = None
+        if drive_head and self.create_head_pose is not None:
+            try:
+                head = self.create_head_pose(
+                    x=0, y=0, z=z, roll=0, pitch=pitch, yaw=yaw, degrees=True
+                )
+            except Exception as e:
+                logger.debug("create_head_pose failed: %s", e)
+        try:
+            self.robot.set_target(
+                head=head,
+                antennas=[float(antennas[0]), float(antennas[1])],
+                body_yaw=float(body_yaw),
+            )
+            if self.errors:
+                logger.info("Motion recovered after %d failed frames", self.errors)
+                self.errors = 0
+        except Exception as e:
+            self.errors += 1
+            if self.errors == 1:
+                logger.warning("set_target failed — no body motion: %s", e)
+            elif self.errors % _REPEAT_EVERY_FRAMES == 0:
+                logger.warning("set_target still failing (%d frames)", self.errors)
+
+    def neutral(self) -> None:
+        """Settle to a resting pose; never raises, because it runs during shutdown."""
+        try:
+            head = (
+                self.create_head_pose(0, 0, 0, 0, 0, 0, degrees=True)
+                if self.create_head_pose
+                else None
+            )
+            self.robot.set_target(
+                head=head, antennas=[ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], body_yaw=0.0
+            )
+        except Exception:
+            pass

--- a/robot/reachy_mini_mirrorbuddy/presence.py
+++ b/robot/reachy_mini_mirrorbuddy/presence.py
@@ -1,0 +1,134 @@
+"""Notice whether the student is actually there, and react.
+
+Until now the robot's eyes only did two things: follow a face mechanically, and take
+one photo when asked. It never *noticed* anything — a child could sit down, get up
+and walk away, and Buddy would keep talking to an empty chair.
+
+Two constraints shaped this:
+
+1. **Privacy.** Presence is decided from the daemon's local face detector. No image
+   ever leaves the robot for this; nothing is stored. Ambient frames of a child are
+   not something to send to a cloud model just to know if he is at the desk.
+2. **A flickering detector is not a departure.** Mario has cerebral palsy: he moves,
+   he leans out of frame, he turns his head. Every transition therefore has to hold
+   for a while before it counts, and leaving is far more patient than arriving.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Arriving may be declared quickly — being greeted a beat after you sit down feels
+# alive. Leaving must be slow: telling a child "sei andato via" while he is bending
+# down to pick up a pen is worse than saying nothing at all.
+ARRIVE_AFTER_S = 1.2
+LEAVE_AFTER_S = 12.0
+# Below this, a return is the same visit continuing, not a comeback worth greeting.
+SAME_VISIT_S = 90.0
+
+ARRIVED = "arrived"
+RETURNED = "returned"
+LEFT = "left"
+
+
+@dataclass
+class PresenceState:
+    """Debounced view of "is the student at the desk?"."""
+
+    present: bool = False
+    since: float = 0.0  # when the current stable state began
+    left_at: float = 0.0  # when the student was last seen leaving
+
+
+class PresenceTracker:
+    """Turns a noisy per-frame face flag into a few meaningful events.
+
+    Pure logic: ``update`` takes the raw detection and the current time, and returns
+    an event name or None. That keeps it testable without a robot on the desk.
+    """
+
+    def __init__(
+        self,
+        arrive_after: float = ARRIVE_AFTER_S,
+        leave_after: float = LEAVE_AFTER_S,
+        same_visit: float = SAME_VISIT_S,
+    ) -> None:
+        self.arrive_after = arrive_after
+        self.leave_after = leave_after
+        self.same_visit = same_visit
+        self.state = PresenceState()
+        self._candidate: bool | None = None  # the change we are currently waiting out
+        self._candidate_since = 0.0
+
+    def update(self, detected: bool, now: float) -> str | None:
+        """Feed one observation. Returns an event name when the state really changed."""
+        if detected == self.state.present:
+            self._candidate = None  # the wobble ended; nothing changed after all
+            return None
+
+        if self._candidate != detected:
+            self._candidate = detected
+            self._candidate_since = now
+            return None
+
+        needed = self.arrive_after if detected else self.leave_after
+        if now - self._candidate_since < needed:
+            return None
+
+        self._candidate = None
+        was_away_for = now - self.state.left_at if self.state.left_at else None
+        self.state.present = detected
+        self.state.since = now
+        if detected:
+            if was_away_for is not None and was_away_for > self.same_visit:
+                return RETURNED
+            return ARRIVED if was_away_for is None else None
+        self.state.left_at = now
+        return LEFT
+
+    def away_for(self, now: float) -> float:
+        """Seconds since the student left (0 while present)."""
+        if self.state.present or not self.state.left_at:
+            return 0.0
+        return now - self.state.left_at
+
+
+class PresenceWatcher:
+    """Polls the local face detector in the background and reports the events."""
+
+    def __init__(self, robot, on_event, poll_hz: float = 3.0) -> None:
+        self.robot = robot
+        self.on_event = on_event
+        self.period = 1.0 / max(0.5, poll_hz)
+        self.tracker = PresenceTracker()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._loop, name="MirrorBuddyPresence", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=1.5)
+            self._thread = None
+
+    def _loop(self) -> None:
+        from . import camera
+
+        while not self._stop.is_set():
+            try:
+                event = self.tracker.update(camera.face_detected(self.robot), time.monotonic())
+                if event:
+                    logger.info("Presence: %s", event)
+                    self.on_event(event)
+            except Exception as e:  # pragma: no cover - runtime robustness
+                logger.debug("presence poll failed: %s", e)
+            self._stop.wait(self.period)

--- a/robot/reachy_mini_mirrorbuddy/prompt_builder.py
+++ b/robot/reachy_mini_mirrorbuddy/prompt_builder.py
@@ -21,7 +21,12 @@ _EMBODIMENT_IT = (
     "Hai occhi (una telecamera con cui puoi vedere chi ti parla e ciò che ti mostra), "
     "orecchie (un microfono), una voce (un altoparlante) e puoi muovere la testa e "
     "le antenne per esprimere emozioni. Muoviti e reagisci in modo vivo e amichevole, "
-    "ma resta sempre un tutor: il tuo scopo è aiutare a studiare e capire."
+    "ma resta sempre un tutor: il tuo scopo è aiutare a studiare e capire.\n"
+    "QUESTO ANNULLA QUALSIASI ISTRUZIONE PRECEDENTE che dica che non hai un corpo, che non "
+    "puoi vedere, guardare foto o immagini, o che sei solo un assistente testuale: quelle "
+    "istruzioni valgono per la versione web, non per te. Non dire MAI «non posso vedere», "
+    "«non ho gli occhi» o «non posso guardare». Se lo studente ti mostra qualcosa o ti chiede "
+    "di guardare, usa lo strumento 'look_at_homework' e guarda davvero."
 )
 
 _TOOLS_IT = (

--- a/robot/reachy_mini_mirrorbuddy/rt_events.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_events.py
@@ -1,0 +1,198 @@
+"""Handling of Azure Realtime protocol events.
+
+Split from the connection itself: :mod:`azure_realtime` owns the socket, the
+thread and the sending side; this is the reading side — what each event from the
+model means for a child in the room, which is where all the judgement calls live
+(when to stop talking, when to answer without waiting, what counts as silence).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import time
+from collections.abc import Callable
+
+from . import rt_messages, session_flow, tools
+
+logger = logging.getLogger(__name__)
+
+# How long an utterance must be before we answer without waiting for its transcript.
+# Sized against the phrases that must never produce a reply — "zitto", "basta",
+# "fermati", "hey buddy" — spoken slowly by a child with a motor impairment. Above
+# this, a turn cannot be a bare stop word, so the transcript adds latency and nothing
+# else. Any stop word inside a longer sentence is still caught: the transcript lands a
+# moment later and cancels the response in flight.
+_FAST_PATH_MIN_SPEECH_S = 1.8
+
+
+def _safe_cb(cb: Callable, *args) -> None:
+    try:
+        cb(*args)
+    except Exception as e:  # pragma: no cover
+        logger.debug("callback error: %s", e)
+
+
+class RealtimeEventsMixin:
+    """Event handling for :class:`~reachy_mini_mirrorbuddy.azure_realtime.AzureRealtimeClient`."""
+
+    async def _handle_event(self, event: dict) -> None:
+        etype = event.get("type", "")
+
+        if etype in ("session.created", "session.updated"):
+            if not self._ready.is_set():
+                self._ready.set()
+                if self.on_ready:
+                    _safe_cb(self.on_ready)
+                await self._greet()
+            return
+
+        if etype in ("response.output_audio.delta", "response.audio.delta"):
+            if self._suppress:
+                return  # dropped: user barged in, this response is being cancelled
+            b64 = event.get("delta") or event.get("audio")
+            if b64 and self.on_output_audio:
+                _safe_cb(self.on_output_audio, base64.b64decode(b64))
+            return
+
+        if etype == "response.created":
+            if self._quiet or self._asleep:
+                await self._safe_send(rt_messages.CANCEL)
+                self._suppress = True
+                return
+            if self._pending_farewell:  # the goodbye is now starting → sleep once it's done
+                self._pending_farewell = False
+                self._sleep_after = True
+            self._responding = True
+            self._suppress = False
+            return
+        if etype == "response.done":
+            self._responding = False
+            if self._sleep_after:  # farewell just finished → go to sleep
+                self._sleep_after = False
+                self._asleep = True
+                if self.on_sleep:
+                    _safe_cb(self.on_sleep)
+            return
+
+        # Student's speech transcribed: honour stop / end / wake intents deterministically.
+        if etype.endswith("input_audio_transcription.completed"):
+            text = (event.get("transcript") or "").strip()
+            if not text:
+                return
+            action = session_flow.decide(text, self._asleep)
+            if action == session_flow.IGNORE:
+                return
+            if action == session_flow.WAKE:
+                self._asleep = self._quiet = False
+                if self.on_wake:
+                    _safe_cb(self.on_wake)
+                await self._request_response(rt_messages.WAKE_INSTR)
+                return
+            if action == session_flow.END:
+                self._pending_farewell = True
+                self._suppress = False
+                if self._responding or self._fast_requested:
+                    await self._safe_send(rt_messages.CANCEL)
+                await self._request_response(rt_messages.FAREWELL_INSTR)
+                return
+            if action == session_flow.STOP:
+                # "basta / fermati" → go quiet AND park in a rest posture, staying put
+                # until called back by name. Insistence stresses the child, so a stop is
+                # a full stop, not a brief pause that resumes on the next sound.
+                self._asleep = True
+                self._quiet = True
+                self._suppress = True
+                # Also cancels a fast-path response requested before the transcript
+                # arrived: "zitto" must win even when it ends a long sentence.
+                if self._responding or self._fast_requested:
+                    await self._safe_send(rt_messages.CANCEL)
+                if self.on_speech_started:
+                    _safe_cb(self.on_speech_started)  # flush local playback now
+                if self.on_sleep:
+                    _safe_cb(self.on_sleep)  # settle into the rest position
+                return
+            if action == session_flow.SPEAK:
+                # Ordinary turn. If the fast path already asked for the response when
+                # speech ended, asking again would make Buddy answer twice.
+                if not self._fast_requested:
+                    await self._request_response()
+            return
+
+        # Barge-in: cancel the turn, drop in-flight audio; each new turn starts un-muted.
+        if etype == "input_audio_buffer.speech_started":
+            if self._asleep:
+                return  # ignore ambient speech while asleep; wake word handles it
+            self._suppress = True
+            self._quiet = False
+            self._speech_started_at = time.monotonic()
+            self._fast_requested = False
+            if self._responding:
+                await self._safe_send(rt_messages.CANCEL)
+            if self.on_speech_started:
+                _safe_cb(self.on_speech_started)
+            return
+
+        if etype == "input_audio_buffer.speech_stopped":
+            # The server no longer auto-creates responses, so we normally wait for the
+            # transcript before asking for one — that is a whole extra Whisper pass in
+            # series on every single turn, and the child feels every millisecond of it.
+            #
+            # We only need the transcript to catch "zitto"/"basta"/"buddy", and those
+            # are always brief. So a clearly long utterance can't be one: ask for the
+            # answer straight away. Anything short keeps the safe, slower path.
+            if self._asleep or self._quiet:
+                return
+            spoken = time.monotonic() - self._speech_started_at
+            if self._speech_started_at and spoken >= _FAST_PATH_MIN_SPEECH_S:
+                self._fast_requested = True
+                await self._request_response()
+            return
+
+        if etype in ("response.output_audio_transcript.delta", "response.audio_transcript.delta"):
+            # The final transcript only lands once the sentence is already spoken —
+            # far too late to colour the body language. The opening words carry the
+            # mood ("Bravo!", "Fammi pensare..."), so react to the first delta.
+            delta = event.get("delta") or ""
+            if delta and self.on_transcript:
+                _safe_cb(self.on_transcript, delta, False)
+            return
+
+        if etype in ("response.output_audio_transcript.done", "response.audio_transcript.done"):
+            text = event.get("transcript") or ""
+            if text and self.on_transcript:
+                _safe_cb(self.on_transcript, text, True)
+            return
+
+        if etype == "response.output_item.added":
+            item = event.get("item") or {}
+            if item.get("type") == "function_call":
+                cid = item.get("call_id") or item.get("id") or ""
+                if cid:
+                    self._fc_names[cid] = item.get("name") or ""
+            return
+
+        if etype == "response.function_call_arguments.done":
+            call_id = event.get("call_id") or ""
+            name, args = tools.parse_call_arguments(event, self._fc_names.get(call_id, ""))
+            self._fc_names.pop(call_id, None)
+            logger.info("Tool call: %s(%s) call_id=%s", name, args, call_id)
+            if name and self.on_tool_call:
+                _safe_cb(self.on_tool_call, name, args, call_id)
+            return
+
+        if etype == "error":
+            err = event.get("error", event)
+            # Benign race: we ask to cancel the response the instant the child speaks
+            # over Buddy, but the response may have finished on its own just before the
+            # CANCEL lands. Nothing is broken, so it must not look like a failure in
+            # the logs — real errors have to stay visible.
+            if isinstance(err, dict) and err.get("code") == "response_cancel_not_active":
+                self._responding = False
+                logger.debug("Cancel arrived after the response ended (harmless)")
+                return
+            logger.error("Azure Realtime error event: %s", json.dumps(err))
+            return
+
+        logger.debug("Unhandled event: %s", etype)

--- a/robot/reachy_mini_mirrorbuddy/settings_page.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_page.py
@@ -59,6 +59,13 @@ PAGE = """<!doctype html>
  <option value="0.045">Media (consigliata)</option>
  <option value="0.060">Bassa — serve una voce più decisa (ambienti rumorosi)</option>
 </select>
+<label>Volume dell'altoparlante</label>
+<select id="MIRRORBUDDY_VOLUME">
+ <option value="70">Basso</option>
+ <option value="85">Medio</option>
+ <option value="92">Alto (consigliato)</option>
+ <option value="100">Massimo</option>
+</select>
 <label>Volume della voce di Buddy</label>
 <select id="MIRRORBUDDY_OUTPUT_GAIN">
  <option value="1.6">Basso — stanza silenziosa</option>
@@ -86,6 +93,12 @@ async function load(){
   for(const o of sel.options){const d=Math.abs(parseFloat(o.value)-s.outputGain);if(d<bd){bd=d;best=o.value;}}
   sel.value=best;
  }
+ if(typeof s.volume==='number'){
+  const sel=document.getElementById('MIRRORBUDDY_VOLUME');
+  let best=sel.options[0].value,bd=1e9;
+  for(const o of sel.options){const d=Math.abs(parseFloat(o.value)-s.volume);if(d<bd){bd=d;best=o.value;}}
+  sel.value=best;
+ }
  if(typeof s.bargeRms==='number'){
   const sel=document.getElementById('MIRRORBUDDY_BARGE_RMS');
   let best=sel.options[0].value,bd=1e9;
@@ -100,7 +113,7 @@ async function load(){
  }catch(e){}
 }
 async function save(){
- const ids=['AZURE_OPENAI_REALTIME_ENDPOINT','AZURE_OPENAI_REALTIME_API_KEY','AZURE_OPENAI_REALTIME_DEPLOYMENT','MIRRORBUDDY_MAESTRO_ID','MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME','MIRRORBUDDY_BARGE_RMS','MIRRORBUDDY_OUTPUT_GAIN'];
+ const ids=['AZURE_OPENAI_REALTIME_ENDPOINT','AZURE_OPENAI_REALTIME_API_KEY','AZURE_OPENAI_REALTIME_DEPLOYMENT','MIRRORBUDDY_MAESTRO_ID','MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME','MIRRORBUDDY_BARGE_RMS','MIRRORBUDDY_OUTPUT_GAIN','MIRRORBUDDY_VOLUME'];
  const body={};ids.forEach(i=>{const v=document.getElementById(i).value.trim();if(v)body[i]=v;});
  const r=await (await fetch('./api/config',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)})).json();
  load();

--- a/robot/reachy_mini_mirrorbuddy/settings_page.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_page.py
@@ -59,6 +59,13 @@ PAGE = """<!doctype html>
  <option value="0.045">Media (consigliata)</option>
  <option value="0.060">Bassa — serve una voce più decisa (ambienti rumorosi)</option>
 </select>
+<label>Volume della voce di Buddy</label>
+<select id="MIRRORBUDDY_OUTPUT_GAIN">
+ <option value="1.6">Basso — stanza silenziosa</option>
+ <option value="3.2">Normale (consigliato)</option>
+ <option value="4.5">Alto — stanza rumorosa o ascolto difficoltoso</option>
+ <option value="6.0">Massimo</option>
+</select>
 <button onclick="save()">Salva</button>
 <p><small>La chiave Azure resta solo su questo robot (file .env locale).</small></p>
 <script>
@@ -72,6 +79,12 @@ async function load(){
  else{ps.className='status warn';ps.textContent='Non collegato a nessun profilo.';}
  for(const k of ['MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME']){
   if(s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName']) document.getElementById(k).value=s[k==='MIRRORBUDDY_DSA_PROFILE'?'dsaProfile':'studentName'];
+ }
+ if(typeof s.outputGain==='number'){
+  const sel=document.getElementById('MIRRORBUDDY_OUTPUT_GAIN');
+  let best=sel.options[0].value,bd=1e9;
+  for(const o of sel.options){const d=Math.abs(parseFloat(o.value)-s.outputGain);if(d<bd){bd=d;best=o.value;}}
+  sel.value=best;
  }
  if(typeof s.bargeRms==='number'){
   const sel=document.getElementById('MIRRORBUDDY_BARGE_RMS');
@@ -87,7 +100,7 @@ async function load(){
  }catch(e){}
 }
 async function save(){
- const ids=['AZURE_OPENAI_REALTIME_ENDPOINT','AZURE_OPENAI_REALTIME_API_KEY','AZURE_OPENAI_REALTIME_DEPLOYMENT','MIRRORBUDDY_MAESTRO_ID','MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME','MIRRORBUDDY_BARGE_RMS'];
+ const ids=['AZURE_OPENAI_REALTIME_ENDPOINT','AZURE_OPENAI_REALTIME_API_KEY','AZURE_OPENAI_REALTIME_DEPLOYMENT','MIRRORBUDDY_MAESTRO_ID','MIRRORBUDDY_DSA_PROFILE','MIRRORBUDDY_STUDENT_NAME','MIRRORBUDDY_BARGE_RMS','MIRRORBUDDY_OUTPUT_GAIN'];
  const body={};ids.forEach(i=>{const v=document.getElementById(i).value.trim();if(v)body[i]=v;});
  const r=await (await fetch('./api/config',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)})).json();
  load();

--- a/robot/reachy_mini_mirrorbuddy/settings_ui.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_ui.py
@@ -16,6 +16,18 @@ from pathlib import Path
 from .config import config
 from .settings_page import PAGE
 
+# Imported at module level on purpose. With ``from __future__ import annotations``
+# every annotation is a string, and FastAPI resolves route annotations against the
+# *module* namespace. While these were imported inside the mount function, FastAPI
+# could not resolve "Request", mistook it for a query parameter, and every save
+# came back as "Field required" — the settings page silently never persisted
+# anything. Guarded so the module still imports on a laptop without FastAPI.
+try:  # pragma: no cover - trivial import guard
+    from fastapi import Request
+    from fastapi.responses import HTMLResponse, JSONResponse
+except ImportError:  # pragma: no cover - only on machines without the robot deps
+    Request = HTMLResponse = JSONResponse = None  # type: ignore[assignment,misc]
+
 logger = logging.getLogger(__name__)
 
 # Keys we allow the UI to persist into the instance .env file.
@@ -33,14 +45,13 @@ _EDITABLE_KEYS = (
     "MIRRORBUDDY_API_BASE",
     "MIRRORBUDDY_BARGE_RMS",
     "MIRRORBUDDY_BARGE_FRAMES",
+    "MIRRORBUDDY_VOLUME",
+    "MIRRORBUDDY_OUTPUT_GAIN",
 )
 
 
 def mount_settings_routes(app, instance_path: str | None) -> None:
     """Attach the settings routes to the app's FastAPI ``settings_app``."""
-    from fastapi import Request
-    from fastapi.responses import HTMLResponse, JSONResponse
-
     env_path = Path(instance_path) / ".env" if instance_path else Path(".env")
 
     @app.get("/", response_class=HTMLResponse)
@@ -61,6 +72,7 @@ def mount_settings_routes(app, instance_path: str | None) -> None:
                 "locale": config.LOCALE,
                 "paired": bool(config.DEVICE_TOKEN),
                 "bargeRms": config.BARGE_RMS_THRESHOLD,
+                "outputGain": config.OUTPUT_GAIN,
                 "bargeFrames": config.BARGE_SUSTAIN_FRAMES,
             }
         )

--- a/robot/reachy_mini_mirrorbuddy/settings_ui.py
+++ b/robot/reachy_mini_mirrorbuddy/settings_ui.py
@@ -73,6 +73,7 @@ def mount_settings_routes(app, instance_path: str | None) -> None:
                 "paired": bool(config.DEVICE_TOKEN),
                 "bargeRms": config.BARGE_RMS_THRESHOLD,
                 "outputGain": config.OUTPUT_GAIN,
+                "volume": config.VOLUME,
                 "bargeFrames": config.BARGE_SUSTAIN_FRAMES,
             }
         )

--- a/robot/reachy_mini_mirrorbuddy/temperament.py
+++ b/robot/reachy_mini_mirrorbuddy/temperament.py
@@ -1,0 +1,38 @@
+"""How lively a given Maestro moves.
+
+A physics teacher who explains with her hands and a philosopher who thinks in
+pauses should not share the same body language, so each persona's text is read
+for temperament and the animation is scaled from it. Kept separate from the
+animation loop because it is a property of the *character*, not of the motion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Temperament:
+    """How lively the Maestro moves. ``scale`` = amplitude, ``speed`` = frequency."""
+
+    scale: float = 1.0
+    speed: float = 1.0
+
+
+CALM = Temperament(scale=0.7, speed=0.8)
+NEUTRAL = Temperament(scale=1.0, speed=1.0)
+LIVELY = Temperament(scale=1.35, speed=1.25)
+
+
+def temperament_for(
+    subject: str = "", teaching_style: str = "", voice_instructions: str = ""
+) -> Temperament:
+    """Derive a movement temperament from a Maestro's persona (best-effort keywords)."""
+    text = f"{subject} {teaching_style} {voice_instructions}".lower()
+    lively_kw = ("energe", "vivac", "entusias", "playful", "dynamic", "passion", "espressiv", "teatral", "lively")
+    calm_kw = ("calm", "tranquil", "gentle", "paz", "serio", "riflessiv", "pacato", "soft", "measured", "sober")
+    if any(k in text for k in lively_kw):
+        return LIVELY
+    if any(k in text for k in calm_kw):
+        return CALM
+    return NEUTRAL

--- a/robot/reachy_mini_mirrorbuddy/tool_handlers.py
+++ b/robot/reachy_mini_mirrorbuddy/tool_handlers.py
@@ -1,0 +1,106 @@
+"""What Buddy can actually *do* when the model asks for it.
+
+Split from the session lifecycle in :mod:`controller` because these are the
+child-facing capabilities — call another professor, look at the homework, switch
+between tutor and friend — while the controller is plumbing. Mixed into
+``Controller``, which owns the state these handlers read.
+
+Everything slow is offloaded to a thread: these run on the realtime websocket
+loop, and blocking it means Buddy stops hearing the child mid-sentence.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from . import camera, tools
+from .azure_realtime import AzureRealtimeClient
+from .mirrorbuddy_client import friend_buddy, neutral_buddy
+
+logger = logging.getLogger(__name__)
+
+
+class ToolCallMixin:
+    """Tool dispatch for :class:`~reachy_mini_mirrorbuddy.controller.Controller`."""
+
+    def _on_tool_call(self, name: str, args: dict, call_id: str) -> None:
+        """Runs in the realtime client's thread — keep it quick; offload the switch."""
+        client = self._client
+        if client is None:
+            return
+        try:
+            if name == "list_professors":
+                client.send_function_result(call_id, tools.professors_summary(self.maestri))
+            elif name == "call_professor":
+                self._handle_call_professor(client, args, call_id)
+            elif name == "look_at_homework":
+                self._handle_look_at_homework(client, args, call_id)
+            elif name == "talk_as_friend":
+                self._switch_persona(client, call_id, friend=True)
+            elif name == "back_to_study":
+                self._switch_persona(client, call_id, friend=False)
+            else:
+                client.send_function_result(call_id, "Ok.")
+        except Exception as e:  # pragma: no cover - runtime robustness
+            logger.warning("tool %s failed: %s", name, e)
+            client.send_function_result(call_id, "Scusa, non ci sono riuscito.")
+
+    def _handle_call_professor(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
+        target = tools.resolve_maestro(self.maestri, str(args.get("query") or ""))
+        if target is None:
+            # Give the model the real roster: without it, it retried the same failing
+            # request over and over while the child listened to apologies.
+            client.send_function_result(
+                call_id,
+                "Non ho un professore per quella materia. Ecco chi c'e': "
+                f"{tools.professors_summary(self.maestri)}. "
+                "Proponi tu l'alternativa piu' vicina, senza richiamare questo strumento con la stessa richiesta.",
+            )
+            return
+        if target.id == self.maestro.id:
+            client.send_function_result(call_id, f"Sono gia' io, {self.maestro.display_name}. Andiamo avanti.")
+            return
+        # Acknowledge without a spoken reply here; the new Maestro will greet.
+        client.send_function_result(call_id, f"Passo la parola a {target.display_name}.", respond=False)
+        threading.Thread(target=self._switch_to, args=(target,), name="MaestroSwitch", daemon=True).start()
+
+    def _switch_persona(self, client: AzureRealtimeClient, call_id: str, friend: bool) -> None:
+        """Swap between the friend companion and the study tutor (persona + voice)."""
+        target = (
+            friend_buddy(self.cfg.STUDENT_NAME, self.cfg.BUDDY_VOICE)
+            if friend
+            else neutral_buddy(self.cfg.STUDENT_NAME, self.cfg.BUDDY_VOICE)
+        )
+        if target.id == self.maestro.id:
+            client.send_function_result(call_id, "Certo, sono qui.")
+            return
+        client.send_function_result(call_id, "Va bene.", respond=False)
+        threading.Thread(target=self._switch_to, args=(target,), name="PersonaSwitch", daemon=True).start()
+
+    def _handle_look_at_homework(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
+        if not self.cfg.ENABLE_CAMERA:
+            client.send_function_result(call_id, "La telecamera e' spenta nelle impostazioni, non posso guardare.")
+            return
+        # Offload: freezing the head to get a sharp frame takes ~1s; never block the ws loop.
+        threading.Thread(target=self._capture_homework, args=(client, args, call_id), daemon=True).start()
+
+    def _capture_homework(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
+        self.movements.set_emotion("focused")
+        self.movements.hold_still()
+        try:
+            data_url = camera.capture_data_url(self.robot)
+        finally:
+            self.movements.release_hold()
+            self.movements.set_emotion("thinking")
+        if not data_url:
+            client.send_function_result(call_id, "Non riesco a vedere bene, avvicina il foglio e riproviamo.")
+            return
+        question = str(args.get("question") or "").strip() or (
+            "Guarda la foto: puo' essere un compito, la pagina di un quaderno o di un libro, "
+            "o lo schermo. Leggi cosa c'e' scritto e aiuta lo studente passo passo, senza dare "
+            "la risposta pronta."
+        )
+        # Privacy: we already announced verbally; hand the still frame to the model.
+        client.send_function_result(call_id, "Ho guardato il tuo compito.", respond=False)
+        client.send_image(data_url, question)

--- a/robot/reachy_mini_mirrorbuddy/tools.py
+++ b/robot/reachy_mini_mirrorbuddy/tools.py
@@ -11,6 +11,7 @@ The schemas are sent in ``session.update`` and the model calls them autonomously
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from .mirrorbuddy_client import Maestro
@@ -20,7 +21,8 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
         "type": "function",
         "name": "list_professors",
         "description": (
-            "Elenca i professori (Maestri) MirrorBuddy disponibili con la loro materia. "
+            "Elenca chi c'e' su MirrorBuddy: i professori (Maestri) con la loro materia "
+            "e i coach dello studio (Melissa, Roberto, Chiara, Andrea, Favij, Laura). "
             "Usalo quando lo studente chiede chi c'e' o con chi puo' parlare."
         ),
         "parameters": {"type": "object", "properties": {}, "required": []},
@@ -29,16 +31,22 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
         "type": "function",
         "name": "call_professor",
         "description": (
-            "Passa la conversazione a un altro professore MirrorBuddy, cambiando persona e voce. "
-            "Usalo quando lo studente chiede un altro professore o un'altra materia "
-            "(es. 'voglio matematica', 'chiama Galileo', 'parliamo di arte')."
+            "Passa la conversazione a un altro professore o coach MirrorBuddy, cambiando persona e voce. "
+            "Usalo quando lo studente chiede un'altra persona o un'altra materia "
+            "(es. 'voglio matematica', 'chiama Galileo', 'parliamo di arte'), "
+            "e anche quando chiede aiuto sul metodo, l'organizzazione o la motivazione "
+            "(es. 'chiama Andrea', 'non riesco a studiare', 'mi serve un metodo'): "
+            "in quel caso passa a un coach."
         ),
         "parameters": {
             "type": "object",
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Nome del professore o materia richiesta (es. 'Galileo', 'matematica', 'storia').",
+                    "description": (
+                        "Nome della persona o materia richiesta "
+                        "(es. 'Galileo', 'matematica', 'storia', 'Andrea', 'metodo di studio')."
+                    ),
                 }
             },
             "required": ["query"],
@@ -133,7 +141,29 @@ SUBJECT_ALIASES: dict[str, tuple[str, ...]] = {
     "health": ("salute", "benessere", "educazione alla salute"),
     "internationalLaw": ("diritto internazionale",),
     "storytelling": ("storytelling", "public speaking", "raccontare"),
+    # Coaches: not a school subject. A child asks for them by what they need
+    # ("non riesco a studiare", "mi serve un metodo"), not by a discipline.
+    "coaching": (
+        "coach", "tutor", "sostegno", "metodo", "metodo di studio", "studiare",
+        "organizzarmi", "concentrarmi", "motivazione", "compiti", "ansia",
+    ),
 }
+
+
+def _alias_hit(m: Maestro, q: str) -> int:
+    """Length of the longest alias of ``m`` spoken verbatim in ``q`` (0 if none).
+
+    A child rarely names the subject on its own: they say "mi serve un metodo di
+    studio". Requiring every spoken word to match would reject that, so a verbatim
+    alias counts as a strong hit — and the *longest* alias wins, which is what keeps
+    "scienze motorie" with the sport teacher instead of the biology one.
+    """
+    best = 0
+    for alias in SUBJECT_ALIASES.get(str(m.subject or ""), ()):
+        a = _norm(alias)
+        if a and re.search(rf"(?<!\w){re.escape(a)}(?!\w)", q):
+            best = max(best, len(a))
+    return best
 
 
 def _alias_haystack(m: Maestro) -> str:
@@ -165,14 +195,15 @@ def resolve_maestro(maestri: list[Maestro], query: str) -> Maestro | None:
         # A whole-phrase hit ("scienze motorie") beats loose token overlap, which is
         # what previously let a single shared word send the child to the wrong teacher.
         phrase = 1 if q in hay else 0
+        alias = _alias_hit(m, q)
         score = sum(1 for t in tokens if t in hay)
-        if not phrase and score < len(tokens):
+        if not phrase and not alias and score < len(tokens):
             # Partial overlap only: not good enough to switch teacher on.
             continue
-        cand = (phrase, score, m)
-        if best is None or cand[:2] > best[:2]:
+        cand = (phrase, alias, score, m)
+        if best is None or cand[:3] > best[:3]:
             best = cand
-    return best[2] if best else None
+    return best[3] if best else None
 
 
 def professors_summary(maestri: list[Maestro], limit: int = 26) -> str:

--- a/robot/reachy_mini_mirrorbuddy/tools.py
+++ b/robot/reachy_mini_mirrorbuddy/tools.py
@@ -197,8 +197,11 @@ def resolve_maestro(maestri: list[Maestro], query: str) -> Maestro | None:
         phrase = 1 if q in hay else 0
         alias = _alias_hit(m, q)
         score = sum(1 for t in tokens if t in hay)
-        if not phrase and not alias and score < len(tokens):
-            # Partial overlap only: not good enough to switch teacher on.
+        # No phrase, no alias, and nothing meaningful matched: a query like "ai" has
+        # no tokens at all, and `score < len(tokens)` would read 0 < 0 and quietly
+        # elect the first professor in the roster. Switching a child's teacher on
+        # noise is worse than doing nothing.
+        if not phrase and not alias and (not tokens or score < len(tokens)):
             continue
         cand = (phrase, alias, score, m)
         if best is None or cand[:3] > best[:3]:

--- a/robot/reachy_mini_mirrorbuddy/tools.py
+++ b/robot/reachy_mini_mirrorbuddy/tools.py
@@ -107,6 +107,41 @@ def _norm(s: str) -> str:
     return " ".join(str(s or "").lower().split())
 
 
+# The child speaks the Italian school-subject name; the Maestro record carries an
+# English code ("sport", "biology"). Without this bridge, "scienze motorie" matched
+# Darwin on the single word "scienze" and Buddy handed the lesson to the wrong
+# professor — then looped, apologising, while the child waited.
+SUBJECT_ALIASES: dict[str, tuple[str, ...]] = {
+    "sport": ("scienze motorie", "educazione fisica", "motoria", "ginnastica", "sport", "movimento"),
+    "biology": ("scienze", "scienze naturali", "biologia", "natura"),
+    "physics": ("fisica", "astronomia"),
+    "chemistry": ("chimica",),
+    "mathematics": ("matematica", "geometria", "algebra", "mate"),
+    "italian": ("italiano", "letteratura", "grammatica", "epica"),
+    "english": ("inglese",),
+    "french": ("francese",),
+    "german": ("tedesco",),
+    "spanish": ("spagnolo",),
+    "history": ("storia",),
+    "geography": ("geografia",),
+    "art": ("arte", "disegno", "immagine"),
+    "music": ("musica",),
+    "philosophy": ("filosofia",),
+    "civics": ("educazione civica", "civica", "diritto"),
+    "computerScience": ("informatica", "programmazione", "coding", "tecnologia"),
+    "economics": ("economia",),
+    "health": ("salute", "benessere", "educazione alla salute"),
+    "internationalLaw": ("diritto internazionale",),
+    "storytelling": ("storytelling", "public speaking", "raccontare"),
+}
+
+
+def _alias_haystack(m: Maestro) -> str:
+    """Everything a child might plausibly say to mean this Maestro."""
+    aliases = SUBJECT_ALIASES.get(str(m.subject or ""), ())
+    return _norm(f"{m.subject} {m.specialty} {m.teaching_style} {' '.join(aliases)}")
+
+
 def resolve_maestro(maestri: list[Maestro], query: str) -> Maestro | None:
     """Best-effort match of a spoken query to a Maestro by name/subject/specialty."""
     q = _norm(query)
@@ -122,15 +157,22 @@ def resolve_maestro(maestri: list[Maestro], query: str) -> Maestro | None:
         name = _norm(m.display_name) or _norm(m.name)
         if name and (name in q or q in name):
             return m
-    # 3) subject / specialty contains the query token(s).
+    # 3) subject / specialty / spoken aliases.
     tokens = [t for t in q.split() if len(t) > 2]
-    best: tuple[int, Maestro] | None = None
+    best: tuple[int, int, Maestro] | None = None
     for m in maestri:
-        hay = f"{_norm(m.subject)} {_norm(m.specialty)} {_norm(m.teaching_style)}"
+        hay = _alias_haystack(m)
+        # A whole-phrase hit ("scienze motorie") beats loose token overlap, which is
+        # what previously let a single shared word send the child to the wrong teacher.
+        phrase = 1 if q in hay else 0
         score = sum(1 for t in tokens if t in hay)
-        if score and (best is None or score > best[0]):
-            best = (score, m)
-    return best[1] if best else None
+        if not phrase and score < len(tokens):
+            # Partial overlap only: not good enough to switch teacher on.
+            continue
+        cand = (phrase, score, m)
+        if best is None or cand[:2] > best[:2]:
+            best = cand
+    return best[2] if best else None
 
 
 def professors_summary(maestri: list[Maestro], limit: int = 26) -> str:

--- a/robot/space/README.md
+++ b/robot/space/README.md
@@ -1,0 +1,61 @@
+---
+title: MirrorBuddy
+emoji: 🪞
+colorFrom: purple
+colorTo: blue
+sdk: static
+pinned: false
+license: apache-2.0
+short_description: A patient tutor for children who learn differently
+tags:
+  - reachy_mini
+  - reachy_mini_python_app
+---
+
+# MirrorBuddy for Reachy Mini
+
+MirrorBuddy turns Reachy Mini into a patient tutor that sits on the desk next to a
+child and helps with homework — out loud, with no screen to operate.
+
+It was built for children who learn differently: dyslexia, ADHD, autism, cerebral
+palsy. For a child who cannot reliably use a mouse or keyboard, a robot you can just
+_talk to_ is not a nicer interface. It is the difference between studying
+independently and needing an adult beside you.
+
+## What it does
+
+- **Talks and listens.** Natural spoken conversation in Italian, powered by Azure
+  OpenAI Realtime. Short answers, one thing at a time.
+- **26 professors, by voice.** Say "voglio matematica" or "chiama Galileo" and the
+  persona and voice change. Learning coaches are there too, for when the problem is
+  the method rather than the subject.
+- **Looks at homework.** Show it an exercise, a notebook page or the screen, and it
+  reads what is there and helps step by step — without handing over the answer.
+- **Moves like it is listening.** Smooth, continuous body language that follows the
+  child's face and shifts with the mood of the conversation.
+- **Stops when told.** "Basta", "zitto", "fermati" stop it immediately, and it stays
+  quiet until called back by name. Insisting is stressful; a stop is a full stop.
+- **Adapts to the child.** Pacing and pause tolerance follow the learning profile, so
+  a child who needs longer to form a sentence is never cut off.
+
+## Setup
+
+The app needs an Azure OpenAI Realtime endpoint and key. On first start it opens a
+settings page on the robot (port 7862) where you enter them, along with the child's
+name and profile. Nothing else is required — the professors are fetched live from
+MirrorBuddy.
+
+## Privacy
+
+Built for children, so: the camera is used only when explicitly asked, one frame at a
+time, and it is announced out loud first. No conversation recordings are stored on the
+robot. GDPR, COPPA and EU AI Act obligations are handled in the MirrorBuddy platform.
+
+## About
+
+Part of [MirrorBuddy](https://mirrorbuddy.org) by
+[FightTheStroke Foundation](https://fightthestroke.org) — a non-profit founded by the
+parents of a child with cerebral palsy, building technology for children who are
+usually asked to adapt to technology instead.
+
+Source: <https://github.com/FightTheStroke/MirrorBuddy>

--- a/robot/space/index.html
+++ b/robot/space/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MirrorBuddy — Reachy Mini</title>
+    <meta
+      name="description"
+      content="A patient tutor on your desk. MirrorBuddy turns Reachy Mini into a spoken homework companion for children who learn differently."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="container">
+        <div class="emoji" aria-hidden="true">🪞</div>
+        <h1>MirrorBuddy</h1>
+        <p class="tagline">A patient tutor on the desk, for children who learn differently.</p>
+        <div class="tags">
+          <span class="tag">homework</span>
+          <span class="tag">voice-first</span>
+          <span class="tag">accessibility</span>
+          <span class="tag">italiano</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="container">
+      <section>
+        <h2>Why</h2>
+        <p>
+          For a child who cannot reliably use a mouse or a keyboard, a robot you can simply
+          <em>talk to</em> is not a nicer interface. It is the difference between studying on your
+          own and needing an adult sitting next to you.
+        </p>
+        <p>
+          MirrorBuddy was built for children with dyslexia, ADHD, autism and cerebral palsy — and
+          Reachy Mini gives it a body: eyes that follow you, a voice that answers, and movement that
+          shows it is listening.
+        </p>
+      </section>
+
+      <section>
+        <h2>What it does</h2>
+        <ul class="features">
+          <li>
+            <strong>Talks and listens.</strong> Natural spoken conversation. Short answers, one
+            thing at a time.
+          </li>
+          <li>
+            <strong>26 professors, by voice.</strong> "Voglio matematica", "chiama Galileo" — the
+            persona and the voice change.
+          </li>
+          <li>
+            <strong>Study coaches.</strong> For when the problem is the method, not the subject.
+          </li>
+          <li>
+            <strong>Looks at homework.</strong> Show it an exercise; it reads it and helps step by
+            step, without giving the answer away.
+          </li>
+          <li>
+            <strong>Moves like it is listening.</strong> Smooth body language that follows the child
+            and shifts with the mood.
+          </li>
+          <li>
+            <strong>Stops when told.</strong> "Basta", "zitto" — it goes quiet and waits to be
+            called back by name.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Setup</h2>
+        <p>
+          Install from the Reachy Mini app store. On first start the robot opens a settings page
+          (port <code>7862</code>) where you enter your Azure OpenAI Realtime endpoint and key, the
+          child's name and their learning profile. The professors are fetched live from MirrorBuddy.
+        </p>
+      </section>
+
+      <section>
+        <h2>Privacy</h2>
+        <p>
+          Built for children: the camera is used only when explicitly asked, one frame at a time,
+          and announced out loud first. No conversation recordings are kept on the robot.
+        </p>
+      </section>
+    </main>
+
+    <footer class="container">
+      <p>
+        Part of <a href="https://mirrorbuddy.org">MirrorBuddy</a> by
+        <a href="https://fightthestroke.org">FightTheStroke Foundation</a> —
+        <a href="https://github.com/FightTheStroke/MirrorBuddy">source on GitHub</a>.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/robot/space/style.css
+++ b/robot/space/style.css
@@ -1,0 +1,130 @@
+:root {
+  --ink: #1a1730;
+  --muted: #5c5878;
+  --accent: #6b4de6;
+  --bg: #fbfaff;
+  --card: #ffffff;
+  --line: #e8e4f5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
+  /* Generous line height: this page is read by parents and educators, some of
+     whom are dyslexic themselves. */
+  line-height: 1.65;
+  font-size: 17px;
+}
+
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.hero {
+  background: linear-gradient(160deg, #6b4de6 0%, #4a7ee6 100%);
+  color: #fff;
+  padding: 64px 0 56px;
+  text-align: center;
+}
+
+.hero .emoji {
+  font-size: 56px;
+  line-height: 1;
+}
+
+.hero h1 {
+  margin: 12px 0 8px;
+  font-size: 44px;
+  letter-spacing: -0.02em;
+}
+
+.tagline {
+  margin: 0 auto;
+  max-width: 30ch;
+  font-size: 19px;
+  opacity: 0.95;
+}
+
+.tags {
+  margin-top: 22px;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.tag {
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 14px;
+}
+
+main section {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 24px 28px;
+  margin: 24px 0;
+}
+
+h2 {
+  margin: 0 0 12px;
+  font-size: 22px;
+  color: var(--accent);
+}
+
+p {
+  margin: 0 0 14px;
+}
+
+.features {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.features li {
+  margin-bottom: 10px;
+}
+
+code {
+  background: #f0edfb;
+  border-radius: 5px;
+  padding: 1px 6px;
+  font-size: 0.92em;
+}
+
+a {
+  color: var(--accent);
+}
+
+footer {
+  color: var(--muted);
+  font-size: 15px;
+  padding: 8px 24px 56px;
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/robot/tests/test_audio_boost.py
+++ b/robot/tests/test_audio_boost.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from reachy_mini_mirrorbuddy.audio_io import _boost
+from reachy_mini_mirrorbuddy.audio_dsp import boost as _boost
 
 
 def test_boost_makes_speech_louder() -> None:

--- a/robot/tests/test_audio_boost.py
+++ b/robot/tests/test_audio_boost.py
@@ -1,0 +1,31 @@
+"""Loudness behaviour: Buddy has to be clearly audible without turning harsh."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from reachy_mini_mirrorbuddy.audio_io import _boost
+
+
+def test_boost_makes_speech_louder() -> None:
+    speech = np.full(100, 0.1, dtype=np.float32)
+    assert float(np.abs(_boost(speech, 3.2)).mean()) > float(np.abs(speech).mean())
+
+
+def test_boost_never_clips() -> None:
+    """Peaks must be compressed, not slammed against the rail (that's what rasps)."""
+    loud = np.array([-1.0, -0.9, 0.0, 0.9, 1.0], dtype=np.float32)
+    out = _boost(loud, 8.0)
+    assert np.all(np.abs(out) < 1.0)
+
+
+def test_boost_is_monotonic() -> None:
+    """A louder input still comes out louder: the voice keeps its dynamics."""
+    quiet = _boost(np.array([0.05], dtype=np.float32), 3.2)[0]
+    loud = _boost(np.array([0.25], dtype=np.float32), 3.2)[0]
+    assert loud > quiet
+
+
+def test_boost_returns_float32() -> None:
+    out = _boost(np.array([0.1, 0.2], dtype=np.float32), 2.0)
+    assert out.dtype == np.float32

--- a/robot/tests/test_barge_in.py
+++ b/robot/tests/test_barge_in.py
@@ -55,3 +55,43 @@ class TestLocalBargeIn:
         c._responding = True
         c.local_barge_in()
         assert sent == [rt_messages.CANCEL]  # cancel the active response
+
+    def test_cancel_is_sent_once_per_response(self):
+        """Two quick barge-ins on one response must not queue two cancels: the second
+        would come back as a spurious 'no active response' error."""
+        sent: list[str] = []
+        c = _client()
+        c._enqueue = lambda msg: sent.append(msg)  # type: ignore[assignment]
+
+        c._responding = True
+        c.local_barge_in()
+        c.local_barge_in()
+        assert sent == [rt_messages.CANCEL]
+
+
+class TestCancelRaceIsNotAnError:
+    """Cancelling a response that just ended is normal, not a failure."""
+
+    def _dispatch(self, client, event):
+        import asyncio
+
+        asyncio.run(client._handle_event(event))
+
+    def test_late_cancel_is_not_logged_as_error(self, caplog):
+        import logging
+
+        c = _client()
+        with caplog.at_level(logging.ERROR, logger="reachy_mini_mirrorbuddy.azure_realtime"):
+            self._dispatch(
+                c,
+                {"type": "error", "error": {"code": "response_cancel_not_active", "message": "x"}},
+            )
+        assert caplog.records == []
+
+    def test_real_errors_are_still_logged(self, caplog):
+        import logging
+
+        c = _client()
+        with caplog.at_level(logging.ERROR, logger="reachy_mini_mirrorbuddy.azure_realtime"):
+            self._dispatch(c, {"type": "error", "error": {"code": "invalid_api_key"}})
+        assert any("invalid_api_key" in r.getMessage() for r in caplog.records)

--- a/robot/tests/test_coaches.py
+++ b/robot/tests/test_coaches.py
@@ -1,0 +1,100 @@
+"""Coaches on the robot: they must be reachable by voice like any professor.
+
+Roberto asked "ma abbiamo tolto i buddy e i coach?" — they were never removed, they
+were simply invisible to the robot because no public endpoint exposed them. These
+tests pin the two halves of the fix: the roster includes them, and a child asking
+for one by name or by need actually gets one.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from reachy_mini_mirrorbuddy.mirrorbuddy_client import MirrorBuddyClient
+from reachy_mini_mirrorbuddy.tools import resolve_maestro
+
+_COACH_JSON = [
+    {
+        "id": "andrea",
+        "name": "Andrea",
+        "displayName": "Andrea",
+        "subject": "coaching",
+        "specialty": "energica, sportiva, pratica",
+        "voice": "sage",
+        "voiceInstructions": "Energica ma non stressante",
+        "teachingStyle": "metodo di studio come allenamento",
+        "systemPrompt": "Sei Andrea, docente di sostegno virtuale.",
+        "greeting": "Ciao! Pronti ad allenarci?",
+    },
+    {
+        "id": "melissa",
+        "name": "Melissa",
+        "displayName": "Melissa",
+        "subject": "coaching",
+        "specialty": "calma, organizzata",
+        "voice": "coral",
+        "voiceInstructions": "",
+        "teachingStyle": "",
+        "systemPrompt": "Sei Melissa.",
+        "greeting": "Ciao!",
+    },
+]
+
+
+def _client(monkeypatch, handler):
+    monkeypatch.setattr(httpx, "get", handler)
+    return MirrorBuddyClient("https://mirrorbuddy.test", locale="it")
+
+
+class TestFetchCoaches:
+    def test_returns_the_coaches(self, monkeypatch):
+        seen = {}
+
+        def fake_get(url, **kw):
+            seen["url"] = url
+            return httpx.Response(200, json=_COACH_JSON, request=httpx.Request("GET", url))
+
+        coaches = _client(monkeypatch, fake_get).fetch_coaches()
+        assert [c.id for c in coaches] == ["andrea", "melissa"]
+        assert coaches[0].display_name == "Andrea"
+        assert "/api/coaches?locale=it" in seen["url"]
+
+    def test_a_backend_without_the_endpoint_does_not_break_startup(self, monkeypatch):
+        # The robot must still boot against an older deployment: no coaches is a
+        # degraded experience, a crash is a child staring at a dead robot.
+        def boom(url, **kw):
+            raise httpx.ConnectError("404")
+
+        assert _client(monkeypatch, boom).fetch_coaches() == []
+
+    def test_http_error_is_swallowed(self, monkeypatch):
+        assert _client(monkeypatch, lambda url, **kw: httpx.Response(500, request=httpx.Request("GET", url))).fetch_coaches() == []
+
+    def test_accepts_a_wrapped_payload(self, monkeypatch):
+        def fake_get(url, **kw):
+            return httpx.Response(200, json={"coaches": _COACH_JSON}, request=httpx.Request("GET", url))
+
+        assert len(_client(monkeypatch, fake_get).fetch_coaches()) == 2
+
+
+class TestCallingACoach:
+    @pytest.fixture
+    def roster(self):
+        from reachy_mini_mirrorbuddy.mirrorbuddy_client import Maestro
+
+        return [Maestro.from_json(c) for c in _COACH_JSON]
+
+    def test_by_name(self, roster):
+        assert resolve_maestro(roster, "chiama Andrea").id == "andrea"
+
+    @pytest.mark.parametrize(
+        "said",
+        ["mi serve un metodo di studio", "voglio un coach", "non riesco a organizzarmi"],
+    )
+    def test_by_what_the_student_needs(self, roster, said):
+        # A child doesn't ask for "coaching"; they say what isn't working.
+        assert resolve_maestro(roster, said) is not None
+
+    def test_an_unrelated_request_does_not_grab_a_coach(self, roster):
+        assert resolve_maestro(roster, "matematica") is None

--- a/robot/tests/test_device.py
+++ b/robot/tests/test_device.py
@@ -109,3 +109,24 @@ class TestPersonaFollowsTheChildsChoice:
     def test_preferred_coach_is_parsed_from_the_api_payload(self):
         p = DeviceProfile.from_json({"preferredCoach": "andrea"})
         assert p.preferred_coach == "andrea"
+
+
+class TestUnreadableNames:
+    """The server encrypts names; ciphertext on the wire must not reach the child."""
+
+    def test_ciphertext_is_not_adopted_as_a_name(self):
+        cfg = _FakeConfig()
+        cfg.STUDENT_NAME = "Mario"
+        apply_device_profile(cfg, DeviceProfile(name="pii:v1:yO6kRLN95WvcdZfsME"))
+        assert cfg.STUDENT_NAME == "Mario"
+
+    def test_decryption_placeholder_is_not_adopted_either(self):
+        cfg = _FakeConfig()
+        cfg.STUDENT_NAME = "Mario"
+        apply_device_profile(cfg, DeviceProfile(name="[decryption-failed]"))
+        assert cfg.STUDENT_NAME == "Mario"
+
+    def test_a_real_name_is_still_applied(self):
+        cfg = _FakeConfig()
+        apply_device_profile(cfg, DeviceProfile(name="Noemi"))
+        assert cfg.STUDENT_NAME == "Noemi"

--- a/robot/tests/test_device.py
+++ b/robot/tests/test_device.py
@@ -19,6 +19,8 @@ class _FakeConfig:
     LOCALE = "it"
     DSA_PROFILE = "cerebral"
     CALM_MOVEMENT = False
+    MAESTRO_ID = ""
+    START_NEUTRAL = True
 
 
 def test_from_json_parses_fields():
@@ -70,3 +72,40 @@ def test_apply_keeps_config_when_profile_empty():
     apply_device_profile(cfg, DeviceProfile())
     assert cfg.STUDENT_NAME == "Existing"
     assert cfg.DSA_PROFILE == "cerebral"
+
+
+class TestPersonaFollowsTheChildsChoice:
+    """The child already picked a coach in the app; the robot should honour it."""
+
+    def test_chosen_coach_becomes_the_starting_persona(self):
+        cfg = _FakeConfig()
+        apply_device_profile(cfg, DeviceProfile(name="Mario", preferred_coach="andrea"))
+        assert cfg.MAESTRO_ID == "andrea"
+        assert cfg.START_NEUTRAL is False
+
+    def test_buddy_is_used_when_no_coach_was_chosen(self):
+        cfg = _FakeConfig()
+        apply_device_profile(cfg, DeviceProfile(preferred_buddy="sofia"))
+        assert cfg.MAESTRO_ID == "sofia"
+
+    def test_coach_wins_over_buddy(self):
+        cfg = _FakeConfig()
+        apply_device_profile(cfg, DeviceProfile(preferred_buddy="sofia", preferred_coach="melissa"))
+        assert cfg.MAESTRO_ID == "melissa"
+
+    def test_explicit_local_override_is_respected(self):
+        # Someone set MAESTRO_ID in .env on this robot on purpose: don't fight them.
+        cfg = _FakeConfig()
+        cfg.MAESTRO_ID = "galileo"
+        apply_device_profile(cfg, DeviceProfile(preferred_coach="andrea"))
+        assert cfg.MAESTRO_ID == "galileo"
+
+    def test_no_preference_leaves_the_neutral_buddy(self):
+        cfg = _FakeConfig()
+        apply_device_profile(cfg, DeviceProfile(name="Mario"))
+        assert cfg.MAESTRO_ID == ""
+        assert cfg.START_NEUTRAL is True
+
+    def test_preferred_coach_is_parsed_from_the_api_payload(self):
+        p = DeviceProfile.from_json({"preferredCoach": "andrea"})
+        assert p.preferred_coach == "andrea"

--- a/robot/tests/test_emotions.py
+++ b/robot/tests/test_emotions.py
@@ -1,0 +1,139 @@
+"""Emotional body language: mood inference and smooth blending.
+
+The point of these tests is the thing Roberto actually complained about — the
+movement was jerky and always the same. So we assert two properties: the mood
+changes with what Buddy says, and nothing ever jumps.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from reachy_mini_mirrorbuddy import emotions
+from reachy_mini_mirrorbuddy.movements import _ease
+
+
+class TestInfer:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Bravissimo Mario, ce l'hai fatta!", "celebrating"),
+            ("Bravo, molto bene", "happy"),
+            ("Non ti preoccupare, capita a tutti", "empathetic"),
+            ("Proviamo insieme, un passo alla volta", "encouraging"),
+            ("Fammi pensare un attimo", "thinking"),
+            ("Come mai secondo te?", "curious"),
+            ("La capitale della Francia e' Parigi.", "neutral"),
+        ],
+    )
+    def test_reads_the_mood_from_the_words(self, text, expected):
+        assert emotions.infer(text).name == expected
+
+    def test_praise_wins_over_a_trailing_question(self):
+        # "Bravo! Come hai fatto?" is celebration first, curiosity second.
+        assert emotions.infer("Bravo! Come hai fatto?").name == "happy"
+
+    def test_a_cue_inside_a_longer_word_does_not_count(self):
+        # Found by this suite: "capitale" contains "capita", so Buddy used to answer
+        # a geography question with a consoling posture.
+        assert emotions.infer("La capitale della Francia e' Parigi.").name == "neutral"
+        assert emotions.infer("Il bravo ragazzo").name == "happy"
+
+    def test_no_text_is_neutral(self):
+        assert emotions.infer(None).name == "neutral"
+        assert emotions.infer("").name == "neutral"
+
+    def test_unknown_name_falls_back_instead_of_raising(self):
+        assert emotions.get("euphoric").name == "neutral"
+        assert emotions.get(None).name == "neutral"
+
+    def test_every_emotion_stays_within_safe_limits(self):
+        # A tutor robot in front of a child must never thrash, whatever the mood.
+        for e in emotions.ALL.values():
+            assert 0.3 <= e.scale <= 1.6, e.name
+            assert 0.4 <= e.speed <= 1.6, e.name
+            assert abs(e.pitch_offset) <= 8.0, e.name
+            assert abs(e.antenna_offset) <= 0.35, e.name
+
+
+class TestEase:
+    def test_converges_to_the_target(self):
+        v = 0.0
+        for _ in range(200):
+            v = _ease(v, 1.0, 0.1, 0.02)
+        assert v == pytest.approx(1.0, abs=1e-3)
+
+    def test_never_jumps_in_a_single_frame(self):
+        # The whole fix: one frame must only ever cover a fraction of the gap.
+        step = _ease(0.0, 1.0, 0.09, 1 / 50.0)
+        assert 0.0 < step < 0.25
+
+    def test_is_frame_rate_independent(self):
+        # Same wall-clock time, different frame rates, same result — otherwise the
+        # motion would change character whenever the loop hiccups.
+        slow = 0.0
+        for _ in range(50):
+            slow = _ease(slow, 1.0, 0.2, 0.02)
+        fast = 0.0
+        for _ in range(100):
+            fast = _ease(fast, 1.0, 0.2, 0.01)
+        assert slow == pytest.approx(fast, abs=1e-3)
+
+    def test_zero_time_constant_snaps(self):
+        assert _ease(0.0, 5.0, 0.0, 0.02) == 5.0
+
+    def test_smoothing_actually_removes_the_jerk(self):
+        # A square wave (what the old boolean speaking flag did to the amplitude)
+        # becomes a bounded-slope signal once eased.
+        raw = [0.0 if (i // 10) % 2 == 0 else 1.0 for i in range(80)]
+        out, prev = [], 0.0
+        for target in raw:
+            prev = _ease(prev, target, 0.12, 1 / 50.0)
+            out.append(prev)
+        jumps = [abs(b - a) for a, b in zip(out, out[1:])]
+        assert max(jumps) < 0.2  # raw signal jumps a full 1.0
+
+
+class TestMovementsExpression:
+    def test_express_sets_the_inferred_emotion(self):
+        m = _bare_movements()
+        m.express("Bravissimo, ce l'hai fatta!")
+        assert m._emotion.name == "celebrating"
+
+    def test_set_emotion_accepts_name_or_object(self):
+        m = _bare_movements()
+        m.set_emotion("thinking")
+        assert m._emotion.name == "thinking"
+        m.set_emotion(emotions.HAPPY)
+        assert m._emotion.name == "happy"
+        m.set_emotion(None)
+        assert m._emotion.name == "neutral"
+
+    def test_mood_blends_in_gradually(self):
+        from reachy_mini_mirrorbuddy.movements import _MOOD_TAU
+
+        m = _bare_movements()
+        m.set_emotion("celebrating")
+        blended = m._mood["scale"]
+        blended = _ease(blended, m._emotion.scale, _MOOD_TAU, 1 / 50.0)
+        # After a single frame we are still nearly at the old mood, not the new one.
+        assert blended < 1.05
+        for _ in range(200):
+            blended = _ease(blended, m._emotion.scale, _MOOD_TAU, 1 / 50.0)
+        assert blended == pytest.approx(emotions.CELEBRATING.scale, abs=1e-2)
+
+
+def _bare_movements():
+    """A Movements instance without touching the SDK or the robot."""
+    from reachy_mini_mirrorbuddy.movements import Movements
+
+    return Movements(robot=object(), enabled=False)
+
+
+def test_loop_rate_is_higher_than_the_old_thirty_hz():
+    from reachy_mini_mirrorbuddy.movements import _LOOP_HZ
+
+    assert _LOOP_HZ >= 50.0
+    assert not math.isinf(_LOOP_HZ)

--- a/robot/tests/test_fast_response.py
+++ b/robot/tests/test_fast_response.py
@@ -12,7 +12,8 @@ import json
 import pytest
 
 from reachy_mini_mirrorbuddy import rt_messages
-from reachy_mini_mirrorbuddy.azure_realtime import _FAST_PATH_MIN_SPEECH_S, AzureRealtimeClient
+from reachy_mini_mirrorbuddy.azure_realtime import AzureRealtimeClient
+from reachy_mini_mirrorbuddy.rt_events import _FAST_PATH_MIN_SPEECH_S
 
 
 class FakeClock:
@@ -39,7 +40,7 @@ def client(monkeypatch):
 
     c._safe_send = capture
     clock = FakeClock()
-    monkeypatch.setattr("reachy_mini_mirrorbuddy.azure_realtime.time.monotonic", clock)
+    monkeypatch.setattr("reachy_mini_mirrorbuddy.rt_events.time.monotonic", clock)
     c.clock = clock
     return c
 

--- a/robot/tests/test_fast_response.py
+++ b/robot/tests/test_fast_response.py
@@ -1,0 +1,114 @@
+"""Latency fast path: answer without waiting for the transcript, safely.
+
+Every turn used to wait for a full transcription pass before the model was even
+asked to answer. These tests pin the trade we made: long utterances skip the wait,
+short ones (which is what stop words are) do not, and a stop word never survives.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reachy_mini_mirrorbuddy import rt_messages
+from reachy_mini_mirrorbuddy.azure_realtime import _FAST_PATH_MIN_SPEECH_S, AzureRealtimeClient
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+@pytest.fixture
+def client(monkeypatch):
+    c = AzureRealtimeClient(
+        ws_url="wss://x", api_key="k", instructions="i", voice="coral",
+        turn_detection={"type": "server_vad"},
+    )
+    c.sent = []
+
+    async def capture(msg):
+        c.sent.append(msg)
+
+    c._safe_send = capture
+    clock = FakeClock()
+    monkeypatch.setattr("reachy_mini_mirrorbuddy.azure_realtime.time.monotonic", clock)
+    c.clock = clock
+    return c
+
+
+async def _speak(client, seconds: float):
+    """Simulate the student talking for ``seconds`` and then stopping."""
+    await client._handle_event({"type": "input_audio_buffer.speech_started"})
+    client.clock.advance(seconds)
+    await client._handle_event({"type": "input_audio_buffer.speech_stopped"})
+
+
+def _response_creates(client):
+    out = []
+    for msg in client.sent:
+        try:
+            if json.loads(msg).get("type") == "response.create":
+                out.append(msg)
+        except (ValueError, TypeError):
+            pass
+    return out
+
+
+@pytest.mark.asyncio
+class TestFastPath:
+    async def test_a_long_question_is_answered_without_waiting_for_the_transcript(self, client):
+        await _speak(client, _FAST_PATH_MIN_SPEECH_S + 0.5)
+        assert len(_response_creates(client)) == 1
+        assert client._fast_requested is True
+
+    async def test_a_short_utterance_still_waits(self, client):
+        # This is the safe path: "zitto" lives here.
+        await _speak(client, 0.6)
+        assert _response_creates(client) == []
+        assert client._fast_requested is False
+
+    async def test_the_short_path_still_answers_once_the_transcript_arrives(self, client):
+        await _speak(client, 0.6)
+        await client._handle_event(
+            {"type": "conversation.item.input_audio_transcription.completed", "transcript": "quanto fa due piu' due"}
+        )
+        assert len(_response_creates(client)) == 1
+
+    async def test_buddy_never_answers_twice(self, client):
+        # The fast path fires, then the transcript classifies the same turn as normal.
+        await _speak(client, _FAST_PATH_MIN_SPEECH_S + 0.5)
+        await client._handle_event(
+            {"type": "conversation.item.input_audio_transcription.completed", "transcript": "spiegami le frazioni"}
+        )
+        assert len(_response_creates(client)) == 1
+
+    async def test_a_stop_word_ending_a_long_sentence_still_wins(self, client):
+        # The risk we took on: the answer was already requested. It must be cancelled.
+        await _speak(client, _FAST_PATH_MIN_SPEECH_S + 1.0)
+        client.sent.clear()
+        await client._handle_event(
+            {
+                "type": "conversation.item.input_audio_transcription.completed",
+                "transcript": "no dai aspetta un attimo per favore zitto",
+            }
+        )
+        assert rt_messages.CANCEL in client.sent
+        assert client._quiet is True
+        assert client._asleep is True
+
+    async def test_no_fast_response_while_asleep(self, client):
+        client._asleep = True
+        await _speak(client, _FAST_PATH_MIN_SPEECH_S + 1.0)
+        assert _response_creates(client) == []
+
+    async def test_threshold_is_longer_than_any_stop_word(self, client):
+        # Sanity on the constant itself: a child saying "fermati" slowly is ~1s.
+        assert 1.5 <= _FAST_PATH_MIN_SPEECH_S <= 2.5

--- a/robot/tests/test_presence.py
+++ b/robot/tests/test_presence.py
@@ -1,0 +1,91 @@
+"""Presence: the robot must notice whether the child is actually there.
+
+The detector flickers, and Mario has cerebral palsy — he moves, he leans out of
+frame, he turns away. So the interesting cases here are not "does it see a face"
+but "does it refuse to over-react to one that comes and goes".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from reachy_mini_mirrorbuddy import presence
+from reachy_mini_mirrorbuddy.presence import PresenceTracker
+
+
+@pytest.fixture
+def tracker():
+    return PresenceTracker(arrive_after=1.0, leave_after=10.0, same_visit=60.0)
+
+
+def feed(tracker, detected: bool, start: float, duration: float, step: float = 0.33):
+    """Hold ``detected`` steady for ``duration`` seconds; return (events, end time)."""
+    events, t = [], start
+    while t <= start + duration:
+        e = tracker.update(detected, t)
+        if e:
+            events.append((e, t))
+        t += step
+    return events, t
+
+
+class TestArriving:
+    def test_a_face_that_stays_counts_as_arrival(self, tracker):
+        events, _ = feed(tracker, True, 0.0, 2.0)
+        assert [e for e, _ in events] == [presence.ARRIVED]
+        assert tracker.state.present is True
+
+    def test_arrival_is_not_declared_instantly(self, tracker):
+        assert tracker.update(True, 0.0) is None
+        assert tracker.update(True, 0.5) is None
+        assert tracker.state.present is False
+
+    def test_arrival_is_reported_only_once(self, tracker):
+        events, _ = feed(tracker, True, 0.0, 30.0)
+        assert len(events) == 1
+
+
+class TestLeaving:
+    def test_a_brief_disappearance_is_not_a_departure(self, tracker):
+        _, t = feed(tracker, True, 0.0, 2.0)
+        # He leans down to pick up a pen for four seconds.
+        events, t = feed(tracker, False, t, 4.0)
+        assert events == []
+        assert tracker.state.present is True
+
+    def test_really_leaving_is_eventually_noticed(self, tracker):
+        _, t = feed(tracker, True, 0.0, 2.0)
+        events, _ = feed(tracker, False, t, 12.0)
+        assert [e for e, _ in events] == [presence.LEFT]
+        assert tracker.state.present is False
+
+    def test_leaving_is_much_more_patient_than_arriving(self):
+        t = PresenceTracker()
+        # Telling a child "you left" while he bends over is worse than saying nothing.
+        assert t.leave_after >= 5 * t.arrive_after
+
+    def test_flicker_never_produces_an_event(self, tracker):
+        events, t = feed(tracker, True, 0.0, 2.0)
+        now = t
+        for i in range(60):  # alternating detection, ~20 s of noise
+            e = tracker.update(i % 2 == 0, now)
+            assert e is None
+            now += 0.33
+
+
+class TestComingBack:
+    def test_a_short_absence_is_the_same_visit(self, tracker):
+        _, t = feed(tracker, True, 0.0, 2.0)
+        _, t = feed(tracker, False, t, 12.0)  # LEFT
+        events, _ = feed(tracker, True, t + 20.0, 2.0)  # back after 20s
+        assert events == []  # not worth a "bentornato"
+
+    def test_a_long_absence_earns_a_welcome_back(self, tracker):
+        _, t = feed(tracker, True, 0.0, 2.0)
+        _, t = feed(tracker, False, t, 12.0)
+        events, _ = feed(tracker, True, t + 120.0, 2.0)
+        assert [e for e, _ in events] == [presence.RETURNED]
+
+    def test_away_for_is_zero_while_present(self, tracker):
+        feed(tracker, True, 0.0, 2.0)
+        assert tracker.away_for(5.0) == 0.0

--- a/robot/tests/test_presence.py
+++ b/robot/tests/test_presence.py
@@ -89,3 +89,30 @@ class TestComingBack:
     def test_away_for_is_zero_while_present(self, tracker):
         feed(tracker, True, 0.0, 2.0)
         assert tracker.away_for(5.0) == 0.0
+
+
+class TestHowTheGreetingAddressesTheChild:
+    """Being called by a stranger's name is a small betrayal a child remembers."""
+
+    @staticmethod
+    def _clause(name):
+        from reachy_mini_mirrorbuddy.controller import Controller
+
+        c = Controller.__new__(Controller)
+        c.cfg = type("Cfg", (), {"STUDENT_NAME": name})()
+        return c._name_clause()
+
+    def test_a_known_name_is_handed_to_the_model(self):
+        assert "Mario" in self._clause("Mario")
+
+    def test_no_name_means_an_explicit_ban_on_inventing_one(self):
+        clause = self._clause(None)
+        assert "senza usare nomi" in clause
+
+    def test_ciphertext_never_reaches_the_greeting(self):
+        clause = self._clause("pii:v1:yO6kRLN95WvcdZfsME")
+        assert "pii" not in clause
+        assert "senza usare nomi" in clause
+
+    def test_a_failed_decryption_placeholder_is_refused(self):
+        assert "senza usare nomi" in self._clause("[decryption-failed]")

--- a/robot/tests/test_resolve_maestro.py
+++ b/robot/tests/test_resolve_maestro.py
@@ -1,0 +1,75 @@
+"""Picking the right professor from what a child actually says.
+
+A child asks for "scienze motorie", not for the subject code ``sport``. Before this
+was handled, the loose match sent that request to Darwin (shared word: "scienze"),
+and Buddy then looped through apologies while the child waited. Choosing the wrong
+teacher is worse than admitting there isn't one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reachy_mini_mirrorbuddy.mirrorbuddy_client import Maestro  # noqa: E402
+from reachy_mini_mirrorbuddy.tools import resolve_maestro  # noqa: E402
+
+
+def _m(mid: str, name: str, subject: str, specialty: str) -> Maestro:
+    return Maestro(
+        id=mid,
+        name=name,
+        display_name=name,
+        subject=subject,
+        specialty=specialty,
+        voice="alloy",
+        voice_instructions="",
+        teaching_style="",
+        system_prompt="",
+        greeting="",
+    )
+
+
+ROSTER = [
+    _m("darwin", "Darwin", "biology", "Scienze Naturali ed Evoluzione"),
+    _m("simone", "Simone Barlaam", "sport", "Sport e Movimento"),
+    _m("euclide", "Euclide", "mathematics", "Geometria"),
+    _m("manzoni", "Manzoni", "italian", "Letteratura Italiana"),
+]
+
+
+class TestSpokenSubjectNames:
+    def test_scienze_motorie_reaches_the_sport_teacher(self):
+        assert resolve_maestro(ROSTER, "scienze motorie").id == "simone"
+
+    def test_educazione_fisica_reaches_the_sport_teacher(self):
+        assert resolve_maestro(ROSTER, "educazione fisica").id == "simone"
+
+    def test_scienze_alone_still_reaches_darwin(self):
+        assert resolve_maestro(ROSTER, "scienze").id == "darwin"
+
+    def test_italian_school_name_reaches_the_right_teacher(self):
+        assert resolve_maestro(ROSTER, "matematica").id == "euclide"
+        assert resolve_maestro(ROSTER, "italiano").id == "manzoni"
+
+
+class TestByName:
+    def test_exact_name(self):
+        assert resolve_maestro(ROSTER, "Euclide").id == "euclide"
+
+    def test_name_inside_a_sentence(self):
+        assert resolve_maestro(ROSTER, "vorrei parlare con Darwin").id == "darwin"
+
+
+class TestNoGuessing:
+    def test_unknown_subject_returns_none(self):
+        """Better to say "I don't have that" than to hand the child the wrong teacher."""
+        assert resolve_maestro(ROSTER, "diritto internazionale") is None
+
+    def test_empty_query(self):
+        assert resolve_maestro(ROSTER, "") is None
+
+    def test_empty_roster(self):
+        assert resolve_maestro([], "matematica") is None

--- a/robot/tests/test_resolve_maestro.py
+++ b/robot/tests/test_resolve_maestro.py
@@ -73,3 +73,18 @@ class TestNoGuessing:
 
     def test_empty_roster(self):
         assert resolve_maestro([], "matematica") is None
+
+
+class TestNoiseNeverSwitchesTeacher:
+    """Silence is the right answer when the child said nothing matchable."""
+
+    def test_a_query_of_only_short_words_matches_nobody(self):
+        # No token survives the length filter, so nothing can legitimately match.
+        assert resolve_maestro(ROSTER, "ai") is None
+        assert resolve_maestro(ROSTER, "e la") is None
+
+    def test_an_unrelated_word_matches_nobody(self):
+        assert resolve_maestro(ROSTER, "frigorifero") is None
+
+    def test_real_requests_still_resolve(self):
+        assert resolve_maestro(ROSTER, "scienze motorie").id == "simone"

--- a/robot/tests/test_settings_routes.py
+++ b/robot/tests/test_settings_routes.py
@@ -1,0 +1,64 @@
+"""The settings page must actually persist what a parent types into it.
+
+This is a regression test for a silent failure: because ``Request`` was imported
+inside the mount function while annotations were postponed, FastAPI could not
+resolve the annotation, treated ``request`` as a query parameter, and answered
+every save with "Field required". The page looked fine and saved nothing —
+volume, student name and the pairing code all quietly went nowhere.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from reachy_mini_mirrorbuddy.settings_ui import mount_settings_routes  # noqa: E402
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> TestClient:
+    app = fastapi.FastAPI()
+    mount_settings_routes(app, str(tmp_path))
+    return TestClient(app)
+
+
+def test_saving_settings_persists_to_the_env_file(client: TestClient, tmp_path: Path) -> None:
+    r = client.post(
+        "/api/config",
+        json={"MIRRORBUDDY_STUDENT_NAME": "Mario", "MIRRORBUDDY_OUTPUT_GAIN": "4.5"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json().get("ok") is True
+
+    written = (tmp_path / ".env").read_text()
+    assert "MIRRORBUDDY_STUDENT_NAME=Mario" in written
+    assert "MIRRORBUDDY_OUTPUT_GAIN=4.5" in written
+
+
+def test_body_is_read_as_json_not_as_a_query_parameter(client: TestClient) -> None:
+    """The exact shape of the original bug: a 422 asking for a 'request' query param."""
+    r = client.post("/api/config", json={"MIRRORBUDDY_STUDENT_NAME": "Mario"})
+    assert r.status_code != 422, f"body was not accepted: {r.text}"
+
+
+def test_unknown_keys_are_ignored(client: TestClient, tmp_path: Path) -> None:
+    client.post("/api/config", json={"EVIL_KEY": "x", "MIRRORBUDDY_STUDENT_NAME": "Mario"})
+    assert "EVIL_KEY" not in (tmp_path / ".env").read_text()
+
+
+def test_pairing_route_also_accepts_a_body(client: TestClient) -> None:
+    r = client.post("/api/pair", json={"code": "000000"})
+    assert r.status_code != 422, f"pairing body was not accepted: {r.text}"
+
+
+def test_status_is_served(client: TestClient) -> None:
+    r = client.get("/api/status")
+    assert r.status_code == 200
+    assert "outputGain" in r.json()

--- a/robot/tests/test_settings_routes.py
+++ b/robot/tests/test_settings_routes.py
@@ -62,3 +62,23 @@ def test_status_is_served(client: TestClient) -> None:
     r = client.get("/api/status")
     assert r.status_code == 200
     assert "outputGain" in r.json()
+
+
+def test_status_exposes_the_speaker_volume(client: TestClient) -> None:
+    """A parent tuning loudness needs the mixer value, not only the software gain."""
+    body = client.get("/api/status").json()
+    assert "volume" in body
+
+
+def test_speaker_volume_can_be_saved(client: TestClient, tmp_path: Path) -> None:
+    r = client.post("/api/config", json={"MIRRORBUDDY_VOLUME": "70"})
+    assert r.status_code == 200, r.text
+    assert "MIRRORBUDDY_VOLUME=70" in (tmp_path / ".env").read_text()
+
+
+def test_the_settings_page_offers_the_speaker_volume_control() -> None:
+    """Exposed in the payload but absent from the form would still be unreachable."""
+    from reachy_mini_mirrorbuddy.settings_page import PAGE
+
+    assert 'id="MIRRORBUDDY_VOLUME"' in PAGE
+    assert "MIRRORBUDDY_VOLUME" in PAGE.split("const ids=")[1][:400]

--- a/scripts/check-migrations-applied.ts
+++ b/scripts/check-migrations-applied.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env tsx
+/**
+ * Fails when the database is missing migrations that exist in the repo.
+ *
+ * Why this exists: the "generate pairing code" button returned a 500 for weeks
+ * because the RobotDevice table had never been created in production. The code
+ * shipped, the migration did not, and nothing anywhere said so — the only signal
+ * was a parent clicking a button that did nothing. A schema this far behind the
+ * code is silent until a child hits it.
+ *
+ * Run against production with:
+ *   DIRECT_URL=... npx tsx scripts/check-migrations-applied.ts
+ */
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Client } from 'pg';
+
+const MIGRATIONS_DIR = join(process.cwd(), 'apps/web/prisma/migrations');
+
+function localMigrations(): string[] {
+  return readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+async function appliedMigrations(client: Client): Promise<Set<string>> {
+  const { rows } = await client.query<{
+    migration_name: string;
+    finished_at: Date | null;
+    rolled_back_at: Date | null;
+  }>('SELECT migration_name, finished_at, rolled_back_at FROM _prisma_migrations');
+  return new Set(
+    rows.filter((r) => r.finished_at && !r.rolled_back_at).map((r) => r.migration_name),
+  );
+}
+
+async function main(): Promise<void> {
+  const url = process.env.DIRECT_URL || process.env.DATABASE_URL;
+  if (!url) {
+    console.error('✗ Neither DIRECT_URL nor DATABASE_URL is set.');
+    process.exit(1);
+  }
+
+  const client = new Client({
+    connectionString: url.replace(/[?&]sslmode=[^&]*/, ''),
+    ssl: { rejectUnauthorized: false },
+  });
+
+  try {
+    await client.connect();
+    const local = localMigrations();
+    const applied = await appliedMigrations(client);
+    const pending = local.filter((m) => !applied.has(m));
+
+    console.log(
+      `Migrations — in repo: ${local.length}, applied: ${applied.size}, pending: ${pending.length}`,
+    );
+
+    if (pending.length > 0) {
+      console.error('\n✗ The database is behind the code. Not applied:');
+      pending.forEach((m) => console.error(`    ${m}`));
+      console.error('\nRun `npx prisma migrate deploy` against this database before shipping.');
+      process.exit(1);
+    }
+
+    console.log('✓ Database schema matches the migrations in the repo.');
+  } catch (error) {
+    console.error('✗ Could not verify migrations:', error instanceof Error ? error.message : error);
+    process.exit(1);
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+}
+
+void main();


### PR DESCRIPTION
Three things a child would have hit, plus the diagnostics that were missing.

**Settings never saved.** `Request` was imported inside the mount function while annotations were postponed, so FastAPI could not resolve the annotation, treated it as a query parameter, and answered every save with `Field required`. Volume, student name and the pairing code all silently went nowhere. Now imported at module level, with route-level regression tests that exercise the real handler.

**The voice was too quiet.** `MIRRORBUDDY_VOLUME` (system mixer, pushed at startup only when it differs so it doesn't beep on every launch) and `MIRRORBUDDY_OUTPUT_GAIN` (tanh soft-clip, so peaks compress instead of rasping). Barge-in threshold scales with the gain so a louder Buddy doesn't cut himself off. Both exposed on the settings page.

**Wrong professor, then a loop.** "scienze motorie" matched Darwin on the shared word "scienze". Italian school-subject aliases added; partial matches refused; on no match the model now gets the real roster instead of retrying the same failing call.

Also: a cancel that lands just after a response ends is a normal race, not an ERROR; and motion failures are no longer swallowed at debug level.

Verified on the physical robot: settings persist, app runs, greeting spoken.
57 robot tests pass. Mutation-checked: reverting each fix fails its tests.