### PR TITLE
fix(ci): install dependencies before the promotion schema gate

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -89,6 +89,12 @@ jobs:
           fi
           echo "✅ Staging is healthy (HTTP $status)"
 
+      # The check below imports `pg`, which only exists once the workspace is
+      # installed. Without this step the gate fails on a missing module and
+      # looks exactly like real schema drift.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Verify database schema is up to date
         env:
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
@@ -101,7 +107,7 @@ jobs:
             echo "::error::DIRECT_URL secret is not set — cannot verify schema drift"
             exit 1
           fi
-          pnpm dlx tsx scripts/check-migrations-applied.ts
+          pnpm exec tsx scripts/check-migrations-applied.ts
 
       - name: Promote to Production
         id: promote


### PR DESCRIPTION
The schema-drift gate added in #584 ran `pnpm dlx tsx scripts/check-migrations-applied.ts` in a workspace that is never installed by this workflow, so `import { Client } from 'pg'` threw and the first real promotion failed — indistinguishable from actual drift.

Evidence: run 30827580942 failed at *Verify database schema is up to date* with production actually in sync (`in repo: 44, applied: 45, pending: 0`, verified locally against DIRECT_URL).

Adds `pnpm install --frozen-lockfile --ignore-scripts` before the gate and runs the script with `pnpm exec`.