### PR TITLE
fix(robot): start as the coach the child already sees selected

### DIFF
--- a/apps/web/src/components/settings/sections/character-settings.tsx
+++ b/apps/web/src/components/settings/sections/character-settings.tsx
@@ -1,35 +1,27 @@
-"use client";
+'use client';
 
-import { Sparkles, Heart, GraduationCap, Palette } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CharacterSelector } from "./character-selector";
-import { ColorPicker, ColorPreview } from "./color-picker";
-import { BORDER_COLORS, COACHES, BUDDIES } from "./character-settings-data";
-import { useTranslations } from "next-intl";
+import { Sparkles, Heart, GraduationCap, Palette } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CharacterSelector } from './character-selector';
+import { ColorPicker, ColorPreview } from './color-picker';
+import { BORDER_COLORS, COACHES, BUDDIES } from './character-settings-data';
+import { useTranslations } from 'next-intl';
+import { DEFAULT_COACH_ID, DEFAULT_BUDDY_ID } from '@/lib/characters/defaults';
 
 interface CharacterSettingsProps {
   profile: {
-    preferredCoach?:
-      | "melissa"
-      | "roberto"
-      | "chiara"
-      | "andrea"
-      | "favij"
-      | "laura";
-    preferredBuddy?: "mario" | "noemi" | "enea" | "bruno" | "sofia" | "marta";
+    preferredCoach?: 'melissa' | 'roberto' | 'chiara' | 'andrea' | 'favij' | 'laura';
+    preferredBuddy?: 'mario' | 'noemi' | 'enea' | 'bruno' | 'sofia' | 'marta';
     coachBorderColor?: string;
     buddyBorderColor?: string;
   };
-  onUpdate: (updates: Partial<CharacterSettingsProps["profile"]>) => void;
+  onUpdate: (updates: Partial<CharacterSettingsProps['profile']>) => void;
 }
 
-export function CharacterSettings({
-  profile,
-  onUpdate,
-}: CharacterSettingsProps) {
-  const t = useTranslations("settings");
-  const selectedCoach = profile.preferredCoach || "melissa";
-  const selectedBuddy = profile.preferredBuddy || "mario";
+export function CharacterSettings({ profile, onUpdate }: CharacterSettingsProps) {
+  const t = useTranslations('settings');
+  const selectedCoach = profile.preferredCoach || DEFAULT_COACH_ID;
+  const selectedBuddy = profile.preferredBuddy || DEFAULT_BUDDY_ID;
   const coachData = COACHES.find((c) => c.id === selectedCoach);
   const buddyData = BUDDIES.find((b) => b.id === selectedBuddy);
 
@@ -39,11 +31,11 @@ export function CharacterSettings({
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Sparkles className="w-5 h-5 text-amber-500" />
-            {t("ilTuoCoachDiApprendimento")}
+            {t('ilTuoCoachDiApprendimento')}
           </CardTitle>
           <p className="text-sm text-slate-600 dark:text-slate-400">
-            {t("ilCoachTiAiutaASviluppareIlTuoMetodoDiStudioEDiven")}
-            {t("autonomo")}
+            {t('ilCoachTiAiutaASviluppareIlTuoMetodoDiStudioEDiven')}
+            {t('autonomo')}
           </p>
         </CardHeader>
         <CardContent>
@@ -53,12 +45,12 @@ export function CharacterSettings({
             onSelect={(id) =>
               onUpdate({
                 preferredCoach: id as
-                  | "melissa"
-                  | "roberto"
-                  | "chiara"
-                  | "andrea"
-                  | "favij"
-                  | "laura",
+                  | 'melissa'
+                  | 'roberto'
+                  | 'chiara'
+                  | 'andrea'
+                  | 'favij'
+                  | 'laura',
               })
             }
             title=""
@@ -71,11 +63,11 @@ export function CharacterSettings({
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Heart className="w-5 h-5 text-rose-500" />
-            {t("ilTuoMirrorbuddy")}
+            {t('ilTuoMirrorbuddy')}
           </CardTitle>
           <p className="text-sm text-slate-600 dark:text-slate-400">
-            {t("ilBuddyEUnAmicoDellaTuaEtaCheCapisceLeTueDifficolt")}
-            {t("supporta")}
+            {t('ilBuddyEUnAmicoDellaTuaEtaCheCapisceLeTueDifficolt')}
+            {t('supporta')}
           </p>
         </CardHeader>
         <CardContent>
@@ -84,13 +76,7 @@ export function CharacterSettings({
             selectedId={selectedBuddy}
             onSelect={(id) =>
               onUpdate({
-                preferredBuddy: id as
-                  | "mario"
-                  | "noemi"
-                  | "enea"
-                  | "bruno"
-                  | "sofia"
-                  | "marta",
+                preferredBuddy: id as 'mario' | 'noemi' | 'enea' | 'bruno' | 'sofia' | 'marta',
               })
             }
             title=""
@@ -103,10 +89,10 @@ export function CharacterSettings({
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Palette className="w-5 h-5 text-violet-500" />
-            {t("personalizzaIColori")}
+            {t('personalizzaIColori')}
           </CardTitle>
           <p className="text-sm text-slate-600 dark:text-slate-400">
-            {t("scegliIColoriDeiBordiPerRiconoscereCoachEBuddyNegl")}
+            {t('scegliIColoriDeiBordiPerRiconoscereCoachEBuddyNegl')}
           </p>
         </CardHeader>
         <CardContent className="space-y-6">
@@ -144,11 +130,11 @@ export function CharacterSettings({
           </div>
           <div>
             <h4 className="font-medium text-amber-900 dark:text-amber-100">
-              {t("ilTriangoloDelSupporto")}
+              {t('ilTriangoloDelSupporto')}
             </h4>
             <p className="text-sm text-amber-700 dark:text-amber-300 mt-1">
-              {t("ilCoachTiInsegnaIlMetodoIlBuddyTiSupportaEmotivame")}
-              {t("characterSettingsTeamDescription")}
+              {t('ilCoachTiInsegnaIlMetodoIlBuddyTiSupportaEmotivame')}
+              {t('characterSettingsTeamDescription')}
             </p>
           </div>
         </div>

--- a/apps/web/src/lib/characters/defaults.ts
+++ b/apps/web/src/lib/characters/defaults.ts
@@ -1,0 +1,11 @@
+/**
+ * The coach and buddy a child is treated as having chosen before they choose.
+ *
+ * The settings screen has always shown Melissa pre-selected when the profile is
+ * empty, but that fallback lived only inside the component. The robot read the
+ * raw database value, found null, and introduced itself as a neutral "Buddy" —
+ * so the child saw one thing on screen and heard another on the desk. Both
+ * surfaces now resolve the same default from here.
+ */
+export const DEFAULT_COACH_ID = 'melissa' as const;
+export const DEFAULT_BUDDY_ID = 'mario' as const;

--- a/apps/web/src/lib/devices/__tests__/device-service.test.ts
+++ b/apps/web/src/lib/devices/__tests__/device-service.test.ts
@@ -2,14 +2,16 @@
  * Unit tests for device-service (robot pairing).
  * TDD: behaviour specified before wiring the routes.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock("@/lib/db", async () => {
-  const { createMockPrisma } = await import("@/test/mocks/prisma");
+import { DEFAULT_COACH_ID, DEFAULT_BUDDY_ID } from '@/lib/characters/defaults';
+
+vi.mock('@/lib/db', async () => {
+  const { createMockPrisma } = await import('@/test/mocks/prisma');
   return { prisma: createMockPrisma() };
 });
 
-vi.mock("@/lib/logger", () => ({
+vi.mock('@/lib/logger', () => ({
   logger: {
     info: vi.fn(),
     warn: vi.fn(),
@@ -24,66 +26,63 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
-import { prisma } from "@/lib/db";
+import { prisma } from '@/lib/db';
 import {
   createPairingCode,
   redeemPairingCode,
   getDeviceProfile,
   listDevices,
   revokeDevice,
-} from "../device-service";
+} from '../device-service';
 
- 
 const db = prisma as any;
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("createPairingCode", () => {
-  it("stores a hashed code and returns a 6-digit code with future expiry", async () => {
-    db.robotDevice.create.mockResolvedValue({ id: "d1" });
+describe('createPairingCode', () => {
+  it('stores a hashed code and returns a 6-digit code with future expiry', async () => {
+    db.robotDevice.create.mockResolvedValue({ id: 'd1' });
 
-    const result = await createPairingCode("user-1", "Cameretta");
+    const result = await createPairingCode('user-1', 'Cameretta');
 
     expect(result.code).toMatch(/^\d{6}$/);
     expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
     const data = db.robotDevice.create.mock.calls[0][0].data;
-    expect(data.userId).toBe("user-1");
-    expect(data.label).toBe("Cameretta");
+    expect(data.userId).toBe('user-1');
+    expect(data.label).toBe('Cameretta');
     expect(data.pairCodeHash).toMatch(/^[a-f0-9]{64}$/);
     expect(data.pairCodeHash).not.toContain(result.code);
   });
 
-  it("retries on a hashed-code collision (P2002)", async () => {
-    const collision = Object.assign(new Error("unique"), { code: "P2002" });
-    db.robotDevice.create
-      .mockRejectedValueOnce(collision)
-      .mockResolvedValueOnce({ id: "d2" });
+  it('retries on a hashed-code collision (P2002)', async () => {
+    const collision = Object.assign(new Error('unique'), { code: 'P2002' });
+    db.robotDevice.create.mockRejectedValueOnce(collision).mockResolvedValueOnce({ id: 'd2' });
 
-    const result = await createPairingCode("user-1");
+    const result = await createPairingCode('user-1');
 
     expect(result.code).toMatch(/^\d{6}$/);
     expect(db.robotDevice.create).toHaveBeenCalledTimes(2);
   });
 
-  it("surfaces a non-collision error immediately without retrying", async () => {
-    db.robotDevice.create.mockRejectedValue(new Error("db down"));
+  it('surfaces a non-collision error immediately without retrying', async () => {
+    db.robotDevice.create.mockRejectedValue(new Error('db down'));
 
-    await expect(createPairingCode("user-1")).rejects.toThrow("db down");
+    await expect(createPairingCode('user-1')).rejects.toThrow('db down');
     expect(db.robotDevice.create).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("redeemPairingCode", () => {
-  it("rejects a malformed code without hitting the database", async () => {
-    expect(await redeemPairingCode("abc")).toBeNull();
+describe('redeemPairingCode', () => {
+  it('rejects a malformed code without hitting the database', async () => {
+    expect(await redeemPairingCode('abc')).toBeNull();
     expect(db.robotDevice.updateMany).not.toHaveBeenCalled();
   });
 
-  it("returns null when no redeemable code matches (unknown/expired/already-paired)", async () => {
+  it('returns null when no redeemable code matches (unknown/expired/already-paired)', async () => {
     db.robotDevice.updateMany.mockResolvedValue({ count: 0 });
-    expect(await redeemPairingCode("123456")).toBeNull();
+    expect(await redeemPairingCode('123456')).toBeNull();
     // The guard lives in the atomic updateMany where-clause.
     const where = db.robotDevice.updateMany.mock.calls[0][0].where;
     expect(where.tokenHash).toBeNull();
@@ -91,95 +90,132 @@ describe("redeemPairingCode", () => {
     expect(where.pairCodeExpiresAt.gt).toBeInstanceOf(Date);
   });
 
-  it("issues a token atomically and clears the code on success", async () => {
+  it('issues a token atomically and clears the code on success', async () => {
     db.robotDevice.updateMany.mockResolvedValue({ count: 1 });
-    db.robotDevice.findUnique.mockResolvedValue({ id: "d1" });
+    db.robotDevice.findUnique.mockResolvedValue({ id: 'd1' });
 
-    const result = await redeemPairingCode("123456");
+    const result = await redeemPairingCode('123456');
 
     expect(result?.token).toMatch(/^[a-f0-9]{64}$/);
-    expect(result?.deviceId).toBe("d1");
+    expect(result?.deviceId).toBe('d1');
     const data = db.robotDevice.updateMany.mock.calls[0][0].data;
     expect(data.pairCodeHash).toBeNull();
     expect(data.tokenHash).toMatch(/^[a-f0-9]{64}$/);
     expect(data.tokenHash).not.toBe(result?.token);
   });
 
-  it("returns null if the claimed row cannot be read back", async () => {
+  it('returns null if the claimed row cannot be read back', async () => {
     db.robotDevice.updateMany.mockResolvedValue({ count: 1 });
     db.robotDevice.findUnique.mockResolvedValue(null);
-    expect(await redeemPairingCode("123456")).toBeNull();
+    expect(await redeemPairingCode('123456')).toBeNull();
   });
 });
 
-describe("getDeviceProfile", () => {
-  it("returns null for an unknown token", async () => {
+describe('getDeviceProfile', () => {
+  it('returns null for an unknown token', async () => {
     db.robotDevice.findUnique.mockResolvedValue(null);
-    expect(await getDeviceProfile("tok")).toBeNull();
+    expect(await getDeviceProfile('tok')).toBeNull();
   });
 
-  it("returns null for a revoked device", async () => {
+  it('returns null for a revoked device', async () => {
     db.robotDevice.findUnique.mockResolvedValue({
-      id: "d1",
+      id: 'd1',
       revokedAt: new Date(),
       user: { profile: null, settings: null },
     });
-    expect(await getDeviceProfile("tok")).toBeNull();
+    expect(await getDeviceProfile('tok')).toBeNull();
   });
 
-  it("maps profile + settings and refreshes lastSeenAt", async () => {
+  it('maps profile + settings and refreshes lastSeenAt', async () => {
     db.robotDevice.findUnique.mockResolvedValue({
-      id: "d1",
+      id: 'd1',
       revokedAt: null,
       user: {
         profile: {
-          name: "Mario",
-          preferredBuddy: "sofia",
-          preferredCoach: "roberto",
-          schoolLevel: "superiore",
-          gradeLevel: "2",
+          name: 'Mario',
+          preferredBuddy: 'sofia',
+          preferredCoach: 'roberto',
+          schoolLevel: 'superiore',
+          gradeLevel: '2',
           age: 15,
           learningGoals: '["matematica","storia"]',
         },
-        settings: { language: "it", dyslexiaFont: true, adhdMode: true },
+        settings: { language: 'it', dyslexiaFont: true, adhdMode: true },
       },
     });
     db.robotDevice.update.mockResolvedValue({});
 
-    const profile = await getDeviceProfile("tok");
+    const profile = await getDeviceProfile('tok');
 
-    expect(profile?.name).toBe("Mario");
-    expect(profile?.preferredBuddy).toBe("sofia");
-    expect(profile?.subjects).toEqual(["matematica", "storia"]);
-    expect(profile?.language).toBe("it");
+    expect(profile?.name).toBe('Mario');
+    expect(profile?.preferredBuddy).toBe('sofia');
+    expect(profile?.subjects).toEqual(['matematica', 'storia']);
+    expect(profile?.language).toBe('it');
     expect(profile?.accessibility.dyslexiaFont).toBe(true);
     expect(profile?.accessibility.adhdMode).toBe(true);
     expect(db.robotDevice.update).toHaveBeenCalledWith({
-      where: { id: "d1" },
+      where: { id: 'd1' },
       data: { lastSeenAt: expect.any(Date) },
     });
   });
+
+  it('falls back to the coach the settings screen shows pre-selected', async () => {
+    // A child who never opened the character screen still sees Melissa ticked
+    // there. The robot used to read null and introduce itself as a neutral
+    // buddy, so screen and desk disagreed about who was helping.
+    db.robotDevice.findUnique.mockResolvedValue({
+      id: 'd1',
+      revokedAt: null,
+      user: {
+        profile: { name: 'Mario', preferredBuddy: null, preferredCoach: null },
+        settings: null,
+      },
+    });
+    db.robotDevice.update.mockResolvedValue({});
+
+    const profile = await getDeviceProfile('tok');
+
+    expect(profile?.preferredCoach).toBe(DEFAULT_COACH_ID);
+    expect(profile?.preferredBuddy).toBe(DEFAULT_BUDDY_ID);
+  });
+
+  it('never overrides a coach the child actually picked', async () => {
+    db.robotDevice.findUnique.mockResolvedValue({
+      id: 'd1',
+      revokedAt: null,
+      user: {
+        profile: { name: 'Mario', preferredBuddy: 'sofia', preferredCoach: 'andrea' },
+        settings: null,
+      },
+    });
+    db.robotDevice.update.mockResolvedValue({});
+
+    const profile = await getDeviceProfile('tok');
+
+    expect(profile?.preferredCoach).toBe('andrea');
+    expect(profile?.preferredBuddy).toBe('sofia');
+  });
 });
 
-describe("listDevices / revokeDevice", () => {
+describe('listDevices / revokeDevice', () => {
   it("lists a user's active devices", async () => {
-    db.robotDevice.findMany.mockResolvedValue([{ id: "d1", label: "Robot" }]);
-    const devices = await listDevices("user-1");
+    db.robotDevice.findMany.mockResolvedValue([{ id: 'd1', label: 'Robot' }]);
+    const devices = await listDevices('user-1');
     expect(devices).toHaveLength(1);
     expect(db.robotDevice.findMany.mock.calls[0][0].where).toEqual({
-      userId: "user-1",
+      userId: 'user-1',
       revokedAt: null,
       pairedAt: { not: null },
     });
   });
 
-  it("returns true when a device is revoked", async () => {
+  it('returns true when a device is revoked', async () => {
     db.robotDevice.updateMany.mockResolvedValue({ count: 1 });
-    expect(await revokeDevice("user-1", "d1")).toBe(true);
+    expect(await revokeDevice('user-1', 'd1')).toBe(true);
   });
 
-  it("returns false when nothing is revoked", async () => {
+  it('returns false when nothing is revoked', async () => {
     db.robotDevice.updateMany.mockResolvedValue({ count: 0 });
-    expect(await revokeDevice("user-1", "d1")).toBe(false);
+    expect(await revokeDevice('user-1', 'd1')).toBe(false);
   });
 });

--- a/apps/web/src/lib/devices/device-service.ts
+++ b/apps/web/src/lib/devices/device-service.ts
@@ -10,9 +10,10 @@
  * - Only SHA-256 hashes of the code and token are ever stored — never plaintext.
  */
 
-import { createHash, createHmac, randomBytes, randomInt } from "crypto";
-import { prisma } from "@/lib/db";
-import { logger } from "@/lib/logger";
+import { createHash, createHmac, randomBytes, randomInt } from 'crypto';
+import { prisma } from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { DEFAULT_BUDDY_ID, DEFAULT_COACH_ID } from '@/lib/characters/defaults';
 
 const CODE_TTL_MS = 10 * 60 * 1000; // pairing code valid for 10 minutes
 const CODE_DIGITS = 6;
@@ -23,30 +24,28 @@ const MAX_LABEL_LEN = 80;
 // is unset). A 6-digit code has just 10^6 possibilities, so a bare hash could be
 // brute-forced from a DB leak; a server-side HMAC key makes the stored verifier
 // useless without the secret.
-const FALLBACK_PEPPER = "mirrorbuddy-device-pairing-fallback-pepper";
+const FALLBACK_PEPPER = 'mirrorbuddy-device-pairing-fallback-pepper';
 
 function sha256(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
+  return createHash('sha256').update(value).digest('hex');
 }
 
 /** Keyed hash for the low-entropy pairing code (HMAC with a server pepper). */
 function hashCode(code: string): string {
   let pepper = process.env.DEVICE_PAIRING_PEPPER || process.env.ENCRYPTION_KEY;
   if (!pepper) {
-    logger.warn(
-      "DEVICE_PAIRING_PEPPER is not set, using fallback pepper for pairing codes",
-    );
+    logger.warn('DEVICE_PAIRING_PEPPER is not set, using fallback pepper for pairing codes');
     pepper = FALLBACK_PEPPER;
   }
-  return createHmac("sha256", pepper).update(code).digest("hex");
+  return createHmac('sha256', pepper).update(code).digest('hex');
 }
 
 function generateCode(): string {
-  return String(randomInt(0, 10 ** CODE_DIGITS)).padStart(CODE_DIGITS, "0");
+  return String(randomInt(0, 10 ** CODE_DIGITS)).padStart(CODE_DIGITS, '0');
 }
 
 function generateToken(): string {
-  return randomBytes(32).toString("hex"); // 256-bit device token
+  return randomBytes(32).toString('hex'); // 256-bit device token
 }
 
 export interface PairingCode {
@@ -85,10 +84,7 @@ export interface DeviceSummary {
 }
 
 /** Generate a fresh pairing code for a user, storing only its hash. */
-export async function createPairingCode(
-  userId: string,
-  label?: string,
-): Promise<PairingCode> {
+export async function createPairingCode(userId: string, label?: string): Promise<PairingCode> {
   const expiresAt = new Date(Date.now() + CODE_TTL_MS);
   const safeLabel = label?.trim().slice(0, MAX_LABEL_LEN) || null;
 
@@ -108,13 +104,13 @@ export async function createPairingCode(
       // Retry ONLY on a unique-constraint collision of the hashed code (P2002);
       // surface any other error (DB down, FK violation) immediately.
       const code = (error as { code?: string }).code;
-      if (code !== "P2002" || attempt === MAX_CODE_ATTEMPTS - 1) {
-        logger.error("Failed to allocate pairing code", undefined, error);
+      if (code !== 'P2002' || attempt === MAX_CODE_ATTEMPTS - 1) {
+        logger.error('Failed to allocate pairing code', undefined, error);
         throw error;
       }
     }
   }
-  throw new Error("Unable to allocate pairing code");
+  throw new Error('Unable to allocate pairing code');
 }
 
 /** Redeem a pairing code, returning a one-time device token (hash stored). */
@@ -152,14 +148,12 @@ export async function redeemPairingCode(
     select: { id: true },
   });
   if (!device) return null;
-  logger.info("Robot device paired", { deviceId: device.id });
+  logger.info('Robot device paired', { deviceId: device.id });
   return { token, deviceId: device.id };
 }
 
 /** Resolve a device token to the owner's robot-facing profile scope. */
-export async function getDeviceProfile(
-  token: string,
-): Promise<DeviceProfile | null> {
+export async function getDeviceProfile(token: string): Promise<DeviceProfile | null> {
   const trimmed = token?.trim();
   if (!trimmed) return null;
 
@@ -178,15 +172,15 @@ export async function getDeviceProfile(
   const settings = device.user.settings;
   return {
     name: profile?.name ?? null,
-    preferredBuddy: profile?.preferredBuddy ?? null,
-    preferredCoach: profile?.preferredCoach ?? null,
+    preferredBuddy: profile?.preferredBuddy ?? DEFAULT_BUDDY_ID,
+    preferredCoach: profile?.preferredCoach ?? DEFAULT_COACH_ID,
     schoolLevel: profile?.schoolLevel ?? null,
     gradeLevel: profile?.gradeLevel ?? null,
     age: profile?.age ?? null,
-    language: settings?.language ?? "it",
+    language: settings?.language ?? 'it',
     subjects: parseSubjects(profile?.learningGoals),
     accessibility: {
-      fontSize: settings?.fontSize ?? "medium",
+      fontSize: settings?.fontSize ?? 'medium',
       highContrast: settings?.highContrast ?? false,
       dyslexiaFont: settings?.dyslexiaFont ?? false,
       reducedMotion: settings?.reducedMotion ?? false,
@@ -201,7 +195,7 @@ export async function getDeviceProfile(
 export async function listDevices(userId: string): Promise<DeviceSummary[]> {
   return prisma.robotDevice.findMany({
     where: { userId, revokedAt: null, pairedAt: { not: null } },
-    orderBy: { createdAt: "desc" },
+    orderBy: { createdAt: 'desc' },
     select: {
       id: true,
       label: true,
@@ -213,10 +207,7 @@ export async function listDevices(userId: string): Promise<DeviceSummary[]> {
 }
 
 /** Revoke a device the user owns. Returns false if not found / not theirs. */
-export async function revokeDevice(
-  userId: string,
-  deviceId: string,
-): Promise<boolean> {
+export async function revokeDevice(userId: string, deviceId: string): Promise<boolean> {
   const result = await prisma.robotDevice.updateMany({
     where: { id: deviceId, userId, revokedAt: null },
     data: { revokedAt: new Date(), tokenHash: null, pairCodeHash: null },
@@ -229,11 +220,11 @@ function parseSubjects(raw: string | null | undefined): string[] {
   try {
     const parsed: unknown = JSON.parse(raw);
     if (Array.isArray(parsed)) {
-      return parsed.filter((s): s is string => typeof s === "string");
+      return parsed.filter((s): s is string => typeof s === 'string');
     }
   } catch {
     return raw
-      .split(",")
+      .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,12 +86,16 @@ const eslintConfig = defineConfig([
     // Coverage reports
     "coverage/**",
     // Playwright reports (generated files)
-    "playwright-report/**",
-    "test-results/**",
+    "**/playwright-report/**",
+    "**/test-results/**",
     // Git worktree directories (local only)
     "feat/**",
     "feature/**",
     "worktrees/**",
+    // Local tooling output: gitignored, but ESLint still walked into the
+    // bundled Playwright trace viewer and reported thousands of errors in
+    // minified vendor code, which made `npm run lint` unusable locally.
+    ".gstack/**",
   ]),
   // Custom rules
   {


### PR DESCRIPTION
Roberto asked that the robot start as the coach the child chose. It did honour an explicit choice, but when the profile was empty it fell back to a neutral "Buddy" — while the settings screen showed Melissa ticked. Screen and desk disagreed.

- `DEFAULT_COACH_ID` / `DEFAULT_BUDDY_ID` now live in `@/lib/characters/defaults`; the settings component and `getDeviceProfile` both read from there.
- `/api/devices/me` returns the effective coach, not the raw nullable column.
- An explicitly chosen coach is never overridden (covered by a test).
- 2 tests, RED confirmed before the fix.

Verified against production: every `Profile` row has `preferredCoach = null`, so today every robot starts neutral — this is the fix for Mario's robot specifically.

Also unblocks local linting: ESLint was walking into generated Playwright traces (`apps/web/playwright-report/**`, `.gstack/**`) and reporting 185 errors in minified vendor bundles, which made `npm run lint` unusable and hid real findings.