### PR TITLE
fix(ci): promotion no longer fails when the deploy is already live or still building

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -120,14 +120,17 @@ jobs:
           # for a broken deploy that did not exist.
           # A build triggered by the merge may still be running when this starts:
           # Vercel then refuses with "is not ready", which is a matter of waiting.
+          promoted=false
           for attempt in $(seq 1 10); do
             if out=$(vercel promote "$url" --token=${{ secrets.VERCEL_TOKEN }} --scope=team_nDwLfqx9JbVIs4C7Il79f4ln --yes 2>&1); then
               echo "$out"
+              promoted=true
               break
             fi
             echo "$out"
             if echo "$out" | grep -q "already the current production deployment"; then
               echo "✅ Already in production — nothing to promote"
+              promoted=true
               break
             fi
             if echo "$out" | grep -q "is not ready"; then
@@ -137,6 +140,13 @@ jobs:
             fi
             exit 1
           done
+          # Running out of attempts is a failure, not a promotion: without this
+          # the loop would fall through to the success line below and report a
+          # deploy that never went live.
+          if [ "$promoted" != "true" ]; then
+            echo "::error::Deployment was still not ready after 10 attempts (5 minutes)"
+            exit 1
+          fi
           echo "✅ Promotion complete"
           echo "promoted_url=$url" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -114,7 +114,29 @@ jobs:
         run: |
           url="${{ steps.find-staging.outputs.deployment_url }}"
           echo "🚀 Promoting $url to production..."
-          vercel promote "$url" --token=${{ secrets.VERCEL_TOKEN }} --scope=team_nDwLfqx9JbVIs4C7Il79f4ln --yes
+          # Vercel already promotes the latest main build on its own, so by the
+          # time this runs the chosen deployment is often already live. That is
+          # the desired end state, not a failure — a red run here sent us looking
+          # for a broken deploy that did not exist.
+          # A build triggered by the merge may still be running when this starts:
+          # Vercel then refuses with "is not ready", which is a matter of waiting.
+          for attempt in $(seq 1 10); do
+            if out=$(vercel promote "$url" --token=${{ secrets.VERCEL_TOKEN }} --scope=team_nDwLfqx9JbVIs4C7Il79f4ln --yes 2>&1); then
+              echo "$out"
+              break
+            fi
+            echo "$out"
+            if echo "$out" | grep -q "already the current production deployment"; then
+              echo "✅ Already in production — nothing to promote"
+              break
+            fi
+            if echo "$out" | grep -q "is not ready"; then
+              echo "Deployment still building; retrying in 30s (attempt $attempt/10)"
+              sleep 30
+              continue
+            fi
+            exit 1
+          done
           echo "✅ Promotion complete"
           echo "promoted_url=$url" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Two promotion runs went red today with nothing wrong with the deploy:

- run 30906721993 — `The provided deploymentId is not ready`: the build started by the merge was still running. Now retried for up to five minutes.
- run 30908149131 — `is already the current production deployment`: `auto-promote-production` in ci.yml had already promoted that build. That is the desired end state, so it now reports success.

Net effect: a red run here used to send us looking for a broken production deployment that did not exist.