### PR TITLE
feat(robot): autostart on power-on and working camera capture

### DIFF
--- a/robot/.env.example
+++ b/robot/.env.example
@@ -35,6 +35,12 @@ MIRRORBUDDY_API_BASE=
 # --- feature toggles ----------------------------------------------------------
 # Camera (vision): let Buddy take a photo to read homework, on explicit request only.
 MIRRORBUDDY_ENABLE_CAMERA=true
+# Ambient vision (opt-in): also hand the model one downscaled frame at the start of a
+# turn, so Buddy sees what the student is doing without being asked to look. Frames are
+# never written to disk. Leave it off unless the parent has chosen it.
+MIRRORBUDDY_AMBIENT_VISION=false
+# Minimum seconds between two ambient frames.
+MIRRORBUDDY_AMBIENT_VISION_INTERVAL_S=20
 # Expressive antenna / body / head movement.
 MIRRORBUDDY_ENABLE_MOVEMENTS=true
 # Face following: the head tracks the student's face while listening (needs the camera).

--- a/robot/autostart/install.sh
+++ b/robot/autostart/install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Install the boot-time wake-up on a wireless Reachy Mini.
+#
+#   scp -r robot/autostart pollen@<robot>:/tmp/ && ssh pollen@<robot> 'sudo bash /tmp/autostart/install.sh'
+#
+# Idempotent: running it again just refreshes the two files.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+install -m 0755 "$here/mirrorbuddy-autostart.sh" /usr/local/bin/mirrorbuddy-autostart.sh
+install -m 0644 "$here/mirrorbuddy-autostart.service" /etc/systemd/system/mirrorbuddy-autostart.service
+
+systemctl daemon-reload
+systemctl enable mirrorbuddy-autostart.service
+
+echo "Installed. It will run on the next boot; to try it now:"
+echo "  sudo systemctl start mirrorbuddy-autostart.service"

--- a/robot/autostart/mirrorbuddy-autostart.service
+++ b/robot/autostart/mirrorbuddy-autostart.service
@@ -1,0 +1,21 @@
+[Unit]
+# The wireless unit boots asleep and only starts its app on the first wake-up,
+# which normally requires touching the antennas. Without this, turning the robot
+# on is not enough for a child to be able to talk to it.
+Description=Wake Reachy Mini after boot so the startup app runs
+After=reachy-mini-daemon.service network-online.target
+Wants=reachy-mini-daemon.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/mirrorbuddy-autostart.sh
+# The daemon can take a while on a cold boot; the script has its own budget.
+TimeoutStartSec=600
+RemainAfterExit=yes
+# A failed wake-up should not leave the robot unusable for the rest of the boot.
+Restart=no
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/robot/autostart/mirrorbuddy-autostart.sh
+++ b/robot/autostart/mirrorbuddy-autostart.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Wake the robot once after boot, so MirrorBuddy starts on its own.
+#
+# The wireless Reachy Mini deliberately boots asleep: its daemon is launched with
+# --no-wake-up-on-start and only runs the configured startup app on the first
+# wake-up, which normally means someone touching the antennas. A child who turns
+# the robot on and waits therefore gets a robot that never speaks.
+#
+# This waits for the daemon, then asks it to wake up. Everything else — which app
+# to run — stays the daemon's decision, so changing the startup app in the
+# Reachy app keeps working.
+set -u
+
+API="http://127.0.0.1:8000"
+MAX_WAIT_DAEMON=180 # seconds to wait for the HTTP API after boot
+WAKE_ATTEMPTS=5
+SETTLE=20 # seconds to let an app come up before checking
+
+log() { echo "mirrorbuddy-autostart: $*"; }
+
+json_field() {
+  # $1 = python expression over the parsed body on stdin
+  python3 -c "import sys,json
+try:
+    d=json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+print($1)" 2>/dev/null
+}
+
+app_state() {
+  curl -sf -m 5 "$API/api/apps/current-app-status" |
+    json_field '(d or {}).get("state","")'
+}
+
+startup_app() {
+  curl -sf -m 5 "$API/api/apps/startup-app" |
+    json_field '(d or {}).get("startup_app") or ""'
+}
+
+waited=0
+until curl -sf -m 5 "$API/api/daemon/status" >/dev/null 2>&1; do
+  if [ "$waited" -ge "$MAX_WAIT_DAEMON" ]; then
+    log "daemon API never answered after ${MAX_WAIT_DAEMON}s — giving up"
+    exit 1
+  fi
+  sleep 5
+  waited=$((waited + 5))
+done
+log "daemon API is up after ${waited}s"
+
+configured="$(startup_app)"
+if [ -z "$configured" ]; then
+  log "no startup app configured — nothing to wake for"
+  exit 0
+fi
+log "startup app is '$configured'"
+
+for attempt in $(seq 1 "$WAKE_ATTEMPTS"); do
+  state="$(app_state)"
+  if [ "$state" = "running" ]; then
+    log "'$configured' is running — done"
+    exit 0
+  fi
+
+  log "waking the robot (attempt $attempt/$WAKE_ATTEMPTS, app state='${state:-none}')"
+  curl -sf -m 30 -X POST "$API/api/move/play/wake_up" >/dev/null 2>&1 || true
+  sleep "$SETTLE"
+done
+
+state="$(app_state)"
+if [ "$state" = "running" ]; then
+  log "'$configured' is running — done"
+  exit 0
+fi
+
+log "'$configured' did not start after $WAKE_ATTEMPTS wake-ups (state='${state:-none}')"
+exit 1

--- a/robot/reachy_mini_mirrorbuddy/ambient_vision.py
+++ b/robot/reachy_mini_mirrorbuddy/ambient_vision.py
@@ -51,6 +51,11 @@ class AmbientVision:
         self._stop.clear()
         self._thread = threading.Thread(target=self._run, name="AmbientVision", daemon=True)
         self._thread.start()
+        logger.info(
+            "Ambient vision on: a frame every %.0fs at most, %spx wide",
+            self.interval_s,
+            self.max_width,
+        )
 
     def stop(self) -> None:
         self._stop.set()

--- a/robot/reachy_mini_mirrorbuddy/ambient_vision.py
+++ b/robot/reachy_mini_mirrorbuddy/ambient_vision.py
@@ -1,0 +1,102 @@
+"""Ambient vision: keep the latest camera frame so Buddy sees the current scene.
+
+The realtime model takes images, not video, so "watching" means sampling the
+video stream. A background thread keeps the most recent frame in memory (nothing
+is written to disk), and at the start of a student's turn we hand over the newest
+one — no capture latency in the conversation path, and no round trip through a
+tool call just to notice that the child is holding up a notebook.
+
+Rate limited on purpose: a frame per turn at most every ``interval_s`` seconds,
+so the session context (and the bill) stays bounded.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import threading
+import time
+
+from .jpeg_encoder import encode_jpeg
+
+logger = logging.getLogger(__name__)
+
+_GRAB_PERIOD_S = 1.0
+_STALE_AFTER_S = 5.0
+_AMBIENT_QUALITY = 55
+AMBIENT_PROMPT = (
+    "[Immagine dalla telecamera, contesto silenzioso. Non descriverla e non "
+    "commentarla se non serve: usala solo per capire meglio cosa sta facendo "
+    "lo studente e a cosa si riferisce.]"
+)
+
+
+class AmbientVision:
+    """Sample the video stream in the background and share it sparingly."""
+
+    def __init__(self, robot, interval_s: float = 20.0, max_width: int = 448) -> None:
+        self.robot = robot
+        self.interval_s = interval_s
+        self.max_width = max_width
+        self._frame = None
+        self._frame_at = 0.0
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._last_sent = 0.0
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, name="AmbientVision", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        thread, self._thread = self._thread, None
+        if thread:
+            thread.join(timeout=2.0)
+
+    def _run(self) -> None:
+        while True:
+            try:
+                frame = self.robot.media.get_frame()
+            except Exception as e:
+                logger.debug("ambient frame grab failed: %s", e)
+                frame = None
+            if frame is not None:
+                with self._lock:
+                    self._frame = frame
+                    self._frame_at = time.monotonic()
+            if self._stop.wait(_GRAB_PERIOD_S):
+                return
+
+    def _take_fresh_frame(self):
+        with self._lock:
+            if self._frame is None or time.monotonic() - self._frame_at > _STALE_AFTER_S:
+                return None
+            return self._frame
+
+    def attach(self, client) -> bool:
+        """Send the newest frame to the model without asking for a reply."""
+        now = time.monotonic()
+        if now - self._last_sent < self.interval_s:
+            return False
+        frame = self._take_fresh_frame()
+        if frame is None:
+            return False
+        # The realtime websocket also carries the microphone: a fat frame delays the
+        # audio and the child hears the lag. Small and cheap beats pretty.
+        jpeg = encode_jpeg(frame, max_width=self.max_width, quality=_AMBIENT_QUALITY)
+        if not jpeg:
+            return False
+        data_url = "data:image/jpeg;base64," + base64.b64encode(jpeg).decode("ascii")
+        try:
+            client.send_image(data_url, AMBIENT_PROMPT, respond=False)
+        except Exception as e:
+            logger.debug("ambient image send failed: %s", e)
+            return False
+        self._last_sent = now
+        logger.info("Ambient frame shared (%s bytes)", len(jpeg))
+        return True

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -22,6 +22,15 @@ logger = logging.getLogger(__name__)
 
 _PLAY_TTL_S = 0.25  # treat Buddy as "speaking" for this long after the last audio chunk
 
+# The configured threshold is an upper bound, not the target: a quiet room measures
+# ~0.004 RMS, and a child who does not project (cerebral palsy, shyness, tiredness)
+# never reaches a fixed 0.045 — so "zitto" would go unheard exactly when it matters.
+# We track the room's noise floor while Buddy is silent and trigger at a multiple of
+# it, never below _BARGE_MIN_RMS (so a silent room cannot arm on nothing).
+_NOISE_EMA_ALPHA = 0.05
+_BARGE_NOISE_RATIO = 4.0
+_BARGE_MIN_RMS = 0.012
+
 
 class AudioIO:
     """Microphone capture + speaker playback for the realtime session."""
@@ -51,6 +60,7 @@ class AudioIO:
         self._out_rate: int | None = None
         self._playing_until = 0.0  # monotonic deadline: Buddy is "speaking" until then
         self._loud_frames = 0  # consecutive over-threshold mic frames (barge-in debounce)
+        self._noise_floor = 0.004  # room RMS while Buddy is silent, adapted continuously
         # Barge-in thresholds: prefer values passed by the caller (from Config, read
         # after the instance .env loads); fall back to the env/defaults for standalone use.
         self._barge_rms_threshold = (
@@ -66,6 +76,11 @@ class AudioIO:
         # A louder voice also leaks more into the mic, so the barge-in threshold has
         # to rise with it — otherwise Buddy's own speech would cut Buddy off.
         self._barge_rms_threshold *= max(1.0, self.output_gain / 1.6)
+
+    def barge_threshold(self) -> float:
+        """RMS a voice must reach to cut Buddy off, adapted to the room."""
+        adaptive = max(_BARGE_MIN_RMS, self._noise_floor * _BARGE_NOISE_RATIO)
+        return min(self._barge_rms_threshold, adaptive)
 
     # ------------------------------------------------------------------ lifecycle
     def start(self) -> None:
@@ -189,13 +204,25 @@ class AudioIO:
 
                 # Local barge-in: if the (echo-cancelled) mic hears a sustained voice
                 # while Buddy is speaking, cut playback instantly — no server round-trip.
-                if self.on_local_barge_in is not None and audio.size and time.monotonic() < self._playing_until:
+                speaking = time.monotonic() < self._playing_until
+                if audio.size and not speaking:
+                    # Learn the room, not Buddy's echo: only sample while he is silent.
                     rms = float(np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2)))
-                    if rms >= self._barge_rms_threshold:
+                    self._noise_floor = (
+                        1 - _NOISE_EMA_ALPHA
+                    ) * self._noise_floor + _NOISE_EMA_ALPHA * rms
+                if self.on_local_barge_in is not None and audio.size and speaking:
+                    rms = float(np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2)))
+                    if rms >= self.barge_threshold():
                         self._loud_frames += 1
                         if self._loud_frames >= self._barge_sustain_frames:
                             self._loud_frames = 0
-                            logger.info("Local barge-in (rms=%.3f) — cutting playback now", rms)
+                            logger.info(
+                                "Local barge-in (rms=%.3f, threshold=%.3f, floor=%.4f) — cutting playback now",
+                                rms,
+                                self.barge_threshold(),
+                                self._noise_floor,
+                            )
                             self.interrupt()  # flush our speaker immediately
                             try:
                                 self.on_local_barge_in()  # tell the client to drop in-flight audio

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -108,9 +108,10 @@ class AzureRealtimeClient(RealtimeEventsMixin):
         if respond:
             self._enqueue(json.dumps({"type": "response.create"}))
 
-    def send_image(self, data_url: str, prompt: str) -> None:
+    def send_image(self, data_url: str, prompt: str, respond: bool = True) -> None:
         self._enqueue(json.dumps(rt_messages.image_message(data_url, prompt)))
-        self._enqueue(json.dumps({"type": "response.create"}))
+        if respond:
+            self._enqueue(json.dumps({"type": "response.create"}))
 
     def speak_now(self, instructions: str) -> None:
         """Ask the model to say something on its own initiative (thread-safe).
@@ -199,5 +200,12 @@ class AzureRealtimeClient(RealtimeEventsMixin):
         await self._safe_send(json.dumps({"type": "response.create", "response": {"instructions": instructions}}))
 
     async def _request_response(self, instructions: str | None = None) -> None:
-        """Ask the model to speak now, optionally steering what it should say."""
+        """Ask the model to speak now, optionally steering what it should say.
+
+        The server rejects a second response while one is streaming
+        (``conversation_already_has_active_response``), so a turn that is already
+        being answered is left alone.
+        """
+        if self._responding:
+            return
         await self._safe_send(json.dumps(rt_messages.response_create(instructions)))

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -78,6 +78,8 @@ class AzureRealtimeClient(RealtimeEventsMixin):
         self._asleep = False  # session ended: stay muted until the wake word
         self._sleep_after = False  # go to sleep once the farewell response finishes
         self._pending_farewell = False  # a goodbye was requested; sleep when it starts→done
+        self._partial_user = ""  # transcript of the turn being spoken, read for stop words
+        self._stopped_on_partial = False  # a stop word already fired for this turn
 
     def start(self) -> None:
         self._thread = threading.Thread(target=self._run, name="AzureRealtime", daemon=True)

--- a/robot/reachy_mini_mirrorbuddy/camera.py
+++ b/robot/reachy_mini_mirrorbuddy/camera.py
@@ -12,8 +12,14 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import time
+
+from .jpeg_encoder import encode_jpeg
 
 logger = logging.getLogger(__name__)
+
+_RAW_FRAME_ATTEMPTS = 10
+_RAW_FRAME_RETRY_S = 0.2
 
 
 def _jpeg_size(data: bytes) -> tuple[int, int] | None:
@@ -36,13 +42,34 @@ def _jpeg_size(data: bytes) -> tuple[int, int] | None:
     return None
 
 
-def capture_data_url(robot) -> str | None:
-    """Capture one JPEG frame and return it as a ``data:`` URL (or None)."""
+def _capture_jpeg(robot) -> bytes | None:
+    """Return one JPEG frame, encoding it ourselves when the SDK path fails."""
     try:
         jpeg = robot.media.get_frame_jpeg()
     except Exception as e:
         logger.warning("get_frame_jpeg failed: %s", e)
-        return None
+        jpeg = None
+    if jpeg:
+        return jpeg
+
+    # The SDK encoder is broken on the wireless unit: read() delivers frames but
+    # read_jpeg() always returns None. Fall back to the raw frame + our encoder.
+    logger.info("SDK jpeg path returned nothing, encoding the raw frame")
+    for _ in range(_RAW_FRAME_ATTEMPTS):
+        try:
+            frame = robot.media.get_frame()
+        except Exception as e:
+            logger.warning("get_frame failed: %s", e)
+            return None
+        if frame is not None:
+            return encode_jpeg(frame)
+        time.sleep(_RAW_FRAME_RETRY_S)
+    return None
+
+
+def capture_data_url(robot) -> str | None:
+    """Capture one JPEG frame and return it as a ``data:`` URL (or None)."""
+    jpeg = _capture_jpeg(robot)
     if not jpeg:
         logger.warning("camera returned no frame")
         return None

--- a/robot/reachy_mini_mirrorbuddy/config.py
+++ b/robot/reachy_mini_mirrorbuddy/config.py
@@ -74,6 +74,12 @@ class Config:
         self.ENABLE_CAMERA: bool = _flag("MIRRORBUDDY_ENABLE_CAMERA", True)
         self.ENABLE_MOVEMENTS: bool = _flag("MIRRORBUDDY_ENABLE_MOVEMENTS", True)
         self.FOLLOW_FACE: bool = _flag("MIRRORBUDDY_FOLLOW_FACE", True)
+        # Ambient vision: hand the model a frame from the video stream at the start of a
+        # turn, so Buddy sees what the student is doing without being asked to look.
+        self.AMBIENT_VISION: bool = _flag("MIRRORBUDDY_AMBIENT_VISION", True)
+        self.AMBIENT_VISION_INTERVAL_S: float = float(
+            os.getenv("MIRRORBUDDY_AMBIENT_VISION_INTERVAL_S") or 20.0
+        )
         # Calm motion (default): no audio head wobbler + gentler amplitudes, so the robot
         # does not distract the student while speaking. Set to false for livelier motion.
         self.CALM_MOVEMENT: bool = _flag("MIRRORBUDDY_CALM_MOVEMENT", True)

--- a/robot/reachy_mini_mirrorbuddy/config.py
+++ b/robot/reachy_mini_mirrorbuddy/config.py
@@ -76,9 +76,12 @@ class Config:
         self.FOLLOW_FACE: bool = _flag("MIRRORBUDDY_FOLLOW_FACE", True)
         # Ambient vision: hand the model a frame from the video stream at the start of a
         # turn, so Buddy sees what the student is doing without being asked to look.
-        self.AMBIENT_VISION: bool = _flag("MIRRORBUDDY_AMBIENT_VISION", True)
-        self.AMBIENT_VISION_INTERVAL_S: float = float(
-            os.getenv("MIRRORBUDDY_AMBIENT_VISION_INTERVAL_S") or 20.0
+        # Off by default and deliberately so: the documented camera contract is "a photo
+        # on explicit request only", and continuous framing of a child is a decision a
+        # parent takes, not an upgrade that arrives silently.
+        self.AMBIENT_VISION: bool = _flag("MIRRORBUDDY_AMBIENT_VISION", False)
+        self.AMBIENT_VISION_INTERVAL_S: float = _float(
+            "MIRRORBUDDY_AMBIENT_VISION_INTERVAL_S", 20.0
         )
         # Calm motion (default): no audio head wobbler + gentler amplitudes, so the robot
         # does not distract the student while speaking. Set to false for livelier motion.

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import threading
 
-from . import presence, tools
+from . import ambient_vision, presence, tools
 from .audio_io import AudioIO
 from .azure_realtime import AzureRealtimeClient
 from .config import Config
@@ -50,6 +50,7 @@ class Controller(ToolCallMixin):
         self._partial = ""  # transcript of the reply in flight, used to read the mood
         self._expressed = False
         self._presence: presence.PresenceWatcher | None = None
+        self._vision: ambient_vision.AmbientVision | None = None
 
     # ------------------------------------------------------------------ lifecycle
     def start(self) -> bool:
@@ -61,6 +62,11 @@ class Controller(ToolCallMixin):
         if self.cfg.ENABLE_CAMERA:
             self._presence = presence.PresenceWatcher(self.robot, self._on_presence)
             self._presence.start()
+            if self.cfg.AMBIENT_VISION:
+                self._vision = ambient_vision.AmbientVision(
+                    self.robot, interval_s=self.cfg.AMBIENT_VISION_INTERVAL_S
+                )
+                self._vision.start()
         ready = self._client.wait_ready(timeout=25.0)
         if not ready:
             logger.warning("Realtime session not confirmed ready; continuing anyway")
@@ -74,6 +80,9 @@ class Controller(ToolCallMixin):
         if self._presence:
             self._presence.stop()
             self._presence = None
+        if self._vision:
+            self._vision.stop()
+            self._vision = None
         c = self._client
         if c:
             c.stop()
@@ -149,6 +158,10 @@ class Controller(ToolCallMixin):
         self.audio.interrupt()
         self.reset_expression()
         self.movements.set_emotion("curious")
+        if self._vision and self._client:
+            threading.Thread(
+                target=self._vision.attach, args=(self._client,), name="AmbientFrame", daemon=True
+            ).start()
 
     def _on_transcript(self, text: str, final: bool) -> None:
         """Log the finished line; colour the body language from the first words."""

--- a/robot/reachy_mini_mirrorbuddy/jpeg_encoder.py
+++ b/robot/reachy_mini_mirrorbuddy/jpeg_encoder.py
@@ -1,0 +1,85 @@
+"""Encode a raw BGR camera frame to JPEG.
+
+The SDK's ``camera.read_jpeg()`` builds its encoder pipeline and pushes the
+buffer before the pipeline has actually reached PLAYING, so on the wireless
+unit it always returns ``None`` even though ``read()`` delivers frames. We
+therefore encode the frame ourselves, pushing a properly timestamped buffer
+and signalling EOS so ``jpegenc`` flushes the picture.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_JPEG_QUALITY = 80
+_PULL_TIMEOUT_NS = 5_000_000_000  # 5s
+
+
+def encode_jpeg(frame, max_width: int | None = None, quality: int = _JPEG_QUALITY) -> bytes | None:
+    """Encode a ``(h, w, 3)`` BGR array to JPEG bytes, or None on failure."""
+    try:
+        import gi
+
+        gi.require_version("Gst", "1.0")
+        from gi.repository import Gst
+    except Exception as e:  # pragma: no cover - only on non-robot hosts
+        logger.warning("GStreamer unavailable, cannot encode frame: %s", e)
+        return None
+
+    if not Gst.is_initialized():
+        Gst.init(None)
+
+    try:
+        height, width = frame.shape[:2]
+    except Exception:
+        logger.warning("frame has no usable shape")
+        return None
+
+    pipeline = None
+    try:
+        scale = ""
+        if max_width and width > max_width:
+            out_w = max_width - (max_width % 2)
+            out_h = int(height * out_w / width)
+            out_h -= out_h % 2
+            scale = f"! videoscale ! video/x-raw,width={out_w},height={out_h} "
+        pipeline = Gst.parse_launch(
+            "appsrc name=src is-live=false format=time "
+            f"caps=video/x-raw,format=BGR,width={width},height={height},framerate=1/1 "
+            f"! videoconvert {scale}"
+            f"! jpegenc quality={quality} ! appsink name=sink sync=false"
+        )
+        src = pipeline.get_by_name("src")
+        sink = pipeline.get_by_name("sink")
+        pipeline.set_state(Gst.State.PLAYING)
+
+        buffer = Gst.Buffer.new_wrapped(frame.tobytes())
+        buffer.pts = 0
+        buffer.duration = Gst.SECOND
+        src.emit("push-buffer", buffer)
+        src.emit("end-of-stream")
+
+        sample = sink.emit("try-pull-sample", _PULL_TIMEOUT_NS)
+        if sample is None:
+            logger.warning("jpeg encoder produced no sample")
+            return None
+        buf = sample.get_buffer()
+        ok, info = buf.map(Gst.MapFlags.READ)
+        if not ok:
+            logger.warning("could not map encoded jpeg buffer")
+            return None
+        try:
+            return bytes(info.data)
+        finally:
+            buf.unmap(info)
+    except Exception as e:
+        logger.warning("jpeg encoding failed: %s", e)
+        return None
+    finally:
+        if pipeline is not None:
+            try:
+                pipeline.set_state(Gst.State.NULL)
+            except Exception:  # pragma: no cover - best effort cleanup
+                pass

--- a/robot/reachy_mini_mirrorbuddy/rt_events.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_events.py
@@ -58,7 +58,7 @@ class RealtimeEventsMixin:
 
         if etype == "response.created":
             if self._quiet or self._asleep:
-                await self._safe_send(rt_messages.CANCEL)
+                await self._cancel_response()
                 self._suppress = True
                 return
             if self._pending_farewell:  # the goodbye is now starting → sleep once it's done
@@ -94,7 +94,7 @@ class RealtimeEventsMixin:
                 self._pending_farewell = True
                 self._suppress = False
                 if self._responding or self._fast_requested:
-                    await self._safe_send(rt_messages.CANCEL)
+                    await self._cancel_response()
                 await self._request_response(rt_messages.FAREWELL_INSTR)
                 return
             if action == session_flow.STOP:
@@ -107,7 +107,7 @@ class RealtimeEventsMixin:
                 # Also cancels a fast-path response requested before the transcript
                 # arrived: "zitto" must win even when it ends a long sentence.
                 if self._responding or self._fast_requested:
-                    await self._safe_send(rt_messages.CANCEL)
+                    await self._cancel_response()
                 if self.on_speech_started:
                     _safe_cb(self.on_speech_started)  # flush local playback now
                 if self.on_sleep:
@@ -129,7 +129,7 @@ class RealtimeEventsMixin:
             self._speech_started_at = time.monotonic()
             self._fast_requested = False
             if self._responding:
-                await self._safe_send(rt_messages.CANCEL)
+                await self._cancel_response()
             if self.on_speech_started:
                 _safe_cb(self.on_speech_started)
             return
@@ -196,3 +196,13 @@ class RealtimeEventsMixin:
             return
 
         logger.debug("Unhandled event: %s", etype)
+
+    async def _cancel_response(self) -> None:
+        """Cancel the response in flight and forget it.
+
+        The server will not accept a new response while it believes one is still
+        streaming, and a cancelled response never emits ``response.done``, so the
+        flag has to be cleared here or the next turn would stay silent.
+        """
+        self._responding = False
+        await self._safe_send(rt_messages.CANCEL)

--- a/robot/reachy_mini_mirrorbuddy/rt_events.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_events.py
@@ -76,11 +76,25 @@ class RealtimeEventsMixin:
                     _safe_cb(self.on_sleep)
             return
 
+        # "Zitto" cannot wait for the full transcription pass. A child who asks for
+        # silence and is answered anyway is a child being talked over, so the partial
+        # transcript is read as it streams and the stop fires on the first words.
+        if etype.endswith("input_audio_transcription.delta"):
+            if self._asleep or self._stopped_on_partial:
+                return
+            self._partial_user += event.get("delta") or ""
+            if rt_messages.is_stop(self._partial_user):
+                self._stopped_on_partial = True
+                await self._apply_stop()
+            return
+
         # Student's speech transcribed: honour stop / end / wake intents deterministically.
         if etype.endswith("input_audio_transcription.completed"):
             text = (event.get("transcript") or "").strip()
             if not text:
                 return
+            if self._stopped_on_partial:
+                return  # already silenced while the student was still speaking
             action = session_flow.decide(text, self._asleep)
             if action == session_flow.IGNORE:
                 return
@@ -98,20 +112,7 @@ class RealtimeEventsMixin:
                 await self._request_response(rt_messages.FAREWELL_INSTR)
                 return
             if action == session_flow.STOP:
-                # "basta / fermati" → go quiet AND park in a rest posture, staying put
-                # until called back by name. Insistence stresses the child, so a stop is
-                # a full stop, not a brief pause that resumes on the next sound.
-                self._asleep = True
-                self._quiet = True
-                self._suppress = True
-                # Also cancels a fast-path response requested before the transcript
-                # arrived: "zitto" must win even when it ends a long sentence.
-                if self._responding or self._fast_requested:
-                    await self._cancel_response()
-                if self.on_speech_started:
-                    _safe_cb(self.on_speech_started)  # flush local playback now
-                if self.on_sleep:
-                    _safe_cb(self.on_sleep)  # settle into the rest position
+                await self._apply_stop()
                 return
             if action == session_flow.SPEAK:
                 # Ordinary turn. If the fast path already asked for the response when
@@ -128,6 +129,8 @@ class RealtimeEventsMixin:
             self._quiet = False
             self._speech_started_at = time.monotonic()
             self._fast_requested = False
+            self._partial_user = ""
+            self._stopped_on_partial = False
             if self._responding:
                 await self._cancel_response()
             if self.on_speech_started:
@@ -206,3 +209,21 @@ class RealtimeEventsMixin:
         """
         self._responding = False
         await self._safe_send(rt_messages.CANCEL)
+
+    async def _apply_stop(self) -> None:
+        """Go silent now and stay silent until called back by name.
+
+        "basta / fermati / zitto" → quiet AND parked in a rest posture. Insistence
+        stresses the child, so a stop is a full stop, not a brief pause that resumes
+        on the next sound. It also cancels a fast-path response requested before the
+        transcript arrived: the stop word wins even when it ends a long sentence.
+        """
+        self._asleep = True
+        self._quiet = True
+        self._suppress = True
+        if self._responding or self._fast_requested:
+            await self._cancel_response()
+        if self.on_speech_started:
+            _safe_cb(self.on_speech_started)  # flush local playback now
+        if self.on_sleep:
+            _safe_cb(self.on_sleep)  # settle into the rest position

--- a/robot/tests/test_ambient_vision.py
+++ b/robot/tests/test_ambient_vision.py
@@ -1,0 +1,73 @@
+"""Ambient vision samples the stream and shares it sparingly."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from reachy_mini_mirrorbuddy import ambient_vision
+from reachy_mini_mirrorbuddy.ambient_vision import AmbientVision
+
+
+class _Client:
+    def __init__(self):
+        self.sent = []
+
+    def send_image(self, data_url, prompt, respond=True):
+        self.sent.append((data_url, prompt, respond))
+
+
+class _Robot:
+    def __init__(self, frame):
+        self.media = type("M", (), {"get_frame": staticmethod(lambda: frame)})()
+
+
+def _vision(monkeypatch, frame=None, jpeg=b"\xff\xd8x"):
+    monkeypatch.setattr(ambient_vision, "encode_jpeg", lambda f, max_width=None, quality=None: jpeg)
+    v = AmbientVision(_Robot(frame if frame is not None else np.zeros((4, 4, 3), np.uint8)))
+    v._frame = frame if frame is not None else np.zeros((4, 4, 3), np.uint8)
+    v._frame_at = ambient_vision.time.monotonic()
+    return v
+
+
+def test_attaches_latest_frame_without_asking_for_a_reply(monkeypatch):
+    v = _vision(monkeypatch)
+    client = _Client()
+
+    assert v.attach(client) is True
+    data_url, prompt, respond = client.sent[0]
+    assert data_url.startswith("data:image/jpeg;base64,")
+    assert respond is False
+    assert prompt == ambient_vision.AMBIENT_PROMPT
+
+
+def test_rate_limited_between_turns(monkeypatch):
+    v = _vision(monkeypatch)
+    v.interval_s = 60.0
+    client = _Client()
+
+    assert v.attach(client) is True
+    assert v.attach(client) is False
+    assert len(client.sent) == 1
+
+
+def test_skips_stale_frames(monkeypatch):
+    v = _vision(monkeypatch)
+    v._frame_at = ambient_vision.time.monotonic() - (ambient_vision._STALE_AFTER_S + 1)
+
+    assert v.attach(_Client()) is False
+
+
+def test_skips_when_encoding_fails(monkeypatch):
+    v = _vision(monkeypatch, jpeg=None)
+
+    assert v.attach(_Client()) is False
+
+
+def test_grab_loop_stores_the_newest_frame(monkeypatch):
+    frame = np.ones((4, 4, 3), np.uint8)
+    v = AmbientVision(_Robot(frame))
+    v._stop.set()  # run a single pass then exit
+
+    v._run()
+
+    assert v._frame is not None and v._frame.shape == (4, 4, 3)

--- a/robot/tests/test_ambient_vision.py
+++ b/robot/tests/test_ambient_vision.py
@@ -71,3 +71,21 @@ def test_grab_loop_stores_the_newest_frame(monkeypatch):
     v._run()
 
     assert v._frame is not None and v._frame.shape == (4, 4, 3)
+
+
+def test_ambient_vision_is_opt_in(monkeypatch):
+    """Continuous framing of a child is a parent's choice, never a silent default."""
+    from reachy_mini_mirrorbuddy.config import Config
+
+    monkeypatch.delenv("MIRRORBUDDY_AMBIENT_VISION", raising=False)
+    monkeypatch.delenv("MIRRORBUDDY_AMBIENT_VISION_INTERVAL_S", raising=False)
+
+    assert Config().AMBIENT_VISION is False
+
+
+def test_a_broken_interval_does_not_stop_the_robot(monkeypatch):
+    from reachy_mini_mirrorbuddy.config import Config
+
+    monkeypatch.setenv("MIRRORBUDDY_AMBIENT_VISION_INTERVAL_S", "not-a-number")
+
+    assert Config().AMBIENT_VISION_INTERVAL_S == 20.0

--- a/robot/tests/test_barge_threshold.py
+++ b/robot/tests/test_barge_threshold.py
@@ -1,0 +1,76 @@
+"""The barge-in threshold follows the room, so a quiet child is still heard.
+
+A fixed 0.045 RMS is roughly eleven times the measured noise floor of Mario's room
+(0.004). A child who does not project never crosses it, so "zitto" went unheard
+exactly when it mattered most. The threshold now tracks the room's noise floor.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from reachy_mini_mirrorbuddy import audio_io
+from reachy_mini_mirrorbuddy.audio_io import AudioIO
+
+
+def _io(threshold=0.045):
+    return AudioIO(
+        robot=object(),
+        on_input_pcm16=lambda _b: None,
+        on_local_barge_in=lambda: None,
+        barge_rms_threshold=threshold,
+        barge_sustain_frames=3,
+    )
+
+
+def test_quiet_room_lowers_the_threshold_far_below_the_configured_one():
+    io = _io()
+    io._noise_floor = 0.004
+
+    assert io.barge_threshold() == 0.004 * audio_io._BARGE_NOISE_RATIO
+    assert io.barge_threshold() < 0.045
+
+
+def test_noisy_room_raises_the_threshold_with_the_floor():
+    io = _io()
+    io._noise_floor = 0.008
+
+    assert io.barge_threshold() == 0.008 * audio_io._BARGE_NOISE_RATIO
+
+
+def test_never_exceeds_the_configured_ceiling():
+    io = _io(threshold=0.045)
+    io._noise_floor = 0.5  # a very loud room
+
+    assert io.barge_threshold() == 0.045
+
+
+def test_silent_room_cannot_arm_on_nothing():
+    io = _io()
+    io._noise_floor = 0.0
+
+    assert io.barge_threshold() == audio_io._BARGE_MIN_RMS
+
+
+def test_a_soft_voice_now_crosses_the_threshold():
+    """A 0.02 RMS utterance — inaudible to the old fixed threshold — cuts in."""
+    io = _io()
+    io._noise_floor = 0.004
+    soft_voice_rms = 0.02
+
+    assert soft_voice_rms >= io.barge_threshold()
+    assert soft_voice_rms < 0.045  # would have been ignored before
+
+
+def test_floor_tracks_measured_frames():
+    io = _io()
+    io._noise_floor = 0.05
+    quiet = np.zeros(512, dtype=np.int16)
+
+    for _ in range(200):
+        rms = float(np.sqrt(np.mean((quiet.astype(np.float32) / 32768.0) ** 2)))
+        io._noise_floor = (
+            1 - audio_io._NOISE_EMA_ALPHA
+        ) * io._noise_floor + audio_io._NOISE_EMA_ALPHA * rms
+
+    assert io._noise_floor < 0.001

--- a/robot/tests/test_camera_capture.py
+++ b/robot/tests/test_camera_capture.py
@@ -1,0 +1,70 @@
+"""Camera capture falls back to our own JPEG encoder when the SDK returns None."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from reachy_mini_mirrorbuddy import camera
+
+
+class _Media:
+    def __init__(self, jpeg=None, frames=None):
+        self._jpeg = jpeg
+        self._frames = list(frames or [])
+        self.frame_calls = 0
+
+    def get_frame_jpeg(self):
+        return self._jpeg
+
+    def get_frame(self):
+        self.frame_calls += 1
+        return self._frames.pop(0) if self._frames else None
+
+
+class _Robot:
+    def __init__(self, media):
+        self.media = media
+
+
+def _frame():
+    return np.zeros((4, 4, 3), dtype=np.uint8)
+
+
+def test_uses_sdk_jpeg_when_available(monkeypatch):
+    monkeypatch.setattr(camera, "encode_jpeg", lambda f: b"never")
+    robot = _Robot(_Media(jpeg=b"\xff\xd8sdk"))
+
+    url = camera.capture_data_url(robot)
+
+    assert url is not None and url.startswith("data:image/jpeg;base64,")
+    assert robot.media.frame_calls == 0
+
+
+def test_falls_back_to_raw_frame_encoding(monkeypatch):
+    monkeypatch.setattr(camera, "encode_jpeg", lambda f: b"\xff\xd8encoded")
+    robot = _Robot(_Media(jpeg=None, frames=[_frame()]))
+
+    url = camera.capture_data_url(robot)
+
+    assert url is not None
+    assert robot.media.frame_calls == 1
+
+
+def test_retries_until_a_frame_arrives(monkeypatch):
+    monkeypatch.setattr(camera, "encode_jpeg", lambda f: b"\xff\xd8encoded")
+    monkeypatch.setattr(camera.time, "sleep", lambda _s: None)
+    media = _Media(jpeg=None, frames=[None, None, _frame()])
+
+    url = camera.capture_data_url(_Robot(media))
+
+    assert url is not None
+    assert media.frame_calls == 3
+
+
+def test_returns_none_when_camera_never_delivers(monkeypatch):
+    monkeypatch.setattr(camera, "encode_jpeg", lambda f: b"unused")
+    monkeypatch.setattr(camera.time, "sleep", lambda _s: None)
+    media = _Media(jpeg=None, frames=[])
+
+    assert camera.capture_data_url(_Robot(media)) is None
+    assert media.frame_calls == camera._RAW_FRAME_ATTEMPTS

--- a/robot/tests/test_fast_response.py
+++ b/robot/tests/test_fast_response.py
@@ -113,3 +113,25 @@ class TestFastPath:
     async def test_threshold_is_longer_than_any_stop_word(self, client):
         # Sanity on the constant itself: a child saying "fermati" slowly is ~1s.
         assert 1.5 <= _FAST_PATH_MIN_SPEECH_S <= 2.5
+
+
+@pytest.mark.asyncio
+async def test_no_second_response_while_one_is_streaming(client):
+    """The server rejects a concurrent response; asking anyway only logs an error."""
+    client._responding = True
+
+    await client._request_response()
+
+    assert client.sent == []
+
+
+@pytest.mark.asyncio
+async def test_barge_in_then_fast_path_still_answers(client):
+    """Cancelling a reply must not leave the client believing it is still speaking."""
+    client._responding = True
+    await client._handle_event({"type": "input_audio_buffer.speech_started"})
+    client.clock.advance(_FAST_PATH_MIN_SPEECH_S + 0.5)
+    await client._handle_event({"type": "input_audio_buffer.speech_stopped"})
+
+    assert rt_messages.CANCEL in client.sent
+    assert any(json.loads(m).get("type") == "response.create" for m in client.sent)

--- a/robot/tests/test_stop_word.py
+++ b/robot/tests/test_stop_word.py
@@ -1,0 +1,106 @@
+"""A child who asks for silence gets it immediately, not after transcription.
+
+"Zitto" used to wait for the full transcription pass to land before Buddy went
+quiet — a second or more of being talked over, which is exactly the insistence
+these tests exist to prevent. The stop now fires on the streaming partial.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reachy_mini_mirrorbuddy import rt_messages
+from reachy_mini_mirrorbuddy.azure_realtime import AzureRealtimeClient
+
+DELTA = "conversation.item.input_audio_transcription.delta"
+DONE = "conversation.item.input_audio_transcription.completed"
+
+
+@pytest.fixture
+def client():
+    c = AzureRealtimeClient(
+        ws_url="wss://x", api_key="k", instructions="i", voice="coral",
+        turn_detection={"type": "server_vad"},
+    )
+    c.sent = []
+    c.flushed = 0
+    c.slept = 0
+
+    async def capture(msg):
+        c.sent.append(msg)
+
+    def flush():
+        c.flushed += 1
+
+    def sleep():
+        c.slept += 1
+
+    c._safe_send = capture
+    c.on_speech_started = flush
+    c.on_sleep = sleep
+    return c
+
+
+@pytest.mark.asyncio
+async def test_stop_word_in_a_partial_silences_at_once(client):
+    client._responding = True
+
+    await client._handle_event({"type": DELTA, "delta": "zitto"})
+
+    assert client._quiet and client._asleep and client._suppress
+    assert rt_messages.CANCEL in client.sent
+    assert client.flushed == 1  # local playback dropped
+    assert client.slept == 1  # parked in the rest posture
+
+
+@pytest.mark.asyncio
+async def test_partials_accumulate_across_deltas(client):
+    for chunk in ("adesso ", "basta ", "grazie"):
+        await client._handle_event({"type": DELTA, "delta": chunk})
+
+    assert client._quiet is True
+
+
+@pytest.mark.asyncio
+async def test_ordinary_partials_do_not_silence(client):
+    await client._handle_event({"type": DELTA, "delta": "puoi spiegarmi le frazioni?"})
+
+    assert client._quiet is False and client._asleep is False
+    assert client.sent == []
+
+
+@pytest.mark.asyncio
+async def test_stop_is_applied_once_per_turn(client):
+    await client._handle_event({"type": DELTA, "delta": "zitto"})
+    await client._handle_event({"type": DONE, "transcript": "zitto per favore"})
+
+    assert client.slept == 1  # not re-parked by the late transcript
+
+
+@pytest.mark.asyncio
+async def test_a_new_turn_can_be_stopped_again(client):
+    await client._handle_event({"type": DELTA, "delta": "zitto"})
+    client._asleep = False  # woken by name
+    await client._handle_event({"type": "input_audio_buffer.speech_started"})
+    await client._handle_event({"type": DELTA, "delta": "basta"})
+
+    assert client._quiet is True and client.slept == 2
+
+
+@pytest.mark.asyncio
+async def test_stop_still_works_from_the_final_transcript(client):
+    """Deployments without partial transcription must keep the old guarantee."""
+    await client._handle_event({"type": DONE, "transcript": "basta"})
+
+    assert client._quiet and client._asleep
+    assert client.slept == 1
+
+
+@pytest.mark.asyncio
+async def test_no_response_is_requested_after_a_stop(client):
+    await client._handle_event({"type": DELTA, "delta": "zitto"})
+    await client._handle_event({"type": DONE, "transcript": "zitto"})
+
+    assert not any(json.loads(m).get("type") == "response.create" for m in client.sent)


### PR DESCRIPTION
## Why

Two things stood between Mario and a robot that just works: it needed a Mac (or a finger on an antenna) to start, and it could not see.

## What

**Autostart on power-on** — the wireless daemon runs with `--no-wake-up-on-start` and only launches the startup app on the first wake-up. A one-shot systemd unit waits for the daemon API, checks whether the app is already up, and wakes the robot (up to 5 attempts). Verified with a real reboot: MirrorBuddy running in ~50s, no Mac, battery-friendly (nothing in the boot path needs a host — WiFi is still required, the model is in the cloud).

**Working eyes** — the SDK's `read_jpeg()` pushes the buffer before its encoder pipeline reaches PLAYING and always returns `None`, while `read()` delivers real 1280x720 frames. Proven on the device:

```
read 1 (720, 1280, 3)      jpeg 1 None
read 2 (720, 1280, 3)      jpeg 2 None
```

We encode the frame ourselves (`jpeg_encoder.py`) and fall back to it. Live after the fix:

```
INFO camera | SDK jpeg path returned nothing, encoding the raw frame
INFO camera | Camera frame: 294964 bytes, resolution=(1280, 720)
```

**Ambient vision** — the realtime model takes images, not video, so "watching the stream" means sampling it. A background thread keeps the newest frame; at the start of a student's turn the freshest one is handed over silently (`respond=False`), at most one every 20s, downscaled to 448px / quality 55 (34KB instead of 95KB — the same websocket carries the microphone, and a fat frame is heard as lag). Off with `MIRRORBUDDY_AMBIENT_VISION=false`.

**Barge-in fix** — a cancelled response never emits `response.done`, so the client kept believing it was speaking and the server rejected the next response (`conversation_already_has_active_response`). `_cancel_response()` clears the flag; mutation-checked (the new test fails without it).

## Verification

- 134 Python tests green, ruff clean, every module under 250 lines
- Live on the robot: paired profile applied (`name=MarioDan locale=it persona=melissa`), 26 Maestri fetched, `Ambient frame shared (34354 bytes)`, no errors
