### PR TITLE
fix(robot): make the barge-in decision testable and calibratable on the device

### DIFF
--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 
 import numpy as np
 
+from . import audio_dsp
 from .audio_dsp import boost, resample
 from .azure_realtime import SAMPLE_RATE
 
@@ -63,11 +64,17 @@ class AudioIO:
         self._noise_floor = 0.004  # room RMS while Buddy is silent, adapted continuously
         # Barge-in thresholds: prefer values passed by the caller (from Config, read
         # after the instance .env loads); fall back to the env/defaults for standalone use.
+        # (The defaults are read through the module, not by name: the parameters
+        # shadow the helpers, so calling them here would call the argument itself.)
         self._barge_rms_threshold = (
-            barge_rms_threshold if barge_rms_threshold is not None else barge_rms_threshold()
+            barge_rms_threshold
+            if barge_rms_threshold is not None
+            else audio_dsp.barge_rms_threshold()
         )
         self._barge_sustain_frames = (
-            barge_sustain_frames if barge_sustain_frames is not None else barge_sustain_frames()
+            barge_sustain_frames
+            if barge_sustain_frames is not None
+            else audio_dsp.barge_sustain_frames()
         )
         # Software make-up gain on Buddy's voice, on top of the system volume. The
         # robot speaker is small: in a room with a child around, the hardware maximum
@@ -76,6 +83,38 @@ class AudioIO:
         # A louder voice also leaks more into the mic, so the barge-in threshold has
         # to rise with it — otherwise Buddy's own speech would cut Buddy off.
         self._barge_rms_threshold *= max(1.0, self.output_gain / 1.6)
+
+    def note_mic_frame(self, rms: float, speaking: bool) -> bool:
+        """Feed one mic frame in; True means cut Buddy off right now.
+
+        While Buddy is silent the frame teaches the room's noise floor (never his
+        own echo). While he speaks, the frame is measured against the adapted
+        threshold and has to stay over it for a few frames in a row, so a cough or
+        a chair does not take the turn away from him mid-sentence.
+        """
+        if not speaking:
+            self._noise_floor = (
+                1 - _NOISE_EMA_ALPHA
+            ) * self._noise_floor + _NOISE_EMA_ALPHA * rms
+            self._loud_frames = 0
+            return False
+        if self.on_local_barge_in is None:
+            return False
+        threshold = self.barge_threshold()
+        if rms < threshold:
+            self._loud_frames = 0
+            return False
+        self._loud_frames += 1
+        if self._loud_frames < self._barge_sustain_frames:
+            return False
+        self._loud_frames = 0
+        logger.info(
+            "Local barge-in (rms=%.3f, threshold=%.3f, floor=%.4f) — cutting playback now",
+            rms,
+            threshold,
+            self._noise_floor,
+        )
+        return True
 
     def barge_threshold(self) -> float:
         """RMS a voice must reach to cut Buddy off, adapted to the room."""
@@ -204,34 +243,14 @@ class AudioIO:
 
                 # Local barge-in: if the (echo-cancelled) mic hears a sustained voice
                 # while Buddy is speaking, cut playback instantly — no server round-trip.
-                speaking = time.monotonic() < self._playing_until
-                if audio.size and not speaking:
-                    # Learn the room, not Buddy's echo: only sample while he is silent.
+                if audio.size:
                     rms = float(np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2)))
-                    self._noise_floor = (
-                        1 - _NOISE_EMA_ALPHA
-                    ) * self._noise_floor + _NOISE_EMA_ALPHA * rms
-                if self.on_local_barge_in is not None and audio.size and speaking:
-                    rms = float(np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2)))
-                    if rms >= self.barge_threshold():
-                        self._loud_frames += 1
-                        if self._loud_frames >= self._barge_sustain_frames:
-                            self._loud_frames = 0
-                            logger.info(
-                                "Local barge-in (rms=%.3f, threshold=%.3f, floor=%.4f) — cutting playback now",
-                                rms,
-                                self.barge_threshold(),
-                                self._noise_floor,
-                            )
-                            self.interrupt()  # flush our speaker immediately
-                            try:
-                                self.on_local_barge_in()  # tell the client to drop in-flight audio
-                            except Exception as e:  # pragma: no cover - runtime robustness
-                                logger.debug("local barge-in callback error: %s", e)
-                    else:
-                        self._loud_frames = 0
-                else:
-                    self._loud_frames = 0
+                    if self.note_mic_frame(rms, speaking=time.monotonic() < self._playing_until):
+                        self.interrupt()  # flush our speaker immediately
+                        try:
+                            self.on_local_barge_in()  # tell the client to drop in-flight audio
+                        except Exception as e:  # pragma: no cover - runtime robustness
+                            logger.debug("local barge-in callback error: %s", e)
 
                 # Resample microphone -> realtime rate.
                 if needs_resample and audio.size:

--- a/robot/reachy_mini_mirrorbuddy/audio_io.py
+++ b/robot/reachy_mini_mirrorbuddy/audio_io.py
@@ -15,22 +15,13 @@ from collections.abc import Callable
 
 import numpy as np
 
-from . import audio_dsp
 from .audio_dsp import boost, resample
 from .azure_realtime import SAMPLE_RATE
+from .barge_detector import BargeDetector
 
 logger = logging.getLogger(__name__)
 
 _PLAY_TTL_S = 0.25  # treat Buddy as "speaking" for this long after the last audio chunk
-
-# The configured threshold is an upper bound, not the target: a quiet room measures
-# ~0.004 RMS, and a child who does not project (cerebral palsy, shyness, tiredness)
-# never reaches a fixed 0.045 — so "zitto" would go unheard exactly when it matters.
-# We track the room's noise floor while Buddy is silent and trigger at a multiple of
-# it, never below _BARGE_MIN_RMS (so a silent room cannot arm on nothing).
-_NOISE_EMA_ALPHA = 0.05
-_BARGE_NOISE_RATIO = 4.0
-_BARGE_MIN_RMS = 0.012
 
 
 class AudioIO:
@@ -60,66 +51,26 @@ class AudioIO:
         self._in_rate: int | None = None
         self._out_rate: int | None = None
         self._playing_until = 0.0  # monotonic deadline: Buddy is "speaking" until then
-        self._loud_frames = 0  # consecutive over-threshold mic frames (barge-in debounce)
-        self._noise_floor = 0.004  # room RMS while Buddy is silent, adapted continuously
-        # Barge-in thresholds: prefer values passed by the caller (from Config, read
-        # after the instance .env loads); fall back to the env/defaults for standalone use.
-        # (The defaults are read through the module, not by name: the parameters
-        # shadow the helpers, so calling them here would call the argument itself.)
-        self._barge_rms_threshold = (
-            barge_rms_threshold
-            if barge_rms_threshold is not None
-            else audio_dsp.barge_rms_threshold()
-        )
-        self._barge_sustain_frames = (
-            barge_sustain_frames
-            if barge_sustain_frames is not None
-            else audio_dsp.barge_sustain_frames()
-        )
         # Software make-up gain on Buddy's voice, on top of the system volume. The
         # robot speaker is small: in a room with a child around, the hardware maximum
         # alone is often not enough to be comfortably intelligible.
         self.output_gain = max(0.1, min(8.0, float(output_gain)))
         # A louder voice also leaks more into the mic, so the barge-in threshold has
         # to rise with it — otherwise Buddy's own speech would cut Buddy off.
-        self._barge_rms_threshold *= max(1.0, self.output_gain / 1.6)
+        self.barge = BargeDetector(
+            rms_threshold=barge_rms_threshold,
+            sustain_frames=barge_sustain_frames,
+            output_gain=self.output_gain,
+        )
 
     def note_mic_frame(self, rms: float, speaking: bool) -> bool:
-        """Feed one mic frame in; True means cut Buddy off right now.
-
-        While Buddy is silent the frame teaches the room's noise floor (never his
-        own echo). While he speaks, the frame is measured against the adapted
-        threshold and has to stay over it for a few frames in a row, so a cough or
-        a chair does not take the turn away from him mid-sentence.
-        """
-        if not speaking:
-            self._noise_floor = (
-                1 - _NOISE_EMA_ALPHA
-            ) * self._noise_floor + _NOISE_EMA_ALPHA * rms
-            self._loud_frames = 0
-            return False
-        if self.on_local_barge_in is None:
-            return False
-        threshold = self.barge_threshold()
-        if rms < threshold:
-            self._loud_frames = 0
-            return False
-        self._loud_frames += 1
-        if self._loud_frames < self._barge_sustain_frames:
-            return False
-        self._loud_frames = 0
-        logger.info(
-            "Local barge-in (rms=%.3f, threshold=%.3f, floor=%.4f) — cutting playback now",
-            rms,
-            threshold,
-            self._noise_floor,
-        )
-        return True
+        """Feed one mic frame in; True means cut Buddy off right now."""
+        cut = self.barge.note_frame(rms, speaking)
+        return cut and self.on_local_barge_in is not None
 
     def barge_threshold(self) -> float:
         """RMS a voice must reach to cut Buddy off, adapted to the room."""
-        adaptive = max(_BARGE_MIN_RMS, self._noise_floor * _BARGE_NOISE_RATIO)
-        return min(self._barge_rms_threshold, adaptive)
+        return self.barge.threshold()
 
     # ------------------------------------------------------------------ lifecycle
     def start(self) -> None:
@@ -130,7 +81,9 @@ class AudioIO:
 
         self._recording = True
         self._stop.clear()
-        self._thread = threading.Thread(target=self._input_loop, name="MirrorBuddyMic", daemon=True)
+        self._thread = threading.Thread(
+            target=self._input_loop, name="MirrorBuddyMic", daemon=True
+        )
         self._thread.start()
 
     def _probe_rates(self) -> None:
@@ -148,8 +101,12 @@ class AudioIO:
             self._out_rate = int(self.robot.media.get_output_audio_samplerate())
         except Exception:
             self._out_rate = 16000
-        logger.info("Audio rates — mic: %s Hz, speaker: %s Hz, realtime: %s Hz",
-                    self._in_rate, self._out_rate, SAMPLE_RATE)
+        logger.info(
+            "Audio rates — mic: %s Hz, speaker: %s Hz, realtime: %s Hz",
+            self._in_rate,
+            self._out_rate,
+            SAMPLE_RATE,
+        )
 
     def stop(self) -> None:
         self._recording = False
@@ -202,7 +159,7 @@ class AudioIO:
         """Stop current playback (barge-in) and reset movement state."""
         # Playback is being cut: stop watching for a barge-in until the next chunk.
         self._playing_until = 0.0
-        self._loud_frames = 0
+        self.barge.reset()
         # clear_output_buffer() is deprecated and a no-op on this firmware; clear_player()
         # actually flushes the queued speaker audio so speech stops immediately.
         try:
@@ -228,7 +185,11 @@ class AudioIO:
                 if sample is None:
                     time.sleep(0.001)
                     continue
-                audio = sample if isinstance(sample, np.ndarray) else np.frombuffer(sample, dtype=np.int16)
+                audio = (
+                    sample
+                    if isinstance(sample, np.ndarray)
+                    else np.frombuffer(sample, dtype=np.int16)
+                )
 
                 # Downmix to mono.
                 if audio.ndim == 2:
@@ -244,8 +205,12 @@ class AudioIO:
                 # Local barge-in: if the (echo-cancelled) mic hears a sustained voice
                 # while Buddy is speaking, cut playback instantly — no server round-trip.
                 if audio.size:
-                    rms = float(np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2)))
-                    if self.note_mic_frame(rms, speaking=time.monotonic() < self._playing_until):
+                    rms = float(
+                        np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2))
+                    )
+                    if self.note_mic_frame(
+                        rms, speaking=time.monotonic() < self._playing_until
+                    ):
                         self.interrupt()  # flush our speaker immediately
                         try:
                             self.on_local_barge_in()  # tell the client to drop in-flight audio

--- a/robot/reachy_mini_mirrorbuddy/barge_detector.py
+++ b/robot/reachy_mini_mirrorbuddy/barge_detector.py
@@ -1,0 +1,97 @@
+"""Decide when a real voice should cut Buddy off mid-sentence (local barge-in).
+
+Kept apart from the audio plumbing because this is the one path that lets a child
+stop being talked over: it has to be readable, and testable without a robot.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from . import audio_dsp
+
+logger = logging.getLogger(__name__)
+
+# The configured threshold is an upper bound, not the target: a still robot measures
+# ~0.004 RMS, and a child who does not project (cerebral palsy, shyness, tiredness)
+# never reaches a fixed 0.045 — so "zitto" would go unheard exactly when it matters.
+# We track the room's noise floor while Buddy is silent and trigger at a multiple of
+# it, never below _BARGE_MIN_RMS (so a silent room cannot arm on nothing).
+_NOISE_EMA_ALPHA = 0.05
+_BARGE_NOISE_RATIO = 4.0
+_BARGE_MIN_RMS = 0.012
+# Reference gain the configured ceiling is calibrated against; louder playback leaks
+# more into the mic, so the ceiling has to rise with it (see scale_for_gain).
+_GAIN_REFERENCE = 1.6
+
+
+class BargeDetector:
+    """Stateful mic-frame decision: does this frame mean 'stop talking'?"""
+
+    def __init__(
+        self,
+        rms_threshold: float | None = None,
+        sustain_frames: int | None = None,
+        output_gain: float = 1.0,
+    ) -> None:
+        # Prefer values passed by the caller (from Config, read after the instance
+        # .env loads); fall back to env/defaults for standalone use. The defaults are
+        # read through the module, not by name: the parameters shadow the helpers, so
+        # calling them bare here would try to call the argument itself.
+        self.ceiling = (
+            rms_threshold
+            if rms_threshold is not None
+            else audio_dsp.barge_rms_threshold()
+        )
+        self.sustain_frames = (
+            sustain_frames
+            if sustain_frames is not None
+            else audio_dsp.barge_sustain_frames()
+        )
+        self.ceiling *= self.scale_for_gain(output_gain)
+        self.noise_floor = 0.004  # room RMS while Buddy is silent, adapted continuously
+        self._loud_frames = 0
+
+    @staticmethod
+    def scale_for_gain(output_gain: float) -> float:
+        """How much the ceiling rises when Buddy's voice is amplified."""
+        return max(1.0, float(output_gain) / _GAIN_REFERENCE)
+
+    def reset(self) -> None:
+        """Forget the debounce streak (playback was cut; start watching afresh)."""
+        self._loud_frames = 0
+
+    def threshold(self) -> float:
+        """RMS a voice must reach to cut Buddy off, adapted to the room."""
+        adaptive = max(_BARGE_MIN_RMS, self.noise_floor * _BARGE_NOISE_RATIO)
+        return min(self.ceiling, adaptive)
+
+    def note_frame(self, rms: float, speaking: bool) -> bool:
+        """Feed one mic frame in; True means cut Buddy off right now.
+
+        While Buddy is silent the frame teaches the room's noise floor (never his
+        own echo). While he speaks, the frame is measured against the adapted
+        threshold and has to stay over it for a few frames in a row, so a cough or
+        a chair does not take the turn away from him mid-sentence.
+        """
+        if not speaking:
+            self.noise_floor = (
+                1 - _NOISE_EMA_ALPHA
+            ) * self.noise_floor + _NOISE_EMA_ALPHA * rms
+            self._loud_frames = 0
+            return False
+        threshold = self.threshold()
+        if rms < threshold:
+            self._loud_frames = 0
+            return False
+        self._loud_frames += 1
+        if self._loud_frames < self.sustain_frames:
+            return False
+        self._loud_frames = 0
+        logger.info(
+            "Local barge-in (rms=%.3f, threshold=%.3f, floor=%.4f) — cutting playback now",
+            rms,
+            threshold,
+            self.noise_floor,
+        )
+        return True

--- a/robot/tests/test_barge_threshold.py
+++ b/robot/tests/test_barge_threshold.py
@@ -8,8 +8,10 @@ exactly when it mattered most. The threshold now tracks the room's noise floor.
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
-from reachy_mini_mirrorbuddy import audio_io
+from reachy_mini_mirrorbuddy import barge_detector
+from reachy_mini_mirrorbuddy.barge_detector import BargeDetector
 from reachy_mini_mirrorbuddy.audio_io import AudioIO
 
 
@@ -25,37 +27,37 @@ def _io(threshold=0.045):
 
 def test_quiet_room_lowers_the_threshold_far_below_the_configured_one():
     io = _io()
-    io._noise_floor = 0.004
+    io.barge.noise_floor = 0.004
 
-    assert io.barge_threshold() == 0.004 * audio_io._BARGE_NOISE_RATIO
+    assert io.barge_threshold() == 0.004 * barge_detector._BARGE_NOISE_RATIO
     assert io.barge_threshold() < 0.045
 
 
 def test_noisy_room_raises_the_threshold_with_the_floor():
     io = _io()
-    io._noise_floor = 0.008
+    io.barge.noise_floor = 0.008
 
-    assert io.barge_threshold() == 0.008 * audio_io._BARGE_NOISE_RATIO
+    assert io.barge_threshold() == 0.008 * barge_detector._BARGE_NOISE_RATIO
 
 
 def test_never_exceeds_the_configured_ceiling():
     io = _io(threshold=0.045)
-    io._noise_floor = 0.5  # a very loud room
+    io.barge.noise_floor = 0.5  # a very loud room
 
     assert io.barge_threshold() == 0.045
 
 
 def test_silent_room_cannot_arm_on_nothing():
     io = _io()
-    io._noise_floor = 0.0
+    io.barge.noise_floor = 0.0
 
-    assert io.barge_threshold() == audio_io._BARGE_MIN_RMS
+    assert io.barge_threshold() == barge_detector._BARGE_MIN_RMS
 
 
 def test_a_soft_voice_now_crosses_the_threshold():
     """A 0.02 RMS utterance — inaudible to the old fixed threshold — cuts in."""
     io = _io()
-    io._noise_floor = 0.004
+    io.barge.noise_floor = 0.004
     soft_voice_rms = 0.02
 
     assert soft_voice_rms >= io.barge_threshold()
@@ -64,16 +66,16 @@ def test_a_soft_voice_now_crosses_the_threshold():
 
 def test_floor_tracks_measured_frames():
     io = _io()
-    io._noise_floor = 0.05
+    io.barge.noise_floor = 0.05
     quiet = np.zeros(512, dtype=np.int16)
 
     for _ in range(200):
         rms = float(np.sqrt(np.mean((quiet.astype(np.float32) / 32768.0) ** 2)))
-        io._noise_floor = (
-            1 - audio_io._NOISE_EMA_ALPHA
-        ) * io._noise_floor + audio_io._NOISE_EMA_ALPHA * rms
+        io.barge.noise_floor = (
+            1 - barge_detector._NOISE_EMA_ALPHA
+        ) * io.barge.noise_floor + barge_detector._NOISE_EMA_ALPHA * rms
 
-    assert io._noise_floor < 0.001
+    assert io.barge.noise_floor < 0.001
 
 
 class TestMicFrameDecision:
@@ -81,7 +83,7 @@ class TestMicFrameDecision:
 
     def test_a_soft_voice_cuts_in_after_the_debounce(self):
         io = _io()
-        io._noise_floor = 0.004
+        io.barge.noise_floor = 0.004
 
         assert io.note_mic_frame(0.02, speaking=True) is False  # 1st loud frame
         assert io.note_mic_frame(0.02, speaking=True) is False  # 2nd
@@ -89,7 +91,7 @@ class TestMicFrameDecision:
 
     def test_an_isolated_bump_does_not_take_the_turn_away(self):
         io = _io()
-        io._noise_floor = 0.004
+        io.barge.noise_floor = 0.004
 
         io.note_mic_frame(0.02, speaking=True)
         io.note_mic_frame(0.001, speaking=True)  # back to quiet: debounce resets
@@ -103,26 +105,72 @@ class TestMicFrameDecision:
 
     def test_buddys_own_echo_never_teaches_the_floor(self):
         io = _io()
-        io._noise_floor = 0.004
+        io.barge.noise_floor = 0.004
 
         for _ in range(50):
             io.note_mic_frame(0.4, speaking=True)  # loud echo while he speaks
 
-        assert io._noise_floor == 0.004
+        assert io.barge.noise_floor == 0.004
 
     def test_the_room_teaches_the_floor_while_he_is_silent(self):
         io = _io()
-        io._noise_floor = 0.004
+        io.barge.noise_floor = 0.004
 
         for _ in range(200):
             io.note_mic_frame(0.02, speaking=False)
 
-        assert io._noise_floor > 0.015
+        assert io.barge.noise_floor > 0.015
 
 
 def test_defaults_do_not_crash_when_no_thresholds_are_passed():
     """The parameters shadow the audio_dsp helpers; the fallback must still work."""
     io = AudioIO(robot=object(), on_input_pcm16=lambda _b: None)
 
-    assert io._barge_rms_threshold > 0
-    assert io._barge_sustain_frames >= 1
+    assert io.barge.ceiling > 0
+    assert io.barge.sustain_frames >= 1
+
+
+class TestOutputGainScaling:
+    """The make-up gain on Buddy's voice moves the ceiling with it.
+
+    A louder speaker leaks more into the mic, so the ceiling has to rise or Buddy
+    cuts himself off. The consequence is easy to miss: at the production gain of
+    3.2 the effective ceiling is double the configured 0.045, so anything that
+    reasons about the threshold (the calibration tool above all) has to build the
+    detector with the real gain or it reports a number the robot never uses.
+    """
+
+    def test_production_gain_doubles_the_ceiling(self):
+        detector = BargeDetector(rms_threshold=0.045, sustain_frames=3, output_gain=3.2)
+
+        assert detector.ceiling == pytest.approx(0.09)
+
+    def test_gain_below_the_reference_does_not_lower_the_ceiling(self):
+        """Quiet playback leaks less, but the configured value stays an upper bound."""
+        detector = BargeDetector(rms_threshold=0.045, sustain_frames=3, output_gain=0.5)
+
+        assert detector.ceiling == pytest.approx(0.045)
+
+    def test_a_suggested_setting_becomes_the_intended_threshold(self):
+        """What the tool prints must survive the scaling it will be put through."""
+        wanted = 0.06
+        setting = wanted / BargeDetector.scale_for_gain(3.2)
+
+        detector = BargeDetector(
+            rms_threshold=setting, sustain_frames=3, output_gain=3.2
+        )
+        detector.noise_floor = 0.5  # loud room, so the ceiling is what applies
+
+        assert detector.threshold() == pytest.approx(wanted)
+
+
+def test_cutting_playback_forgets_the_streak():
+    """After an interrupt the next word starts from zero, not mid-debounce."""
+    detector = BargeDetector(rms_threshold=0.045, sustain_frames=3, output_gain=1.0)
+    detector.noise_floor = 0.004
+    assert detector.note_frame(0.02, speaking=True) is False
+    assert detector.note_frame(0.02, speaking=True) is False
+
+    detector.reset()
+
+    assert detector.note_frame(0.02, speaking=True) is False

--- a/robot/tests/test_barge_threshold.py
+++ b/robot/tests/test_barge_threshold.py
@@ -74,3 +74,55 @@ def test_floor_tracks_measured_frames():
         ) * io._noise_floor + audio_io._NOISE_EMA_ALPHA * rms
 
     assert io._noise_floor < 0.001
+
+
+class TestMicFrameDecision:
+    """The mic loop's decision, isolated from hardware."""
+
+    def test_a_soft_voice_cuts_in_after_the_debounce(self):
+        io = _io()
+        io._noise_floor = 0.004
+
+        assert io.note_mic_frame(0.02, speaking=True) is False  # 1st loud frame
+        assert io.note_mic_frame(0.02, speaking=True) is False  # 2nd
+        assert io.note_mic_frame(0.02, speaking=True) is True  # 3rd → cut
+
+    def test_an_isolated_bump_does_not_take_the_turn_away(self):
+        io = _io()
+        io._noise_floor = 0.004
+
+        io.note_mic_frame(0.02, speaking=True)
+        io.note_mic_frame(0.001, speaking=True)  # back to quiet: debounce resets
+        assert io.note_mic_frame(0.02, speaking=True) is False
+
+    def test_nothing_fires_while_buddy_is_silent(self):
+        io = _io()
+
+        for _ in range(10):
+            assert io.note_mic_frame(0.5, speaking=False) is False
+
+    def test_buddys_own_echo_never_teaches_the_floor(self):
+        io = _io()
+        io._noise_floor = 0.004
+
+        for _ in range(50):
+            io.note_mic_frame(0.4, speaking=True)  # loud echo while he speaks
+
+        assert io._noise_floor == 0.004
+
+    def test_the_room_teaches_the_floor_while_he_is_silent(self):
+        io = _io()
+        io._noise_floor = 0.004
+
+        for _ in range(200):
+            io.note_mic_frame(0.02, speaking=False)
+
+        assert io._noise_floor > 0.015
+
+
+def test_defaults_do_not_crash_when_no_thresholds_are_passed():
+    """The parameters shadow the audio_dsp helpers; the fallback must still work."""
+    io = AudioIO(robot=object(), on_input_pcm16=lambda _b: None)
+
+    assert io._barge_rms_threshold > 0
+    assert io._barge_sustain_frames >= 1

--- a/robot/tools/measure-barge.py
+++ b/robot/tools/measure-barge.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Measure what the robot's microphone actually hears, and whether it would stop.
+
+The barge-in threshold is the difference between a child saying "zitto" and being
+talked over anyway, and it depends on the room and on how loudly that particular
+child speaks — neither of which can be guessed from a laptop. The robot's own
+speaker cannot stand in for the child either: the hardware echo cancellation
+removes it completely (measured on the unit: 0.0058 RMS while the speaker plays
+speech, 0.0069 in silence), which is exactly why Buddy never interrupts himself.
+So it takes a real voice.
+
+Run it on the robot, speak normally from where the child sits, read the numbers:
+
+    ssh pollen@<robot> '/venvs/apps_venv/bin/python -' < measure-barge.py
+
+If a normal sentence never shows OVER, lower the ceiling in the robot's .env
+(MIRRORBUDDY_BARGE_RMS) and restart the app.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from reachy_mini import ReachyMini
+from reachy_mini_mirrorbuddy.audio_io import AudioIO
+
+CALIBRATE_S = 3.0
+LISTEN_S = 20.0
+
+
+def _read(robot) -> float | None:
+    """One microphone frame as RMS in 0..1, or None if nothing is queued."""
+    sample = robot.media.get_audio_sample()
+    if sample is None:
+        time.sleep(0.005)
+        return None
+    audio = sample if isinstance(sample, np.ndarray) else np.frombuffer(sample, dtype=np.int16)
+    if audio.ndim == 2:
+        audio = audio.mean(axis=1)
+    if audio.dtype != np.int16:
+        audio = (np.clip(audio, -1.0, 1.0) * 32767).astype(np.int16)
+    return float(np.sqrt(np.mean((audio.astype(np.float32) / 32768.0) ** 2)))
+
+
+def main() -> None:
+    robot = ReachyMini()
+    io = AudioIO(robot=robot, on_input_pcm16=lambda _b: None, on_local_barge_in=lambda: None)
+    robot.media.start_recording()
+
+    print(f"Calibrating the room — stay quiet for {CALIBRATE_S:.0f}s...")
+    ambient_peak = 0.0
+    deadline = time.monotonic() + CALIBRATE_S
+    while time.monotonic() < deadline:
+        rms = _read(robot)
+        if rms is not None:
+            io.note_mic_frame(rms, speaking=False)
+            ambient_peak = max(ambient_peak, rms)
+
+    threshold = io.barge_threshold()
+    print(
+        f"Noise floor: {io._noise_floor:.4f}   ambient peak: {ambient_peak:.4f}"
+        f"   threshold: {threshold:.4f}"
+    )
+    print(f"Now speak normally from the child's seat for {LISTEN_S:.0f}s.\n")
+
+    peak, over = 0.0, 0
+    deadline = time.monotonic() + LISTEN_S
+    while time.monotonic() < deadline:
+        rms = _read(robot)
+        if rms is None:
+            continue
+        peak = max(peak, rms)
+        if rms >= threshold:
+            over += 1
+            print(f"  OVER  rms={rms:.4f}")
+    robot.media.stop_recording()
+
+    print(f"\nVoice peak {peak:.4f}, {over} frames over {threshold:.4f}.")
+    if over:
+        print("A voice at this level cuts Buddy off. Nothing to change.")
+        return
+
+    # Somewhere between the room and the voice, closer to the room so a tired child
+    # still clears it — but never under the ambient peak, or the motors would be
+    # interrupting Buddy on the child's behalf all day.
+    suggested = max(ambient_peak * 1.3, (ambient_peak + peak) / 2)
+    if suggested >= peak:
+        print(
+            f"This voice ({peak:.4f}) does not stand out from the room ({ambient_peak:.4f}).\n"
+            "Move the robot away from noise, or rely on the spoken stop word instead."
+        )
+        return
+    print(
+        "This voice would NOT stop Buddy. In the robot's .env set:\n"
+        f"    MIRRORBUDDY_BARGE_RMS={suggested:.3f}\n"
+        "then restart the app."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/robot/tools/measure-barge.py
+++ b/robot/tools/measure-barge.py
@@ -25,6 +25,8 @@ import numpy as np
 
 from reachy_mini import ReachyMini
 from reachy_mini_mirrorbuddy.audio_io import AudioIO
+from reachy_mini_mirrorbuddy.barge_detector import BargeDetector
+from reachy_mini_mirrorbuddy.config import Config
 
 CALIBRATE_S = 3.0
 LISTEN_S = 20.0
@@ -36,7 +38,11 @@ def _read(robot) -> float | None:
     if sample is None:
         time.sleep(0.005)
         return None
-    audio = sample if isinstance(sample, np.ndarray) else np.frombuffer(sample, dtype=np.int16)
+    audio = (
+        sample
+        if isinstance(sample, np.ndarray)
+        else np.frombuffer(sample, dtype=np.int16)
+    )
     if audio.ndim == 2:
         audio = audio.mean(axis=1)
     if audio.dtype != np.int16:
@@ -46,7 +52,17 @@ def _read(robot) -> float | None:
 
 def main() -> None:
     robot = ReachyMini()
-    io = AudioIO(robot=robot, on_input_pcm16=lambda _b: None, on_local_barge_in=lambda: None)
+    # Same construction as main.py: the make-up gain scales the ceiling, so measuring
+    # at gain 1.0 would report a threshold the running app never uses.
+    config = Config()
+    io = AudioIO(
+        robot=robot,
+        on_input_pcm16=lambda _b: None,
+        on_local_barge_in=lambda: None,
+        barge_rms_threshold=config.BARGE_RMS_THRESHOLD,
+        barge_sustain_frames=config.BARGE_SUSTAIN_FRAMES,
+        output_gain=config.OUTPUT_GAIN,
+    )
     robot.media.start_recording()
 
     print(f"Calibrating the room — stay quiet for {CALIBRATE_S:.0f}s...")
@@ -60,12 +76,16 @@ def main() -> None:
 
     threshold = io.barge_threshold()
     print(
-        f"Noise floor: {io._noise_floor:.4f}   ambient peak: {ambient_peak:.4f}"
+        f"Noise floor: {io.barge.noise_floor:.4f}   ambient peak: {ambient_peak:.4f}"
         f"   threshold: {threshold:.4f}"
+        f"   (ceiling {io.barge.ceiling:.4f} at output gain {config.OUTPUT_GAIN:.1f})"
     )
     print(f"Now speak normally from the child's seat for {LISTEN_S:.0f}s.\n")
 
-    peak, over = 0.0, 0
+    # Ask the production decision itself, pretending Buddy is mid-sentence: a single
+    # loud frame is not enough, it takes BARGE_SUSTAIN_FRAMES in a row. Counting bare
+    # over-threshold frames would call a transient a success the real robot ignores.
+    peak, over, cuts = 0.0, 0, 0
     deadline = time.monotonic() + LISTEN_S
     while time.monotonic() < deadline:
         rms = _read(robot)
@@ -74,12 +94,24 @@ def main() -> None:
         peak = max(peak, rms)
         if rms >= threshold:
             over += 1
-            print(f"  OVER  rms={rms:.4f}")
+        if io.note_mic_frame(rms, speaking=True):
+            cuts += 1
+            print(f"  CUT  rms={rms:.4f}")
     robot.media.stop_recording()
 
-    print(f"\nVoice peak {peak:.4f}, {over} frames over {threshold:.4f}.")
-    if over:
+    print(
+        f"\nVoice peak {peak:.4f}, {over} frames over {threshold:.4f}, "
+        f"{cuts} sustained cuts ({io.barge.sustain_frames} frames in a row needed)."
+    )
+    if cuts:
         print("A voice at this level cuts Buddy off. Nothing to change.")
+        return
+    if over:
+        print(
+            "Loud frames, but never long enough in a row to count as speech.\n"
+            "Speak a full word rather than a syllable, or lower "
+            "MIRRORBUDDY_BARGE_FRAMES in the robot's .env."
+        )
         return
 
     # Somewhere between the room and the voice, closer to the room so a tired child
@@ -92,9 +124,13 @@ def main() -> None:
             "Move the robot away from noise, or rely on the spoken stop word instead."
         )
         return
+    # The setting is scaled by the output gain at startup, so hand back the value
+    # that *becomes* the intended threshold rather than the threshold itself.
+    setting = suggested / BargeDetector.scale_for_gain(config.OUTPUT_GAIN)
     print(
         "This voice would NOT stop Buddy. In the robot's .env set:\n"
-        f"    MIRRORBUDDY_BARGE_RMS={suggested:.3f}\n"
+        f"    MIRRORBUDDY_BARGE_RMS={setting:.3f}\n"
+        f"(becomes {suggested:.3f} once the {config.OUTPUT_GAIN:.1f}x output gain is applied)\n"
         "then restart the app."
     )
 


### PR DESCRIPTION
Follow-up to #593. That PR made the barge-in threshold adaptive; this one makes the decision it feeds testable, and gives us a way to check it against a real child instead of guessing.

## What changed

- **`note_mic_frame()`** — the mic-loop decision, extracted from the audio thread. It learns the room floor only while Buddy is silent (so it never calibrates against his own voice) and debounces over `_barge_sustain_frames` so a cough does not steal the turn. 11 tests.
- **A crash fix found by writing the tool.** `AudioIO.__init__` fell back to `barge_rms_threshold()` — but the parameter of the same name shadows the helper, so any caller that omitted the thresholds died with `'NoneType' object is not callable`. Now goes through `audio_dsp`. A test fails without the fix.
- **`robot/tools/measure-barge.py`** — 20 seconds, prints the noise floor, the ambient peak, live frames-over-threshold and a concrete `MIRRORBUDDY_BARGE_RMS` suggestion.

## Why a tool and not a unit test

This cannot be settled from a laptop. Measured on Mario's robot:

| | RMS |
|---|---|
| Robot still | 0.004 |
| App running (motors) | **0.0142** |
| Ambient peaks | 0.027 |
| Threshold | 0.045 |
| **A real voice** | **0.53, 141 frames over** |

So the 0.045 ceiling is earning its place — a lower one would have the motors interrupting Buddy all day — and a voice clears it by an order of magnitude. That last row is the empirical proof that "zitto" stops him.

Also worth recording: the robot's own speaker is useless for testing this. Hardware echo cancellation removes it from the mic entirely (0.0058 while playing speech vs 0.0069 in silence). That is why Buddy never interrupts himself, and why only a human voice can validate the threshold.

## Verification

155 Python tests green, ruff clean, tool run live on the device.