### PR TITLE
fix(hooks): MainGuard reads the file path other agent hosts actually send

### DIFF
--- a/.claude/hooks/main-guard.sh
+++ b/.claude/hooks/main-guard.sh
@@ -27,6 +27,15 @@ if [ -n "$fp" ]; then
   else
     lookup_dir="$(dirname "$fp")"
   fi
+  # Creating the first file in a new directory means the parent does not exist yet,
+  # and `git -C <missing dir>` fails: `repo_root` came back empty and the guard
+  # exited 0 — i.e. `mkdir`-ing your way onto `main` was an unlocked door. Walk up
+  # to the nearest existing ancestor before asking git anything.
+  while [ -n "$lookup_dir" ] && [ ! -d "$lookup_dir" ]; do
+    parent="$(dirname "$lookup_dir")"
+    [ "$parent" = "$lookup_dir" ] && break
+    lookup_dir="$parent"
+  done
 fi
 repo_root="$(git -C "${lookup_dir:-.}" rev-parse --show-toplevel 2>/dev/null || true)"
 if [ -z "$repo_root" ]; then

--- a/.claude/hooks/main-guard.sh
+++ b/.claude/hooks/main-guard.sh
@@ -12,7 +12,10 @@ fi
 
 # Extract file path from stdin
 input="$(cat)"
-fp="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')"
+# `file_path` is Claude Code's key; other hosts (Copilot CLI) send `path`. Reading
+# only the first one left `fp` empty, the lookup fell back to the CWD — which is the
+# main checkout — and every edit inside a feature worktree was denied.
+fp="$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // ""')"
 
 # Resolve the repo of the FILE (not CWD) — git worktrees live outside the main
 # project dir and have their own HEAD. Without this, edits on a feature branch


### PR DESCRIPTION
The guard extracted `.tool_input.file_path`, which is Claude Code's key. Copilot CLI's create/edit tools send `path`, so `fp` came back empty, the repo lookup fell back to the CWD — the main checkout — and **every edit inside a feature worktree was denied**. The guard was refusing exactly the discipline it exists to enforce.

Reading both keys restores it. Verified by hand:

| input | branch resolved | outcome |
| --- | --- | --- |
| `{"path": "<worktree>/robot/x.py"}` | `fix/main-guard-path` | allowed |
| `{"path": "<main>/robot/x.py"}` | `main` | denied |
| `{"file_path": "<main>/robot/x.py"}` | `main` | denied (unchanged) |