### PR TITLE
feat(robot): Buddy can meet the child's friends, and stops repeating one name

### DIFF
--- a/docs/adr/0170-reachy-mini-robot-embodiment.md
+++ b/docs/adr/0170-reachy-mini-robot-embodiment.md
@@ -96,6 +96,15 @@ child's account via a short-lived code exchanged for a scoped token:
 The child's credentials never leave the computer; the robot only ever holds a
 revocable token and a learning profile.
 
+### Bystanders (friends, siblings, parents)
+
+A robot on a kitchen table is used in front of people who never paired anything. Buddy
+may therefore learn a bystander's **first name only**, and only because they said it
+out loud (`remember_person`). That roster is **in-memory for one power cycle**: never
+written to disk, never sent to the server, gone when the robot is switched off. There
+is no voice or face recognition — identifying a third party biometrically would need
+its own ADR and its own consent, and we are not doing it.
+
 ### Security model (reviewed — see Consequences)
 
 - Codes are 6-digit, single-use, 10-min TTL.

--- a/robot/README.md
+++ b/robot/README.md
@@ -74,7 +74,8 @@ model speech stream over a single Azure Realtime WebSocket (`azure_realtime`).
 | `audio_io.py` | Robot mic ↔ speaker bridge (resampling, playback, barge-in) |
 | `movements.py` | Expressive full-body motion + daemon face-follow while listening |
 | `camera.py` | On-demand JPEG capture + daemon head/face tracking helpers |
-| `tools.py` | Voice tool schemas (list/change professor, look at homework, friend/study) + resolver |
+| `people.py` | Who is in the room right now — session-only, never written to disk |
+| `tools.py` | Voice tool schemas (list/change professor, look at homework, friend/study, who is here) + resolver |
 | `session_flow.py` | Pure stop / end / wake decisions for the live loop (accessibility-critical) |
 | `controller.py` | Tool dispatch, live professor switching, vision, sleep/wake |
 | `settings_ui.py` | Minimal in-app settings page (creds + Maestro/DSA selection) |
@@ -94,6 +95,29 @@ Buddy is voice-only, so the model drives the robot through realtime **tools**:
   po'»*. Buddy switches to **friend mode** (`talk_as_friend`): the peer‑companion Buddy of
   MirrorBuddy's Support Triangle — a warm coetaneo you can talk to about anything, not a
   tutor. Say *«torniamo ai compiti»* (`back_to_study`) to go back to studying.
+
+## More than one person at the table
+
+The robot sits on a kitchen table, so a friend, a sibling or a parent sits down and
+starts talking. Buddy is built for that:
+
+- **It asks.** A new voice is greeted and asked its name; `remember_person` stores it
+  for the rest of the session, so the friend is addressed as themselves, not as the
+  paired child. `who_is_here` lets Buddy recall the room when it is unsure.
+- **Guests are first-class.** They can ask questions and call a professor like the
+  paired child. The safety guardrails apply to everyone equally.
+- **Names are used sparingly.** At the greeting, when singling someone out, when
+  calling attention — not at the start of every sentence, which is the tic the earlier
+  "call him by name" instruction produced.
+- **Never invented.** A name only exists if a human said it out loud. Encrypted blobs
+  (`pii:…`), digits and sentence-length strings are refused rather than spoken.
+
+**Nothing is persisted.** The roster lives in memory for one power cycle: a friend's
+name is a third child's personal data, and keeping it past the power switch is a
+consent decision their parents never made. Turn the robot off, the room empties.
+
+There is no voice or face recognition, deliberately — Buddy knows who is speaking only
+because someone told it.
 
 ## Ending a session & interrupting (accessibility‑critical)
 

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -21,6 +21,7 @@ from .config import Config
 from .dsa import turn_detection_config
 from .mirrorbuddy_client import Maestro
 from .movements import Movements, temperament_for
+from .people import Roster
 from .prompt_builder import build_instructions
 from .tool_handlers import ToolCallMixin
 
@@ -45,6 +46,8 @@ class Controller(ToolCallMixin):
         self.maestro = maestro
         self.audio = audio
         self.movements = movements
+        # Who is in the room, for this power cycle only (see people.Roster).
+        self.people = Roster(cfg.STUDENT_NAME)
         self._client: AzureRealtimeClient | None = None
         self._switch_lock = threading.Lock()
         self._partial = ""  # transcript of the reply in flight, used to read the mood
@@ -95,6 +98,7 @@ class Controller(ToolCallMixin):
             locale=self.cfg.LOCALE,
             dsa_profile=self.cfg.DSA_PROFILE,
             student_name=self.cfg.STUDENT_NAME,
+            roster=self.people,
         )
         return AzureRealtimeClient(
             ws_url=self.cfg.realtime_ws_url(),
@@ -136,19 +140,27 @@ class Controller(ToolCallMixin):
             )
         elif event == presence.RETURNED:
             client.speak_now(
-                f"Lo studente e' tornato dopo una pausa: fai un bentornato molto breve "
-                f"{self._name_clause()} e riprendi da dove eravate. Una frase soltanto."
+                "Lo studente e' tornato dopo una pausa: fai un bentornato molto breve "
+                f"{self._name_clause(use_name=False)} e riprendi da dove eravate. Una frase soltanto."
             )
 
-    def _name_clause(self) -> str:
-        """How to address the child — never an open invitation to invent a name.
+    def _name_clause(self, use_name: bool = True) -> str:
+        """How to address the room — never an open invitation to invent a name.
 
         "Greet him by name" without supplying one is exactly how the robot ended up
         calling Mario "Luca". If we don't have a usable name (the server encrypts
         names, and a decryption miss puts ciphertext on the wire), we say so.
+
+        ``use_name=False`` is the sparing half of the fix: the opening hello may use
+        the name, a welcome-back two minutes later should not — repeating it every
+        single time is the tic Roberto asked us to remove.
         """
-        name = (self.cfg.STUDENT_NAME or "").strip()
-        if name and not name.startswith(("pii:", "[")):
+        if self.people.guests:
+            # More than one person at the table: a single name would address the
+            # wrong one, so greet the room and let the model pick who is speaking.
+            return "salutando chi c'e' senza ripetere i nomi"
+        name = self.people.primary
+        if use_name and name:
             return f"chiamandolo per nome ({name})"
         return "senza usare nomi propri"
 

--- a/robot/reachy_mini_mirrorbuddy/people.py
+++ b/robot/reachy_mini_mirrorbuddy/people.py
@@ -25,9 +25,11 @@ MAX_NAME_LEN = 40
 
 # A decryption miss or a placeholder must never be spoken as if it were a person.
 _NOT_A_NAME_PREFIXES = ("pii:", "[", "{", "<")
-# Letters (accented included), apostrophes, hyphens and spaces. Nothing else is a
-# name a child says out loud; digits and punctuation mean we misheard a sentence.
-_NAME_RE = re.compile(r"^[^\W\d_][\w' -]*$", re.UNICODE)
+# Letters (accented included), apostrophes, hyphens and spaces — and nothing else.
+# `\w` was wrong here: it admits digits and underscores after the first character, so
+# an ASR mishearing like "Mario2" or "Giulia_" was stored and then read aloud as a
+# name. A name a child says out loud has no digits in it.
+_NAME_RE = re.compile(r"^[^\W\d_](?:[^\W\d_]|[ '-])*$", re.UNICODE)
 
 
 def clean_name(raw: str | None) -> str | None:
@@ -62,6 +64,22 @@ class Roster:
     @property
     def guests(self) -> tuple[str, ...]:
         return tuple(self._guests)
+
+    def set_primary(self, raw: str | None) -> str | None:
+        """Record the paired child's own name, said out loud.
+
+        The robot often starts with no ``STUDENT_NAME`` at all — no pairing token, or
+        a name the server could not decrypt. Without this, the child who answers "mi
+        chiamo Mario" was filed as a guest: every prompt rebuilt afterwards still
+        declared the student unknown, and then listed Mario as someone sitting next
+        to himself.
+        """
+        name = clean_name(raw)
+        if name is None:
+            return None
+        self._primary = name
+        self._guests = [g for g in self._guests if g.casefold() != name.casefold()]
+        return name
 
     def add_guest(self, raw: str | None) -> str | None:
         """Record someone who just introduced themselves.

--- a/robot/reachy_mini_mirrorbuddy/people.py
+++ b/robot/reachy_mini_mirrorbuddy/people.py
@@ -1,0 +1,103 @@
+"""Who is in the room right now.
+
+The robot sits on a kitchen table, not in a lab: a friend, a sibling or a parent
+sits down next to the child and starts talking. Buddy needs somewhere to put the
+names it is told, so it can address the right person instead of calling everyone
+by the paired child's name.
+
+Two deliberate constraints:
+
+- **Session-only.** Nothing is written to disk. A friend's name is a third child's
+  personal data and keeping it past the power switch is a consent decision their
+  parents never made. Turn the robot off, the room empties.
+- **Never invent, never guess.** A name only enters here if a human said it out
+  loud. Encrypted blobs (``pii:…``), numbers and sentence-length strings are
+  rejected, because the alternative is a robot cheerfully addressing a child as
+  "pii:8f3a2b" — or as someone who isn't in the room.
+"""
+
+from __future__ import annotations
+
+import re
+
+MAX_GUESTS = 6
+MAX_NAME_LEN = 40
+
+# A decryption miss or a placeholder must never be spoken as if it were a person.
+_NOT_A_NAME_PREFIXES = ("pii:", "[", "{", "<")
+# Letters (accented included), apostrophes, hyphens and spaces. Nothing else is a
+# name a child says out loud; digits and punctuation mean we misheard a sentence.
+_NAME_RE = re.compile(r"^[^\W\d_][\w' -]*$", re.UNICODE)
+
+
+def clean_name(raw: str | None) -> str | None:
+    """Normalise a spoken name, or ``None`` when it cannot be trusted as one."""
+    name = " ".join(str(raw or "").split())
+    if not name or len(name) > MAX_NAME_LEN:
+        return None
+    if name.lower().startswith(_NOT_A_NAME_PREFIXES):
+        return None
+    if not _NAME_RE.match(name):
+        return None
+    return " ".join(_capitalise(part) for part in name.split(" "))
+
+
+def _capitalise(part: str) -> str:
+    """Capitalise a name part without flattening the rest ("d'angelo" → "D'Angelo")."""
+    return re.sub(r"(^|['-])(\w)", lambda m: m.group(1) + m.group(2).upper(), part.lower())
+
+
+class Roster:
+    """The people Buddy currently knows it is talking to."""
+
+    def __init__(self, primary: str | None = None) -> None:
+        self._primary = clean_name(primary)
+        self._guests: list[str] = []
+
+    @property
+    def primary(self) -> str | None:
+        """The paired child, when we have a usable name for them."""
+        return self._primary
+
+    @property
+    def guests(self) -> tuple[str, ...]:
+        return tuple(self._guests)
+
+    def add_guest(self, raw: str | None) -> str | None:
+        """Record someone who just introduced themselves.
+
+        Returns the stored name, or ``None`` when what we heard was not a name.
+        Saying the paired child's own name is not an error — it simply changes
+        nothing, which is what "sono Mario" should do.
+        """
+        name = clean_name(raw)
+        if name is None:
+            return None
+        known = {n.casefold() for n in self._guests}
+        if self._primary and name.casefold() == self._primary.casefold():
+            return self._primary
+        if name.casefold() in known:
+            return next(n for n in self._guests if n.casefold() == name.casefold())
+        if len(self._guests) >= MAX_GUESTS:
+            # A full table is a party, not a study session; keep the earliest names
+            # rather than letting a noisy room evict the child's actual friends.
+            return None
+        self._guests.append(name)
+        return name
+
+    def clear_guests(self) -> None:
+        """The friends went home; the paired child stays."""
+        self._guests.clear()
+
+    def everyone(self) -> list[str]:
+        """Every name we can actually use, the paired child first."""
+        return ([self._primary] if self._primary else []) + list(self._guests)
+
+    def summary(self) -> str:
+        """A spoken-friendly list of who is here ("" when we know nobody)."""
+        names = self.everyone()
+        if not names:
+            return ""
+        if len(names) == 1:
+            return names[0]
+        return ", ".join(names[:-1]) + f" e {names[-1]}"

--- a/robot/reachy_mini_mirrorbuddy/prompt_builder.py
+++ b/robot/reachy_mini_mirrorbuddy/prompt_builder.py
@@ -50,7 +50,8 @@ _PEOPLE_IT = (
     "in quel momento, non a un interlocutore fisso.\n"
     "- Se senti qualcuno che non conosci, o qualcuno si presenta, accoglilo con calore e "
     "chiedigli come si chiama; appena te lo dice usa lo strumento 'remember_person' con "
-    "quel nome, cosi' te lo ricordi davvero per tutta la sessione.\n"
+    "quel nome, cosi' te lo ricordi davvero per tutta la sessione. Se chi ti dice il nome "
+    "e' lo studente che segui, passa anche is_student=true.\n"
     "- Se non sei sicuro di chi ti sta parlando, chiedilo con semplicita' ('chi sta "
     "parlando adesso?') invece di indovinare. Puoi usare 'who_is_here' per ricordarti chi c'e'.\n"
     "- Gli amici sono i benvenuti: possono farti domande e chiedere un professore come lo "
@@ -121,12 +122,17 @@ def build_instructions(
         )
     else:
         student_bits.append(
-            "Non conosci il nome dello studente: non inventarlo. Puoi chiederglielo "
-            "con gentilezza e poi registrarlo con 'remember_person'."
+            "Non sai ancora come si chiama lo studente: non inventarlo. Puoi chiederglielo "
+            "con gentilezza e registrarlo con 'remember_person' passando is_student=true."
         )
-    if room.guests:
+    if room.guests and room.primary:
         student_bits.append(
             f"In questo momento con lui ci sono anche: {', '.join(room.guests)}."
+        )
+    elif room.guests:
+        # No student name yet: saying "with him there are also…" would invent a him.
+        student_bits.append(
+            f"Le persone che si sono presentate finora sono: {', '.join(room.guests)}."
         )
     if dsa_profile:
         student_bits.append(_dsa_note(dsa_profile))

--- a/robot/reachy_mini_mirrorbuddy/prompt_builder.py
+++ b/robot/reachy_mini_mirrorbuddy/prompt_builder.py
@@ -8,6 +8,7 @@ so the Maestro knows it now has a physical body (eyes, ears, mouth, movements).
 from __future__ import annotations
 
 from .mirrorbuddy_client import Maestro
+from .people import Roster
 from .safety import get_safety_preamble
 
 _LANGUAGE_IT = (
@@ -30,7 +31,7 @@ _EMBODIMENT_IT = (
 )
 
 _TOOLS_IT = (
-    "Puoi fare tre cose con gli strumenti, quando serve, senza che nessuno tocchi uno schermo:\n"
+    "Con gli strumenti puoi agire davvero, quando serve, senza che nessuno tocchi uno schermo:\n"
     "- Se lo studente chiede chi c'è o con chi può parlare, usa 'list_professors'.\n"
     "- IMPORTANTE: se lo studente chiede un altro professore o un'altra materia (es. «voglio "
     "matematica», «chiama Galileo», «parliamo di storia»), DEVI usare SUBITO lo strumento "
@@ -41,6 +42,24 @@ _TOOLS_IT = (
     "Prima dì a voce che stai per guardare (es. «fammi dare un'occhiata»); poi resta fermo, non "
     "muovere la testa, perché il robot si ferma da solo per scattare una foto nitida. Non spiare "
     "mai: usa la telecamera solo su richiesta, per aiutare con lo studio, e non descrivere le persone."
+)
+
+_PEOPLE_IT = (
+    "Davanti a te puo' esserci piu' di una persona: oltre allo studente, un amico, un "
+    "fratello o un genitore che si siedono al tavolo. Rivolgiti sempre a chi sta parlando "
+    "in quel momento, non a un interlocutore fisso.\n"
+    "- Se senti qualcuno che non conosci, o qualcuno si presenta, accoglilo con calore e "
+    "chiedigli come si chiama; appena te lo dice usa lo strumento 'remember_person' con "
+    "quel nome, cosi' te lo ricordi davvero per tutta la sessione.\n"
+    "- Se non sei sicuro di chi ti sta parlando, chiedilo con semplicita' ('chi sta "
+    "parlando adesso?') invece di indovinare. Puoi usare 'who_is_here' per ricordarti chi c'e'.\n"
+    "- Gli amici sono i benvenuti: possono farti domande e chiedere un professore come lo "
+    "studente. Valgono per tutti le stesse regole di sicurezza.\n"
+    "- Usa i nomi propri con PARSIMONIA: al saluto, quando ti rivolgi a una persona precisa "
+    "per distinguerla dalle altre, o quando richiami l'attenzione. Non iniziare ogni frase "
+    "con un nome e non ripeterlo a ogni risposta: nessuno parla cosi'.\n"
+    "- Non inventare MAI un nome e non usarne uno di cui non sei sicuro: se non lo sai, "
+    "parla senza nomi propri."
 )
 
 _CONTROL_IT = (
@@ -57,8 +76,14 @@ def build_instructions(
     locale: str = "it",
     dsa_profile: str | None = None,
     student_name: str | None = None,
+    roster: Roster | None = None,
 ) -> str:
-    """Compose the full system instructions for the realtime session."""
+    """Compose the full system instructions for the realtime session.
+
+    ``roster`` carries the people Buddy has already met in this session, so a friend
+    who introduced themselves five minutes ago is still known after a professor
+    switch (which rebuilds these instructions from scratch).
+    """
     parts: list[str] = []
 
     # 1. Safety first — highest priority, non-negotiable.
@@ -83,18 +108,30 @@ def build_instructions(
     # 4. Robot embodiment + voice-driven tools + conversation control.
     parts.append(_EMBODIMENT_IT)
     parts.append(_TOOLS_IT)
+    parts.append(_PEOPLE_IT)
     parts.append(_CONTROL_IT)
 
-    # 5. Student personalisation + DSA sensitivity.
+    # 5. Who is in the room + DSA sensitivity.
+    room = roster if roster is not None else Roster(student_name)
     student_bits: list[str] = []
-    if student_name:
+    if room.primary:
         student_bits.append(
-            f"Stai facendo da tutor a {student_name}. Chiamalo per nome, con affetto."
+            f"Lo studente che segui si chiama {room.primary}. Usa il suo nome solo "
+            "ogni tanto, come faresti parlando con un amico."
+        )
+    else:
+        student_bits.append(
+            "Non conosci il nome dello studente: non inventarlo. Puoi chiederglielo "
+            "con gentilezza e poi registrarlo con 'remember_person'."
+        )
+    if room.guests:
+        student_bits.append(
+            f"In questo momento con lui ci sono anche: {', '.join(room.guests)}."
         )
     if dsa_profile:
         student_bits.append(_dsa_note(dsa_profile))
     if student_bits:
-        parts.append(" ".join(student_bits))
+        parts.append(" ".join(b for b in student_bits if b))
 
     return "\n\n".join(p.strip() for p in parts if p and p.strip())
 

--- a/robot/reachy_mini_mirrorbuddy/tool_handlers.py
+++ b/robot/reachy_mini_mirrorbuddy/tool_handlers.py
@@ -40,6 +40,10 @@ class ToolCallMixin:
                 self._switch_persona(client, call_id, friend=True)
             elif name == "back_to_study":
                 self._switch_persona(client, call_id, friend=False)
+            elif name == "remember_person":
+                self._handle_remember_person(client, args, call_id)
+            elif name == "who_is_here":
+                client.send_function_result(call_id, self._room_summary())
             else:
                 client.send_function_result(call_id, "Ok.")
         except Exception as e:  # pragma: no cover - runtime robustness
@@ -64,6 +68,34 @@ class ToolCallMixin:
         # Acknowledge without a spoken reply here; the new Maestro will greet.
         client.send_function_result(call_id, f"Passo la parola a {target.display_name}.", respond=False)
         threading.Thread(target=self._switch_to, args=(target,), name="MaestroSwitch", daemon=True).start()
+
+    def _handle_remember_person(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
+        """Record a name someone just said out loud — nothing else ever gets in.
+
+        A rejected name is reported as a rejection, on purpose: the failure mode we
+        are designing against is Buddy smoothing over a misheard name and then
+        addressing a child by something nobody in the room is called.
+        """
+        stored = self.people.add_guest(str(args.get("name") or ""))
+        if stored is None:
+            client.send_function_result(
+                call_id,
+                "Non ho capito bene il nome. Chiedi di ripeterlo con gentilezza, "
+                "e non usare un nome di cui non sei sicuro.",
+            )
+            return
+        client.send_function_result(
+            call_id,
+            f"Ok, {stored} adesso lo conosco. {self._room_summary()} "
+            "Salutalo brevemente e vai avanti: usa i nomi solo quando servono.",
+        )
+
+    def _room_summary(self) -> str:
+        """Who Buddy can name right now, phrased for the model to read aloud."""
+        summary = self.people.summary()
+        if not summary:
+            return "Non so ancora come si chiama chi e' con te: se serve, chiedilo."
+        return f"In questo momento davanti a te ci sono: {summary}."
 
     def _switch_persona(self, client: AzureRealtimeClient, call_id: str, friend: bool) -> None:
         """Swap between the friend companion and the study tutor (persona + voice)."""

--- a/robot/reachy_mini_mirrorbuddy/tool_handlers.py
+++ b/robot/reachy_mini_mirrorbuddy/tool_handlers.py
@@ -76,7 +76,14 @@ class ToolCallMixin:
         are designing against is Buddy smoothing over a misheard name and then
         addressing a child by something nobody in the room is called.
         """
-        stored = self.people.add_guest(str(args.get("name") or ""))
+        raw = str(args.get("name") or "")
+        # The paired child is not a guest: when the robot boots without a usable
+        # STUDENT_NAME, the child answering "mi chiamo Mario" has to land as the
+        # student, or every prompt rebuilt afterwards keeps calling them unknown.
+        if args.get("is_student"):
+            stored = self.people.set_primary(raw)
+        else:
+            stored = self.people.add_guest(raw)
         if stored is None:
             client.send_function_result(
                 call_id,

--- a/robot/reachy_mini_mirrorbuddy/tools.py
+++ b/robot/reachy_mini_mirrorbuddy/tools.py
@@ -97,6 +97,35 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
         ),
         "parameters": {"type": "object", "properties": {}, "required": []},
     },
+    {
+        "type": "function",
+        "name": "remember_person",
+        "description": (
+            "Registra il nome di una persona che si e' appena presentata o che ti ha detto come "
+            "si chiama (un amico dello studente, un fratello, un genitore, o lo studente stesso). "
+            "Usalo SUBITO dopo aver sentito il nome, cosi' te lo ricordi per tutta la conversazione "
+            "e puoi rivolgerti alla persona giusta. Non usarlo con nomi che non hai sentito dire."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Il nome proprio cosi' come la persona lo ha detto (es. 'Giulia').",
+                }
+            },
+            "required": ["name"],
+        },
+    },
+    {
+        "type": "function",
+        "name": "who_is_here",
+        "description": (
+            "Ricorda chi c'e' in questo momento davanti a te: lo studente e le persone che si sono "
+            "presentate. Usalo se non ricordi o non sei sicuro di come si chiama chi ti sta parlando."
+        ),
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
 ]
 
 

--- a/robot/reachy_mini_mirrorbuddy/tools.py
+++ b/robot/reachy_mini_mirrorbuddy/tools.py
@@ -112,7 +112,14 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
                 "name": {
                     "type": "string",
                     "description": "Il nome proprio cosi' come la persona lo ha detto (es. 'Giulia').",
-                }
+                },
+                "is_student": {
+                    "type": "boolean",
+                    "description": (
+                        "true se e' lo studente che segui a dirti il proprio nome; "
+                        "false o assente se e' un'altra persona (un amico, un fratello, un genitore)."
+                    ),
+                },
             },
             "required": ["name"],
         },

--- a/robot/tests/test_people.py
+++ b/robot/tests/test_people.py
@@ -1,0 +1,135 @@
+"""More than one child in front of the robot, and a name used like a person uses it.
+
+Two complaints, one fix. Buddy knew exactly one human — the paired account — so a
+friend sitting down next to the child was addressed with the child's name, or not
+addressed at all. And it said that one name in nearly every sentence, which is what
+nobody does when talking to someone in the same room.
+
+The roster is deliberately in-memory only: a friend's name is a third child's
+personal data, and keeping it on the device past the power switch is a consent
+decision their parents never made.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from reachy_mini_mirrorbuddy import people
+from reachy_mini_mirrorbuddy.mirrorbuddy_client import Maestro
+from reachy_mini_mirrorbuddy.prompt_builder import build_instructions
+
+
+@pytest.fixture
+def maestro():
+    return Maestro(
+        id="buddy",
+        name="Buddy",
+        display_name="Buddy",
+        subject="",
+        specialty="",
+        voice="coral",
+        voice_instructions="",
+        teaching_style="",
+        system_prompt="Sei Buddy.",
+        greeting="Ciao!",
+    )
+
+
+class TestRoster:
+    def test_starts_with_the_paired_child_alone(self):
+        r = people.Roster("Mario")
+        assert r.primary == "Mario"
+        assert r.guests == ()
+        assert r.everyone() == ["Mario"]
+
+    def test_a_friend_introduces_themselves(self):
+        r = people.Roster("Mario")
+        assert r.add_guest("giulia") == "Giulia"
+        assert r.guests == ("Giulia",)
+        assert r.everyone() == ["Mario", "Giulia"]
+
+    def test_the_same_friend_is_not_added_twice(self):
+        r = people.Roster("Mario")
+        r.add_guest("Giulia")
+        assert r.add_guest("  giulia ") == "Giulia"
+        assert r.guests == ("Giulia",)
+
+    def test_the_paired_child_is_never_also_a_guest(self):
+        r = people.Roster("Mario")
+        assert r.add_guest("mario") == "Mario"
+        assert r.guests == ()
+
+    @pytest.mark.parametrize(
+        "junk",
+        [
+            "",
+            "   ",
+            "pii:8f3a2b",  # a decryption miss must never become a person
+            "[encrypted]",
+            "12345",
+            "!!!",
+            "x" * 41,  # a whole sentence mistaken for a name
+        ],
+    )
+    def test_junk_never_becomes_a_person(self, junk):
+        r = people.Roster("Mario")
+        assert r.add_guest(junk) is None
+        assert r.guests == ()
+
+    def test_a_ciphertext_primary_is_treated_as_no_name(self):
+        # The server encrypts names; a miss puts ciphertext on the wire, and the
+        # robot must stay silent about names rather than read a blob aloud.
+        r = people.Roster("pii:8f3a2b")
+        assert r.primary is None
+        assert r.everyone() == []
+
+    def test_the_room_does_not_grow_without_bound(self):
+        r = people.Roster("Mario")
+        for i in range(people.MAX_GUESTS + 4):
+            r.add_guest(f"Amico{chr(ord('a') + i)}")
+        assert len(r.guests) == people.MAX_GUESTS
+
+    def test_everyone_can_leave(self):
+        r = people.Roster("Mario")
+        r.add_guest("Giulia")
+        r.clear_guests()
+        assert r.guests == ()
+        assert r.primary == "Mario"  # the paired child stays
+
+    def test_a_compound_name_survives_intact(self):
+        r = people.Roster(None)
+        assert r.add_guest("maria luisa d'angelo") == "Maria Luisa D'Angelo"
+
+    def test_nothing_is_written_to_disk(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        r = people.Roster("Mario")
+        r.add_guest("Giulia")
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestInstructions:
+    def test_the_name_is_used_sparingly_not_every_sentence(self, maestro):
+        text = build_instructions(maestro, student_name="Mario")
+        assert "parsimonia" in text.lower()
+        # The old instruction told the model to call the child by name, full stop.
+        assert "Chiamalo per nome, con affetto." not in text
+
+    def test_buddy_is_told_it_may_have_several_people_in_front_of_it(self, maestro):
+        text = build_instructions(maestro, student_name="Mario")
+        assert "remember_person" in text
+        assert "chi sta parlando" in text
+
+    def test_guests_are_named_in_the_session(self, maestro):
+        r = people.Roster("Mario")
+        r.add_guest("Giulia")
+        text = build_instructions(maestro, student_name="Mario", roster=r)
+        assert "Giulia" in text
+
+    def test_without_a_usable_name_buddy_is_told_not_to_invent_one(self, maestro):
+        text = build_instructions(maestro, student_name="pii:8f3a2b")
+        assert "8f3a2b" not in text
+        assert "non inventare" in text.lower()
+
+    def test_the_safety_rules_still_come_first(self, maestro):
+        text = build_instructions(maestro, student_name="Mario", roster=people.Roster("Mario"))
+        assert text.index("REGOLE DI SICUREZZA") < text.lower().index("parsimonia")

--- a/robot/tests/test_people.py
+++ b/robot/tests/test_people.py
@@ -67,6 +67,9 @@ class TestRoster:
             "pii:8f3a2b",  # a decryption miss must never become a person
             "[encrypted]",
             "12345",
+            "Mario2",  # ASR digits: `\w` used to let these through
+            "Giulia_",
+            "M4rio",
             "!!!",
             "x" * 41,  # a whole sentence mistaken for a name
         ],
@@ -95,6 +98,32 @@ class TestRoster:
         r.clear_guests()
         assert r.guests == ()
         assert r.primary == "Mario"  # the paired child stays
+
+    def test_the_paired_child_can_introduce_themselves(self):
+        # No STUDENT_NAME configured: the child says their own name out loud, and it
+        # must land as the student — not as a guest standing next to a nobody.
+        r = people.Roster(None)
+        assert r.set_primary("mario") == "Mario"
+        assert r.primary == "Mario"
+        assert r.guests == ()
+
+    def test_introducing_the_student_twice_does_not_duplicate_them(self):
+        r = people.Roster(None)
+        r.set_primary("Mario")
+        r.add_guest("Mario")
+        assert r.everyone() == ["Mario"]
+
+    def test_a_promoted_guest_stops_being_a_guest(self):
+        r = people.Roster(None)
+        r.add_guest("Mario")
+        assert r.set_primary("Mario") == "Mario"
+        assert r.guests == ()
+        assert r.everyone() == ["Mario"]
+
+    def test_junk_never_becomes_the_student(self):
+        r = people.Roster(None)
+        assert r.set_primary("pii:8f3a2b") is None
+        assert r.primary is None
 
     def test_a_compound_name_survives_intact(self):
         r = people.Roster(None)
@@ -133,3 +162,10 @@ class TestInstructions:
     def test_the_safety_rules_still_come_first(self, maestro):
         text = build_instructions(maestro, student_name="Mario", roster=people.Roster("Mario"))
         assert text.index("REGOLE DI SICUREZZA") < text.lower().index("parsimonia")
+
+    def test_once_someone_introduced_themselves_buddy_is_not_told_the_room_is_unknown(self, maestro):
+        r = people.Roster(None)
+        r.add_guest("Giulia")
+        text = build_instructions(maestro, roster=r)
+        assert "Giulia" in text
+        assert "Non conosci il nome dello studente" not in text

--- a/robot/tests/test_presence.py
+++ b/robot/tests/test_presence.py
@@ -95,12 +95,16 @@ class TestHowTheGreetingAddressesTheChild:
     """Being called by a stranger's name is a small betrayal a child remembers."""
 
     @staticmethod
-    def _clause(name):
+    def _clause(name, guests=(), use_name=True):
         from reachy_mini_mirrorbuddy.controller import Controller
+        from reachy_mini_mirrorbuddy.people import Roster
 
         c = Controller.__new__(Controller)
         c.cfg = type("Cfg", (), {"STUDENT_NAME": name})()
-        return c._name_clause()
+        c.people = Roster(name)
+        for g in guests:
+            c.people.add_guest(g)
+        return c._name_clause(use_name=use_name)
 
     def test_a_known_name_is_handed_to_the_model(self):
         assert "Mario" in self._clause("Mario")
@@ -116,3 +120,12 @@ class TestHowTheGreetingAddressesTheChild:
 
     def test_a_failed_decryption_placeholder_is_refused(self):
         assert "senza usare nomi" in self._clause("[decryption-failed]")
+
+    def test_a_welcome_back_does_not_repeat_the_name(self):
+        # Sparing use: the first hello may name the child, the one two minutes
+        # later should not. Repeating it every time is the tic we removed.
+        assert "senza usare nomi" in self._clause("Mario", use_name=False)
+
+    def test_with_a_friend_at_the_table_nobody_is_singled_out(self):
+        clause = self._clause("Mario", guests=("Giulia",))
+        assert "Mario" not in clause and "Giulia" not in clause

--- a/robot/tests/test_remember_person.py
+++ b/robot/tests/test_remember_person.py
@@ -1,0 +1,92 @@
+"""A friend says their name and Buddy actually keeps it — for this session.
+
+The failure this pins: the model would happily *say* "piacere Giulia!" and then
+address her as Mario two turns later, because nothing on the device ever recorded
+that a second person existed. The tool is what turns the courtesy into state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from reachy_mini_mirrorbuddy import people, tools
+from reachy_mini_mirrorbuddy.tool_handlers import ToolCallMixin
+
+
+class FakeClient:
+    def __init__(self):
+        self.results: list[tuple[str, str, bool]] = []
+
+    def send_function_result(self, call_id, text, respond=True):
+        self.results.append((call_id, text, respond))
+
+
+class Buddy(ToolCallMixin):
+    """The tool surface of Controller, without the robot underneath it."""
+
+    def __init__(self, primary="Mario"):
+        self.people = people.Roster(primary)
+        self._client = FakeClient()
+        self.maestri = []
+
+
+@pytest.fixture
+def buddy():
+    return Buddy()
+
+
+def _said(buddy):
+    return " ".join(text for _, text, _ in buddy._client.results)
+
+
+class TestRememberPerson:
+    def test_the_tool_is_offered_to_the_model(self):
+        assert any(t["name"] == "remember_person" for t in tools.TOOL_SCHEMAS)
+
+    def test_a_new_friend_is_added_to_the_room(self, buddy):
+        buddy._on_tool_call("remember_person", {"name": "Giulia"}, "c1")
+
+        assert buddy.people.guests == ("Giulia",)
+        assert "Giulia" in _said(buddy)
+
+    def test_the_answer_lists_who_is_in_the_room(self, buddy):
+        buddy._on_tool_call("remember_person", {"name": "Giulia"}, "c1")
+        buddy._on_tool_call("remember_person", {"name": "Luca"}, "c2")
+
+        last = buddy._client.results[-1][1]
+        assert "Mario" in last and "Giulia" in last and "Luca" in last
+
+    def test_an_unusable_name_is_reported_not_invented(self, buddy):
+        buddy._on_tool_call("remember_person", {"name": "   "}, "c1")
+
+        assert buddy.people.guests == ()
+        # Buddy must ask again rather than silently pretend it understood.
+        assert "chiedi" in _said(buddy).lower()
+
+    def test_ciphertext_is_never_accepted_as_a_name(self, buddy):
+        buddy._on_tool_call("remember_person", {"name": "pii:8f3a2b"}, "c1")
+
+        assert buddy.people.guests == ()
+        assert "8f3a2b" not in _said(buddy)
+
+    def test_a_missing_argument_does_not_crash_the_session(self, buddy):
+        buddy._on_tool_call("remember_person", {}, "c1")
+
+        assert buddy.people.guests == ()
+        assert buddy._client.results  # the model always gets an answer back
+
+
+class TestWhoIsHere:
+    def test_buddy_can_recall_the_room(self, buddy):
+        buddy.people.add_guest("Giulia")
+
+        buddy._on_tool_call("who_is_here", {}, "c1")
+
+        assert "Mario" in _said(buddy) and "Giulia" in _said(buddy)
+
+    def test_an_empty_room_is_stated_plainly(self):
+        b = Buddy(primary=None)
+
+        b._on_tool_call("who_is_here", {}, "c1")
+
+        assert "non so" in _said(b).lower()

--- a/robot/tests/test_remember_person.py
+++ b/robot/tests/test_remember_person.py
@@ -76,6 +76,31 @@ class TestRememberPerson:
         assert buddy._client.results  # the model always gets an answer back
 
 
+class TestTheStudentsOwnName:
+    def test_the_child_introducing_themselves_becomes_the_student(self):
+        # Codex caught this: with no STUDENT_NAME configured, the prompt asks the
+        # child for their name, and storing it as a guest left every rebuilt prompt
+        # still insisting the student was unknown.
+        b = Buddy(primary=None)
+
+        b._on_tool_call("remember_person", {"name": "Mario", "is_student": True}, "c1")
+
+        assert b.people.primary == "Mario"
+        assert b.people.guests == ()
+
+    def test_a_friend_is_still_only_a_friend(self, buddy):
+        buddy._on_tool_call("remember_person", {"name": "Giulia", "is_student": False}, "c1")
+
+        assert buddy.people.primary == "Mario"
+        assert buddy.people.guests == ("Giulia",)
+
+    def test_a_digit_bearing_mishearing_is_refused(self, buddy):
+        buddy._on_tool_call("remember_person", {"name": "Mario2"}, "c1")
+
+        assert buddy.people.guests == ()
+        assert "chiedi" in _said(buddy).lower()
+
+
 class TestWhoIsHere:
     def test_buddy_can_recall_the_room(self, buddy):
         buddy.people.add_guest("Giulia")


### PR DESCRIPTION
Roberto: *«si può fare in modo che possa interagire anche con altri amici dell'utente principale? […] e che non chiami sempre e solo il nome dell'utente»*.

Two complaints, one root cause: the robot knew exactly **one** human — the paired account — and the instruction `Chiamalo per nome, con affetto` made it say that one name in nearly every sentence.

## What changes

- **`people.Roster`** — who is in the room. **In memory only, one power cycle.** A friend's first name is a third child's personal data; keeping it past the power switch is a consent decision their parents never made. Nothing is written to disk, nothing is sent to the server.
- **`remember_person` / `who_is_here`** — Buddy greets a new voice, asks its name and actually keeps it, instead of saying *«piacere Giulia»* and calling her Mario two turns later. Guests can ask questions and call a professor like the paired child; the safety guardrails apply to everyone.
- **Names used sparingly** — greeting, singling someone out, calling attention. Not at the start of every sentence. The welcome-back greeting no longer repeats the name, and with a friend at the table nobody is singled out.
- **Never invented** — ciphertext (`pii:…`), digits and sentence-length strings are refused rather than spoken. This is the "Mario called Luca" scar, extended to guests.

**No voice or face recognition, deliberately.** Buddy knows who is speaking only because someone told it. Identifying a third party biometrically would need its own ADR and its own consent. ADR 0170 now records that boundary.

## Decisions taken with Roberto before coding

| question | choice |
| --- | --- |
| memory of friends | session only — no file on the device |
| how it knows who speaks | conversational (it asks); no biometrics |
| use of the main user's name | sparing |
| guests may use the tools | yes |

## Verification

- `pytest` on the robot package: **182 passed, 1 skipped** (venv with numpy/scipy — the two collection errors on a bare python are pre-existing on `main`).
- `ruff`: **83 findings on this branch, 83 on `main`** — no new lint debt; the new module is clean.
- **Mutation-checked**, because a green test that cannot fail is worth nothing:

| mutation | result |
| --- | --- |
| drop the multi-person prompt block | 4 tests red |
| accept any string as a name | 2 tests red |
| always use the name on welcome-back | 1 test red |
| silently swallow an unusable name | 1 test red |
| restored | 45 green |

## Deploying to the robot

Not automatic: after merge, `robot/publish-space.sh` pushes the package to the Hugging Face Space the robot installs from. Today's check found the Space byte-identical to `main`, `reachy-mini.local` reachable and `mirrorbuddy-autostart` enabled + active.