### PR TITLE
fix(robot): Buddy stops going silent — pause vs rest, and reconnect instead of dying

### DIFF
--- a/docs/adr/0170-reachy-mini-robot-embodiment.md
+++ b/docs/adr/0170-reachy-mini-robot-embodiment.md
@@ -1,12 +1,12 @@
 # ADR 0170: Reachy Mini as MirrorBuddy's Physical Embodiment + Device Pairing
 
-| Field          | Value                                                                                     |
-| -------------- | ----------------------------------------------------------------------------------------- |
-| Status         | **PROPOSED**                                                                              |
-| Date           | 2026-07-19                                                                                |
-| Branch         | feat/reachy-mini-mirrorbuddy · feat/reachy-mini-mirrorbuddy-pairing                       |
+| Field          | Value                                                                                                                                                   |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Status         | **PROPOSED**                                                                                                                                            |
+| Date           | 2026-07-19                                                                                                                                              |
+| Branch         | feat/reachy-mini-mirrorbuddy · feat/reachy-mini-mirrorbuddy-pairing                                                                                     |
 | Related ADRs   | ADR 0169 (Azure Realtime 2.1 Cedar), ADR 0122 (Realtime Vision), ADR 0126 (Unified Camera), ADR 0008 (Parent GDPR consent), ADR 0104 (i18n wrapper key) |
-| Related Issues | Reachy Mini embodiment, device pairing                                                     |
+| Related Issues | Reachy Mini embodiment, device pairing                                                                                                                  |
 
 ## Context
 
@@ -64,8 +64,11 @@ A self-contained app under `robot/` (`reachy_mini_mirrorbuddy`) that:
   calmer amplitude while speaking so movement does not distract the student.
 - Uses the camera on an **explicit** `look_at_homework` request only (single
   frame, never streamed, nothing persisted) — consistent with ADR 0122/0126.
-- Enforces a **hard local interrupt** on stop words ("basta/zitto/fermati/
-  aspetta/pausa") via `audio.clear_player()`, with **no auto-resume**.
+- Enforces a **hard local interrupt** on hush words via `audio.clear_player()`,
+  with **no auto-resume**. Two tiers: a _pause_ ("aspetta/basta/fermati")
+  stops the current sentence and stays awake, a _rest_ ("zitto/dormi/taci")
+  parks the robot until it is called by name. Everyday filler must silence
+  the robot without costing the child the wake word.
 - Exposes everything by voice tools (switch professor/subject, look at homework).
 
 **Pros:** low latency; safety is local and deterministic; robot survives web

--- a/robot/README.md
+++ b/robot/README.md
@@ -62,24 +62,24 @@ model speech stream over a single Azure Realtime WebSocket (`azure_realtime`).
 
 ## Modules
 
-| File | Responsibility |
-| --- | --- |
-| `config.py` | Environment / `.env` configuration + WS URL (GA vs Preview) |
-| `mirrorbuddy_client.py` | Fetch + pick a Maestro from MirrorBuddy's public API |
-| `prompt_builder.py` | Assemble the realtime `instructions` (persona + safety + embodiment) |
-| `safety.py` | Child-safety guardrails (aligned with MirrorBuddy) |
-| `dsa.py` | Accessibility → server-VAD turn-detection tuning |
-| `azure_realtime.py` | Azure OpenAI Realtime WebSocket client (audio + tools + vision) |
-| `rt_messages.py` | Pure builders for the realtime protocol messages |
-| `audio_io.py` | Robot mic ↔ speaker bridge (resampling, playback, barge-in) |
-| `movements.py` | Expressive full-body motion + daemon face-follow while listening |
-| `camera.py` | On-demand JPEG capture + daemon head/face tracking helpers |
-| `people.py` | Who is in the room right now — session-only, never written to disk |
-| `tools.py` | Voice tool schemas (list/change professor, look at homework, friend/study, who is here) + resolver |
-| `session_flow.py` | Pure stop / end / wake decisions for the live loop (accessibility-critical) |
-| `controller.py` | Tool dispatch, live professor switching, vision, sleep/wake |
-| `settings_ui.py` | Minimal in-app settings page (creds + Maestro/DSA selection) |
-| `main.py` | App entry point wiring everything together |
+| File                    | Responsibility                                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------------------------- |
+| `config.py`             | Environment / `.env` configuration + WS URL (GA vs Preview)                                        |
+| `mirrorbuddy_client.py` | Fetch + pick a Maestro from MirrorBuddy's public API                                               |
+| `prompt_builder.py`     | Assemble the realtime `instructions` (persona + safety + embodiment)                               |
+| `safety.py`             | Child-safety guardrails (aligned with MirrorBuddy)                                                 |
+| `dsa.py`                | Accessibility → server-VAD turn-detection tuning                                                   |
+| `azure_realtime.py`     | Azure OpenAI Realtime WebSocket client (audio + tools + vision)                                    |
+| `rt_messages.py`        | Pure builders for the realtime protocol messages                                                   |
+| `audio_io.py`           | Robot mic ↔ speaker bridge (resampling, playback, barge-in)                                        |
+| `movements.py`          | Expressive full-body motion + daemon face-follow while listening                                   |
+| `camera.py`             | On-demand JPEG capture + daemon head/face tracking helpers                                         |
+| `people.py`             | Who is in the room right now — session-only, never written to disk                                 |
+| `tools.py`              | Voice tool schemas (list/change professor, look at homework, friend/study, who is here) + resolver |
+| `session_flow.py`       | Pure stop / end / wake decisions for the live loop (accessibility-critical)                        |
+| `controller.py`         | Tool dispatch, live professor switching, vision, sleep/wake                                        |
+| `settings_ui.py`        | Minimal in-app settings page (creds + Maestro/DSA selection)                                       |
+| `main.py`               | App entry point wiring everything together                                                         |
 
 ## Everything by voice (no screen)
 
@@ -150,6 +150,20 @@ locally** — never left to the model:
 
 These intents are detected in `session_flow.py`/`rt_messages.py` and enforced in
 `azure_realtime.py`, so they work even if the model would rather keep talking.
+
+## Staying alive (session resilience)
+
+Azure Realtime hard-closes **every** session at 60 minutes (`session_expired`),
+and home Wi-Fi drops. Either event closes the WebSocket, and the app used to end
+right there: the robot went silent for good, deaf even to its wake word, and only
+a manual restart brought it back.
+
+The session loop now treats a closed socket as a **reconnect, not an exit** — it
+comes back within a second, with an exponential backoff (max 30s) if Azure is
+genuinely unreachable. The resumed session is **silent**: no second greeting in
+the middle of homework. Per-session state (in-flight response, audio suppression)
+is reset, while what the child asked for — _rest_ after «zitto» — is preserved.
+Only closing the app really stops it.
 
 ## Pair with the child's MirrorBuddy profile
 

--- a/robot/README.md
+++ b/robot/README.md
@@ -62,61 +62,66 @@ model speech stream over a single Azure Realtime WebSocket (`azure_realtime`).
 
 ## Modules
 
-| File | Responsibility |
-| --- | --- |
-| `config.py` | Environment / `.env` configuration + WS URL (GA vs Preview) |
-| `mirrorbuddy_client.py` | Fetch + pick a Maestro from MirrorBuddy's public API |
-| `prompt_builder.py` | Assemble the realtime `instructions` (persona + safety + embodiment) |
-| `safety.py` | Child-safety guardrails (aligned with MirrorBuddy) |
-| `dsa.py` | Accessibility → server-VAD turn-detection tuning |
-| `azure_realtime.py` | Azure OpenAI Realtime WebSocket client (audio + tools + vision) |
-| `rt_messages.py` | Pure builders for the realtime protocol messages |
-| `audio_io.py` | Robot mic ↔ speaker bridge (resampling, playback, barge-in) |
-| `movements.py` | Expressive full-body motion + daemon face-follow while listening |
-| `camera.py` | On-demand JPEG capture + daemon head/face tracking helpers |
-| `tools.py` | Voice tool schemas (list/change professor, look at homework, friend/study) + resolver |
-| `session_flow.py` | Pure stop / end / wake decisions for the live loop (accessibility-critical) |
-| `controller.py` | Tool dispatch, live professor switching, vision, sleep/wake |
-| `settings_ui.py` | Minimal in-app settings page (creds + Maestro/DSA selection) |
-| `main.py` | App entry point wiring everything together |
+| File                    | Responsibility                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------- |
+| `config.py`             | Environment / `.env` configuration + WS URL (GA vs Preview)                           |
+| `mirrorbuddy_client.py` | Fetch + pick a Maestro from MirrorBuddy's public API                                  |
+| `prompt_builder.py`     | Assemble the realtime `instructions` (persona + safety + embodiment)                  |
+| `safety.py`             | Child-safety guardrails (aligned with MirrorBuddy)                                    |
+| `dsa.py`                | Accessibility → server-VAD turn-detection tuning                                      |
+| `azure_realtime.py`     | Azure OpenAI Realtime WebSocket client (audio + tools + vision)                       |
+| `rt_messages.py`        | Pure builders for the realtime protocol messages                                      |
+| `audio_io.py`           | Robot mic ↔ speaker bridge (resampling, playback, barge-in)                           |
+| `movements.py`          | Expressive full-body motion + daemon face-follow while listening                      |
+| `camera.py`             | On-demand JPEG capture + daemon head/face tracking helpers                            |
+| `tools.py`              | Voice tool schemas (list/change professor, look at homework, friend/study) + resolver |
+| `session_flow.py`       | Pure stop / end / wake decisions for the live loop (accessibility-critical)           |
+| `controller.py`         | Tool dispatch, live professor switching, vision, sleep/wake                           |
+| `settings_ui.py`        | Minimal in-app settings page (creds + Maestro/DSA selection)                          |
+| `main.py`               | App entry point wiring everything together                                            |
 
 ## Everything by voice (no screen)
 
 Buddy is voice-only, so the model drives the robot through realtime **tools**:
 
-- **Change professor / subject** — say e.g. *«voglio matematica»* or *«chiama Galileo»*.
+- **Change professor / subject** — say e.g. _«voglio matematica»_ or _«chiama Galileo»_.
   `call_professor` resolves the Maestro and reconnects the session with the new
   **persona + voice**; the new professor greets. All 26 MirrorBuddy Maestri are available.
-- **Look at homework** — say e.g. *«guarda questo compito»*. `look_at_homework` captures
+- **Look at homework** — say e.g. _«guarda questo compito»_. `look_at_homework` captures
   one camera frame and the model reads the exercise and helps step by step.
 - **Who is here** — `list_professors` enumerates the available Maestri and their subjects.
-- **Just a friend (not school)** — say e.g. *«non voglio fare i compiti»* or *«parliamo un
-  po'»*. Buddy switches to **friend mode** (`talk_as_friend`): the peer‑companion Buddy of
+- **Just a friend (not school)** — say e.g. _«non voglio fare i compiti»_ or _«parliamo un
+  po'»_. Buddy switches to **friend mode** (`talk_as_friend`): the peer‑companion Buddy of
   MirrorBuddy's Support Triangle — a warm coetaneo you can talk to about anything, not a
-  tutor. Say *«torniamo ai compiti»* (`back_to_study`) to go back to studying.
+  tutor. Say _«torniamo ai compiti»_ (`back_to_study`) to go back to studying.
 
 ## Ending a session & interrupting (accessibility‑critical)
 
 Insistence is stressful for the child, so these are handled **deterministically and
 locally** — never left to the model:
 
-- **Stop / rest now** — say *«basta»*, *«zitto»*, *«fermati»*, *«aspetta»*, *«pausa»*, or
-  the explicit sleep command *«dormi»* / *«vai a dormire»* / *«riposati»*.
-  Buddy goes silent **immediately and says nothing back** (local audio flush + turn cancel,
-  and the server is configured **not** to auto-reply — a response is only ever requested
-  after an ordinary turn), settles into a calm **rest position** and **stays parked** — no
-  fidgeting, no talking — until you call it back. A stop is a full stop, never a reply.
-- **Instant on-device barge-in** — the moment the child speaks *over* Buddy, playback is
+- **Pause** — _«aspetta»_, _«basta»_, _«fermati»_, _«un attimo»_, _«pausa»_. Buddy stops
+  the sentence it is saying **immediately and says nothing back** (local audio flush + turn
+  cancel, and the server is configured **not** to auto-reply). It stays awake: the next
+  thing you say is answered normally. These words are everyday Italian — _«aspetta che
+  scrivo»_ must not cost you the wake word.
+- **Rest** — the deliberate _«zitto»_, _«silenzio»_, _«taci»_, _«dormi»_, _«vai a dormire»_,
+  _«riposati»_, _«spegniti»_. Buddy goes silent, settles into a calm **rest position** and
+  **stays parked** — no fidgeting, no talking — until you call it back **by name**
+  (_«Buddy»_). A rest is a full stop, never a reply.
+- **Goodbye** — _«abbiamo finito»_, _«a domani»_, _«ci vediamo»_ at the end of a sentence:
+  a short farewell, then rest. Mid-sentence (_«ci vediamo dopo pranzo»_) it is just talk.
+- **Instant on-device barge-in** — the moment the child speaks _over_ Buddy, playback is
   cut on the robot itself, without waiting for the server. The Reachy Mini mic array is
   echo-cancelled in hardware, so voice energy on the mic while Buddy is speaking is a real
   nearby voice (not the robot hearing itself) — `audio_io.py` flushes the speaker and the
   realtime client drops any in-flight audio right away. Sensitivity is configurable from
   the robot's **settings page** ("Sensibilità basta") — or via `MIRRORBUDDY_BARGE_RMS`
   (default `0.045`, lower = more sensitive) and `MIRRORBUDDY_BARGE_FRAMES` (default `3`).
-- **We're done for today** — say *«abbiamo finito»*, *«a domani»*, *«buonanotte»*,
-  *«ci vediamo»*. Buddy says **one** short goodbye, then rests the same way.
+- **We're done for today** — say _«abbiamo finito»_, _«a domani»_, _«buonanotte»_,
+  _«ci vediamo»_. Buddy says **one** short goodbye, then rests the same way.
 - **Wake it back up** — while resting it ignores everything **except its name**: say
-  *«Buddy»* and it wakes with a small gesture, greets again and asks what you'd like to do.
+  _«Buddy»_ and it wakes with a small gesture, greets again and asks what you'd like to do.
   Nothing else brings it back, so a rest really lasts until you call it.
 
 These intents are detected in `session_flow.py`/`rt_messages.py` and enforced in
@@ -152,7 +157,7 @@ While listening, the robot **follows the student's face** (daemon head tracking)
 Buddy speaks, the head hands over to the audio wobbler for lip-sync-like motion.
 
 Privacy by design: the camera **never streams** and captures a frame **only** on an
-explicit `look_at_homework` request, always preceded by a spoken *"I'm going to look…"*.
+explicit `look_at_homework` request, always preceded by a spoken _"I'm going to look…"_.
 Nothing (audio or images) is persisted to disk. Face-follow and the camera can be turned
 off with `MIRRORBUDDY_FOLLOW_FACE=false` / `MIRRORBUDDY_ENABLE_CAMERA=false`.
 
@@ -173,8 +178,8 @@ Useful optional:
 - `MIRRORBUDDY_MAESTRO_ID` — which professor to embody (empty = first Italian tutor)
 - `MIRRORBUDDY_DSA_PROFILE` — `cerebral` (default), `dyslexia`, `adhd`, …
 - `MIRRORBUDDY_STUDENT_NAME` — personalises the greeting (e.g. `Mario`)
-- `MIRRORBUDDY_DEVICE_TOKEN` — set automatically when you pair (see *Pair with the
-  child's MirrorBuddy profile* above); overrides the fields above with the live profile
+- `MIRRORBUDDY_DEVICE_TOKEN` — set automatically when you pair (see _Pair with the
+  child's MirrorBuddy profile_ above); overrides the fields above with the live profile
 
 ### Publishing to the Reachy Mini app store
 
@@ -200,5 +205,5 @@ The app registers under the `reachy_mini_apps` entry-point group as
 ## Roadmap
 
 - **Vision** — the camera hardware is available; sending frames to the realtime model
-  (so Buddy can actually *see* homework you show it) is the next enhancement.
+  (so Buddy can actually _see_ homework you show it) is the next enhancement.
 - **Emotion → richer movement** — map transcript sentiment to head gestures.

--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -10,6 +10,7 @@ import base64
 import json
 import logging
 import threading
+import time
 from collections.abc import Callable
 
 import websockets
@@ -20,6 +21,10 @@ from .rt_events import RealtimeEventsMixin
 logger = logging.getLogger(__name__)
 
 SAMPLE_RATE = rt_messages.SAMPLE_RATE  # Azure Realtime PCM sample rate (in and out)
+
+_RECONNECT_MIN_S = 1.0  # a session that ran its course comes back immediately
+_RECONNECT_MAX_S = 30.0  # a robot deaf for more than half a minute is a broken robot
+_HEALTHY_SESSION_S = 30.0  # shorter than this counts as a failure, so we back off
 
 
 def _ws_major() -> int:
@@ -150,11 +155,51 @@ class AzureRealtimeClient(RealtimeEventsMixin):
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
         try:
-            self._loop.run_until_complete(self._connect_and_listen())
+            self._loop.run_until_complete(self._session_loop())
         except Exception as e:  # pragma: no cover - network runtime
             logger.error("Azure Realtime loop crashed: %s", e, exc_info=True)
         finally:
             self._loop.close()
+
+    async def _session_loop(self) -> None:
+        """Keep a live session for as long as the app runs.
+
+        Azure hard-closes every Realtime session at 60 minutes
+        ("session_expired"), and Wi-Fi drops happen. Either way this thread used
+        to end, which ended the app: the robot went deaf mid-homework and not even
+        the wake word could reach it. So a closed socket is a reconnect, not an
+        exit — only :meth:`stop` really stops.
+        """
+        delay = _RECONNECT_MIN_S
+        while not self._stop.is_set():
+            started = time.monotonic()
+            self._reset_session_state()
+            try:
+                await self._connect_and_listen()
+            except Exception as e:
+                logger.error("Realtime session dropped: %s", e)
+            if self._stop.is_set():
+                return
+            if time.monotonic() - started >= _HEALTHY_SESSION_S:
+                delay = _RECONNECT_MIN_S  # a real session ran: come back at once
+            logger.info("Realtime session ended; reconnecting in %.0fs", delay)
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, _RECONNECT_MAX_S)
+
+    def _reset_session_state(self) -> None:
+        """Clear per-session flags, keep what the child asked for.
+
+        A session that died mid-sentence leaves audio suppressed and a response
+        "in flight"; carrying that into the new session would mute it entirely.
+        ``_asleep`` / ``_quiet`` are deliberately preserved: if the child said
+        "zitto", coming back talking is exactly the insistence to avoid.
+        """
+        self._ws = None
+        self._suppress = False
+        self._responding = False
+        self._fast_requested = False
+        self._stopped_on_partial = False
+        self._partial_user = ""
 
     async def _safe_send(self, msg: str) -> None:
         ws = self._ws

--- a/robot/reachy_mini_mirrorbuddy/rt_events.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_events.py
@@ -94,7 +94,10 @@ class RealtimeEventsMixin:
             if not text:
                 return
             action = session_flow.decide(text, self._asleep)
-            if self._stopped_on_partial and action not in (session_flow.END, session_flow.REST):
+            # The wake word is never swallowed: being called by name outranks any
+            # hush already applied for this turn.
+            _still_matters = (session_flow.END, session_flow.REST, session_flow.WAKE)
+            if self._stopped_on_partial and action not in _still_matters:
                 return  # already hushed while the student was still speaking
             if action == session_flow.IGNORE:
                 return
@@ -126,14 +129,18 @@ class RealtimeEventsMixin:
 
         # Barge-in: cancel the turn, drop in-flight audio; each new turn starts un-muted.
         if etype == "input_audio_buffer.speech_started":
+            # Clear the per-turn hush flags first, asleep or not: they used to
+            # survive a rest, and the next transcript — even "Buddy" — was then
+            # dropped before the wake word was ever read. The robot could only be
+            # revived by restarting the app.
+            self._partial_user = ""
+            self._stopped_on_partial = False
             if self._asleep:
                 return  # ignore ambient speech while asleep; wake word handles it
             self._suppress = True
             self._quiet = False
             self._speech_started_at = time.monotonic()
             self._fast_requested = False
-            self._partial_user = ""
-            self._stopped_on_partial = False
             if self._responding:
                 await self._cancel_response()
             if self.on_speech_started:

--- a/robot/reachy_mini_mirrorbuddy/rt_events.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_events.py
@@ -94,10 +94,16 @@ class RealtimeEventsMixin:
             if not text:
                 return
             action = session_flow.decide(text, self._asleep)
+            # The hush belongs to the turn that triggered it. Deployments that emit
+            # partials but no speech_started have nothing else to clear it, and a
+            # flag that outlives its turn silences every turn after it.
+            hushed, self._stopped_on_partial, self._partial_user = (
+                self._stopped_on_partial, False, "",
+            )
             # The wake word is never swallowed: being called by name outranks any
             # hush already applied for this turn.
             _still_matters = (session_flow.END, session_flow.REST, session_flow.WAKE)
-            if self._stopped_on_partial and action not in _still_matters:
+            if hushed and action not in _still_matters:
                 return  # already hushed while the student was still speaking
             if action == session_flow.IGNORE:
                 return

--- a/robot/reachy_mini_mirrorbuddy/rt_events.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_events.py
@@ -78,14 +78,14 @@ class RealtimeEventsMixin:
 
         # "Zitto" cannot wait for the full transcription pass. A child who asks for
         # silence and is answered anyway is a child being talked over, so the partial
-        # transcript is read as it streams and the stop fires on the first words.
+        # transcript is read as it streams and the hush fires on the first words.
         if etype.endswith("input_audio_transcription.delta"):
             if self._asleep or self._stopped_on_partial:
                 return
             self._partial_user += event.get("delta") or ""
             if rt_messages.is_stop(self._partial_user):
                 self._stopped_on_partial = True
-                await self._apply_stop()
+                await self._apply_stop(rest=rt_messages.is_rest(self._partial_user))
             return
 
         # Student's speech transcribed: honour stop / end / wake intents deterministically.
@@ -93,9 +93,9 @@ class RealtimeEventsMixin:
             text = (event.get("transcript") or "").strip()
             if not text:
                 return
-            if self._stopped_on_partial:
-                return  # already silenced while the student was still speaking
             action = session_flow.decide(text, self._asleep)
+            if self._stopped_on_partial and action not in (session_flow.END, session_flow.REST):
+                return  # already hushed while the student was still speaking
             if action == session_flow.IGNORE:
                 return
             if action == session_flow.WAKE:
@@ -106,15 +106,18 @@ class RealtimeEventsMixin:
                 return
             if action == session_flow.END:
                 self._pending_farewell = True
-                self._suppress = False
+                self._suppress = self._quiet = False
                 if self._responding or self._fast_requested:
                     await self._cancel_response()
                 await self._request_response(rt_messages.FAREWELL_INSTR)
                 return
-            if action == session_flow.STOP:
-                await self._apply_stop()
+            if action in (session_flow.REST, session_flow.PAUSE):
+                await self._apply_stop(rest=action == session_flow.REST)
                 return
             if action == session_flow.SPEAK:
+                # A pause lifts on the next thing the student says, even where the
+                # deployment never emits speech_started to clear the flag for us.
+                self._quiet = False
                 # Ordinary turn. If the fast path already asked for the response when
                 # speech ended, asking again would make Buddy answer twice.
                 if not self._fast_requested:
@@ -210,20 +213,26 @@ class RealtimeEventsMixin:
         self._responding = False
         await self._safe_send(rt_messages.CANCEL)
 
-    async def _apply_stop(self) -> None:
-        """Go silent now and stay silent until called back by name.
+    async def _apply_stop(self, rest: bool) -> None:
+        """Stop talking now; go to sleep only if the silence was asked for deliberately.
 
-        "basta / fermati / zitto" → quiet AND parked in a rest posture. Insistence
-        stresses the child, so a stop is a full stop, not a brief pause that resumes
-        on the next sound. It also cancels a fast-path response requested before the
-        transcript arrived: the stop word wins even when it ends a long sentence.
+        ``rest=True`` ("zitto", "dormi") parks the robot: quiet, in the rest posture,
+        and awake again only when the child calls it by name. ``rest=False``
+        ("aspetta") just drops the current sentence — the next turn is answered
+        normally, because everyday filler must not cost the wake word.
+
+        Either way the in-flight response is cancelled, including one requested by
+        the fast path before the transcript arrived: the hush wins even when it ends
+        a long sentence.
         """
-        self._asleep = True
         self._quiet = True
         self._suppress = True
         if self._responding or self._fast_requested:
             await self._cancel_response()
         if self.on_speech_started:
             _safe_cb(self.on_speech_started)  # flush local playback now
+        if not rest:
+            return
+        self._asleep = True
         if self.on_sleep:
             _safe_cb(self.on_sleep)  # settle into the rest position

--- a/robot/reachy_mini_mirrorbuddy/rt_messages.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_messages.py
@@ -15,32 +15,60 @@ SAMPLE_RATE = 24000  # PCM sample rate (in and out)
 # Pre-serialised cancel of the model's current response (used on barge-in / stop).
 CANCEL = json.dumps({"type": "response.cancel"})
 
-# Stop-intent words. When the student says any of these the robot must go silent
-# immediately, deterministically — never relying on the model to choose to yield.
-# This is an accessibility requirement: insistence stresses the student.
-_STOP_RE = re.compile(
-    r"\b(basta|ferma(?:ti|te|lo)?|zitt[oaie]|silenzio|silence|aspetta|"
-    r"pausa|stop|taci|smettila|smetti|shh+|sh+t?|"
+# Hush intents come in two tiers, because the cost of getting them wrong differs.
+#
+# REST is deliberate: "zitto", "dormi". The robot goes silent and stays asleep
+# until the child calls it by name. Honouring it instantly is an accessibility
+# requirement — insistence stresses the student.
+#
+# PAUSE is everyday filler: "aspetta", "basta", "un attimo". It stops the current
+# sentence and nothing more; the next thing the child says is answered normally.
+# These words are far too common in ordinary Italian ("aspetta che scrivo") to
+# cost the wake word — a robot that needs its name after "aspetta" reads as broken.
+_REST_RE = re.compile(
+    r"\b(zitt[oaie]|silenzio|silence|taci|smettila|smetti|shh+|sh+t?|"
     r"dormi|dormire|riposati|riposa|spegniti|mettiti\s+a\s+riposo)\b",
     re.IGNORECASE,
 )
 
+_PAUSE_RE = re.compile(
+    r"\b(basta|ferma(?:ti|te|lo)?|aspetta|attendi|pausa|stop|"
+    r"un\s+attimo|un\s+momento)\b",
+    re.IGNORECASE,
+)
+
+
+def is_rest(text: str | None) -> bool:
+    """True if the student deliberately asked for silence ('zitto', 'dormi')."""
+    return bool(text and _REST_RE.search(text))
+
+
+def is_pause(text: str | None) -> bool:
+    """True if the student asked the robot to hold on a moment ('aspetta')."""
+    return bool(text and not is_rest(text) and _PAUSE_RE.search(text))
+
 
 def is_stop(text: str | None) -> bool:
-    """True if the user utterance is a command to stop / be quiet."""
-    return bool(text and _STOP_RE.search(text))
+    """True for either tier: the robot must stop talking right now."""
+    return is_rest(text) or is_pause(text)
 
 
 # End-of-session intent: the student signals they are done for now. Unlike a stop
 # (be quiet a moment), this ends the session — the robot says a short goodbye and
 # goes to sleep until it hears its name again. Deterministic, like the stop word.
-_END_RE = re.compile(
+_DONE_RE = re.compile(
     r"\b("
     r"(?:abbiamo|ho|hai)\s+(?:finito|terminato|concluso)|"
-    r"finito\s+per\s+oggi|basta\s+(?:studiare|compiti|per\s+oggi)|"
-    r"a\s+domani|ci\s+vediamo|arrivederci|buonanotte|buona\s+notte|"
-    r"abbiamo\s+finito"
+    r"finito\s+per\s+oggi|basta\s+(?:studiare|compiti|per\s+oggi)"
     r")\b",
+    re.IGNORECASE,
+)
+
+# Farewells only end the session when they actually close the utterance: "ci
+# vediamo dopo pranzo" is a plan, not a goodbye.
+_BYE_RE = re.compile(
+    r"\b(a\s+domani|ci\s+vediamo|ci\s+sentiamo|arrivederci|"
+    r"buonanotte|buona\s+notte)\W*$",
     re.IGNORECASE,
 )
 
@@ -52,7 +80,9 @@ _WAKE_RE = re.compile(r"\bbudd?(?:y|i|ie)\b", re.IGNORECASE)
 
 def is_end(text: str | None) -> bool:
     """True if the student is ending the session ('abbiamo finito', 'a domani'...)."""
-    return bool(text and _END_RE.search(text))
+    if not text:
+        return False
+    return bool(_DONE_RE.search(text) or _BYE_RE.search(text))
 
 
 def is_wake(text: str | None) -> bool:

--- a/robot/reachy_mini_mirrorbuddy/session_flow.py
+++ b/robot/reachy_mini_mirrorbuddy/session_flow.py
@@ -13,7 +13,8 @@ from . import rt_messages
 IGNORE = "ignore"  # asleep and not addressed → do nothing
 WAKE = "wake"  # asleep + wake word → resume and greet again
 END = "end"  # "abbiamo finito" → say a short goodbye, then sleep
-STOP = "stop"  # "basta" → go silent immediately (transient)
+REST = "rest"  # "zitto" / "dormi" → silent AND asleep until called by name
+PAUSE = "pause"  # "aspetta" → stop this sentence, stay awake for the next one
 SPEAK = "speak"  # ordinary turn → let the model answer
 
 
@@ -21,13 +22,15 @@ def decide(text: str, asleep: bool) -> str:
     """Classify a final transcript into the action the client should take.
 
     Order matters: while asleep only the wake word matters; otherwise an
-    end-of-session intent takes precedence over a plain stop, which takes
-    precedence over a normal turn.
+    end-of-session intent takes precedence over a deliberate rest, which takes
+    precedence over a transient pause, which takes precedence over a normal turn.
     """
     if asleep:
         return WAKE if rt_messages.is_wake(text) else IGNORE
     if rt_messages.is_end(text):
         return END
-    if rt_messages.is_stop(text):
-        return STOP
+    if rt_messages.is_rest(text):
+        return REST
+    if rt_messages.is_pause(text):
+        return PAUSE
     return SPEAK

--- a/robot/tests/test_pause_vs_rest.py
+++ b/robot/tests/test_pause_vs_rest.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 
 import pytest
-
 from reachy_mini_mirrorbuddy import rt_messages, session_flow
 from reachy_mini_mirrorbuddy.azure_realtime import AzureRealtimeClient
 

--- a/robot/tests/test_pause_vs_rest.py
+++ b/robot/tests/test_pause_vs_rest.py
@@ -1,0 +1,153 @@
+"""A "wait a second" must not put the robot to sleep.
+
+Every hush word used to trigger the same full rest: silent AND asleep until the
+child said "Buddy" again. Everyday Italian filler — "aspetta", "basta", "ci
+vediamo dopo pranzo" — therefore looked exactly like a crash to the family.
+
+Two tiers now: a PAUSE stops the current sentence and stays awake, a REST is a
+deliberate "be quiet / go to sleep" and still needs the name to come back.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reachy_mini_mirrorbuddy import rt_messages, session_flow
+from reachy_mini_mirrorbuddy.azure_realtime import AzureRealtimeClient
+
+DELTA = "conversation.item.input_audio_transcription.delta"
+DONE = "conversation.item.input_audio_transcription.completed"
+SPEECH = "input_audio_buffer.speech_started"
+
+
+@pytest.fixture
+def client():
+    c = AzureRealtimeClient(
+        ws_url="wss://x", api_key="k", instructions="i", voice="coral",
+        turn_detection={"type": "server_vad"},
+    )
+    c.sent = []
+    c.flushed = 0
+    c.slept = 0
+
+    async def capture(msg):
+        c.sent.append(msg)
+
+    c._safe_send = capture
+    c.on_speech_started = lambda: setattr(c, "flushed", c.flushed + 1)
+    c.on_sleep = lambda: setattr(c, "slept", c.slept + 1)
+    return c
+
+
+class TestIntentTiers:
+    def test_pause_words_are_transient(self):
+        for t in ["aspetta", "aspetta un attimo", "basta", "Basta!", "fermati",
+                  "un momento", "pausa", "stop"]:
+            assert rt_messages.is_pause(t), t
+            assert not rt_messages.is_rest(t), t
+
+    def test_rest_words_are_deliberate(self):
+        for t in ["zitto", "stai zitta", "silenzio", "taci", "smettila",
+                  "dormi", "vai a dormire", "riposati", "spegniti",
+                  "mettiti a riposo"]:
+            assert rt_messages.is_rest(t), t
+            assert not rt_messages.is_pause(t), t
+
+    def test_the_tiers_are_mutually_exclusive(self):
+        # A mixed utterance is deliberate: "aspetta, dormi" is a rest, never a pause.
+        for t in ["aspetta, dormi", "basta, stai zitto", "fermati e riposati"]:
+            assert rt_messages.is_rest(t), t
+            assert not rt_messages.is_pause(t), t
+
+    def test_is_stop_still_covers_both(self):
+        # The streaming fast path uses is_stop() to hush without waiting.
+        assert rt_messages.is_stop("aspetta") and rt_messages.is_stop("zitto")
+        assert not rt_messages.is_stop("spiegami le frazioni")
+
+    def test_ordinary_speech_is_neither(self):
+        for t in ["ciao", "parliamo di storia", "", None]:
+            assert not rt_messages.is_pause(t), t
+            assert not rt_messages.is_rest(t), t
+
+
+class TestEverydayItalianDoesNotEndTheSession:
+    def test_a_farewell_mid_sentence_is_not_goodbye(self):
+        for t in ["ci vediamo dopo pranzo", "ci vediamo domani ma prima finiamo",
+                  "arrivederci si dice così"]:
+            assert not rt_messages.is_end(t), t
+
+    def test_a_real_farewell_still_ends(self):
+        for t in ["a domani", "abbiamo finito, ci vediamo", "arrivederci!",
+                  "buonanotte", "ho finito i compiti"]:
+            assert rt_messages.is_end(t), t
+
+    def test_filler_only_pauses(self):
+        # "aspetta che scrivo" must not cost the child the wake word.
+        for t in ["aspetta che scrivo", "basta poco", "aspetta un attimo che penso"]:
+            assert session_flow.decide(t, asleep=False) == session_flow.PAUSE, t
+
+
+class TestDecideTiers:
+    def test_rest_command(self):
+        for t in ["zitto", "dormi", "mettiti a riposo"]:
+            assert session_flow.decide(t, asleep=False) == session_flow.REST, t
+
+    def test_rest_beats_pause_when_both_present(self):
+        assert session_flow.decide("aspetta, dormi", asleep=False) == session_flow.REST
+
+    def test_end_still_wins(self):
+        assert session_flow.decide("basta per oggi", asleep=False) == session_flow.END
+
+    def test_asleep_only_the_name_wakes(self):
+        assert session_flow.decide("aspetta", asleep=True) == session_flow.IGNORE
+        assert session_flow.decide("buddy", asleep=True) == session_flow.WAKE
+
+
+@pytest.mark.asyncio
+class TestPauseKeepsTheRobotAwake:
+    async def test_pause_hushes_without_sleeping(self, client):
+        client._responding = True
+
+        await client._handle_event({"type": DELTA, "delta": "aspetta"})
+
+        assert client._quiet and client._suppress
+        assert client._asleep is False  # still there, no wake word needed
+        assert client.slept == 0  # not parked in the rest posture
+        assert client.flushed == 1  # but the current sentence stops now
+        assert rt_messages.CANCEL in client.sent
+
+    async def test_the_next_turn_is_answered_normally(self, client):
+        await client._handle_event({"type": DELTA, "delta": "aspetta"})
+
+        await client._handle_event({"type": SPEECH})
+        await client._handle_event({"type": DONE, "transcript": "quanto fa due più due"})
+
+        assert client._quiet is False
+        assert any(json.loads(m).get("type") == "response.create" for m in client.sent)
+
+    async def test_a_pause_recovers_even_without_a_speech_started_event(self, client):
+        # Some deployments never emit speech_started; a pause must still not stick.
+        await client._handle_event({"type": DONE, "transcript": "aspetta"})
+        await client._handle_event({"type": DONE, "transcript": "spiegami le frazioni"})
+
+        assert client._quiet is False
+        assert any(json.loads(m).get("type") == "response.create" for m in client.sent)
+
+    async def test_rest_still_sleeps(self, client):
+        await client._handle_event({"type": DELTA, "delta": "zitto"})
+
+        assert client._quiet and client._asleep and client.slept == 1
+
+    async def test_a_pause_can_escalate_to_rest_on_the_full_transcript(self, client):
+        await client._handle_event({"type": DELTA, "delta": "aspetta"})
+        await client._handle_event({"type": DONE, "transcript": "aspetta, dormi"})
+
+        assert client._asleep is True and client.slept == 1
+
+    async def test_a_pause_can_escalate_to_a_goodbye(self, client):
+        await client._handle_event({"type": DELTA, "delta": "aspetta"})
+        await client._handle_event({"type": DONE, "transcript": "aspetta, abbiamo finito"})
+
+        assert client._pending_farewell is True

--- a/robot/tests/test_pause_vs_rest.py
+++ b/robot/tests/test_pause_vs_rest.py
@@ -150,3 +150,40 @@ class TestPauseKeepsTheRobotAwake:
         await client._handle_event({"type": DONE, "transcript": "aspetta, abbiamo finito"})
 
         assert client._pending_farewell is True
+
+
+@pytest.mark.asyncio
+class TestTheWakeWordAlwaysGetsThrough:
+    """After "zitto" the robot could never be woken again — the real freeze.
+
+    The hush fires on the streaming partial and raises a per-turn flag. That flag
+    was only cleared when speech started again, and that path returns early while
+    asleep — so the flag stayed raised for ever and the next transcript, even
+    "Buddy", hit a `return` before the wake word was ever considered. The only
+    cure was restarting the app.
+    """
+
+    async def test_buddy_wakes_a_robot_hushed_on_a_partial(self, client):
+        await client._handle_event({"type": DELTA, "delta": "zitto"})
+        assert client._asleep is True
+
+        await client._handle_event({"type": SPEECH})
+        await client._handle_event({"type": DONE, "transcript": "Buddy"})
+
+        assert client._asleep is False
+        assert any(json.loads(m).get("type") == "response.create" for m in client.sent)
+
+    async def test_buddy_wakes_it_even_without_a_speech_started_event(self, client):
+        await client._handle_event({"type": DELTA, "delta": "zitto"})
+
+        await client._handle_event({"type": DONE, "transcript": "ehi Buddy ci sei?"})
+
+        assert client._asleep is False
+
+    async def test_the_turn_flag_is_cleared_while_asleep(self, client):
+        await client._handle_event({"type": DELTA, "delta": "zitto"})
+
+        await client._handle_event({"type": SPEECH})
+
+        assert client._stopped_on_partial is False
+        assert client._partial_user == ""

--- a/robot/tests/test_pause_vs_rest.py
+++ b/robot/tests/test_pause_vs_rest.py
@@ -187,3 +187,36 @@ class TestTheWakeWordAlwaysGetsThrough:
 
         assert client._stopped_on_partial is False
         assert client._partial_user == ""
+
+
+@pytest.mark.asyncio
+class TestAPauseIsConsumedByItsOwnTurn:
+    """Without speech_started events the hush flag had nothing to clear it.
+
+    A partial "aspetta" raised the per-turn flag; the completed transcript for
+    that same turn hit the "already hushed" guard and returned with the flag
+    still raised. Every later turn then hit the same guard before the SPEAK
+    branch could unmute — Buddy stayed silent for the rest of the session.
+    """
+
+    async def test_the_next_turn_is_answered_without_a_speech_started_event(self, client):
+        await client._handle_event({"type": DELTA, "delta": "aspetta"})
+        await client._handle_event({"type": DONE, "transcript": "aspetta"})
+
+        await client._handle_event({"type": DONE, "transcript": "quanto fa due più due"})
+
+        assert client._quiet is False
+        assert any(json.loads(m).get("type") == "response.create" for m in client.sent)
+
+    async def test_the_flag_does_not_outlive_its_turn(self, client):
+        await client._handle_event({"type": DELTA, "delta": "aspetta"})
+        await client._handle_event({"type": DONE, "transcript": "aspetta un attimo"})
+
+        assert client._stopped_on_partial is False
+        assert client._partial_user == ""
+
+    async def test_the_hush_is_still_applied_only_once(self, client):
+        await client._handle_event({"type": DELTA, "delta": "zitto"})
+        await client._handle_event({"type": DONE, "transcript": "zitto per favore"})
+
+        assert client.slept == 1  # not re-parked by the late transcript

--- a/robot/tests/test_session_flow.py
+++ b/robot/tests/test_session_flow.py
@@ -63,12 +63,13 @@ class TestDecide:
         assert session_flow.decide("abbiamo finito, a domani", asleep=False) == session_flow.END
 
     def test_awake_stop(self):
-        assert session_flow.decide("basta", asleep=False) == session_flow.STOP
+        # "basta" is everyday filler: hush this sentence, stay awake.
+        assert session_flow.decide("basta", asleep=False) == session_flow.PAUSE
 
-    def test_awake_sleep_command_is_stop(self):
+    def test_awake_sleep_command_is_rest(self):
         # "dormi" is a sleep command: rest immediately, no reply, wake only on "buddy".
         for t in ["dormi", "vai a dormire", "mettiti a riposo", "riposati"]:
-            assert session_flow.decide(t, asleep=False) == session_flow.STOP, t
+            assert session_flow.decide(t, asleep=False) == session_flow.REST, t
 
     def test_asleep_stays_asleep_on_sleep_command(self):
         assert session_flow.decide("dormi", asleep=True) == session_flow.IGNORE

--- a/robot/tests/test_session_resume.py
+++ b/robot/tests/test_session_resume.py
@@ -1,0 +1,160 @@
+"""A 60-minute Azure session cap must not kill the app.
+
+Azure Realtime hard-closes any session at 60 minutes ("session_expired"). The
+client thread then ended, `main` stopped waiting and the whole app exited — the
+robot went permanently deaf, and not even the wake word could bring it back
+because nothing was listening. The session loop now reconnects on its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reachy_mini_mirrorbuddy.azure_realtime import AzureRealtimeClient
+
+
+def make_client(**kw):
+    return AzureRealtimeClient(
+        ws_url="wss://x", api_key="k", instructions="i", voice="coral",
+        turn_detection={"type": "server_vad"}, **kw,
+    )
+
+
+@pytest.fixture
+def client(monkeypatch):
+    c = make_client()
+    c.connects = 0
+    c.slept = []
+
+    async def no_sleep(d):
+        c.slept.append(d)
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+    return c
+
+
+@pytest.mark.asyncio
+class TestSessionLoopSurvives:
+    async def test_a_clean_expiry_reconnects(self, client):
+        async def connect():
+            client.connects += 1
+            if client.connects >= 3:
+                client._stop.set()  # third session: shut down for the test
+
+        client._connect_and_listen = connect
+
+        await client._session_loop()
+
+        assert client.connects == 3  # expiry is not the end of the app
+
+    async def test_a_network_error_reconnects_with_backoff(self, client):
+        async def connect():
+            client.connects += 1
+            if client.connects >= 4:
+                client._stop.set()
+            raise OSError("connection refused")
+
+        client._connect_and_listen = connect
+
+        await client._session_loop()
+
+        assert client.connects == 4
+        assert client.slept == sorted(client.slept)  # backs off, never hammers Azure
+        assert client.slept[-1] > client.slept[0]  # and the wait really grows
+        assert max(client.slept) <= 30.0  # but always comes back within half a minute
+
+    async def test_a_deliberate_stop_does_not_wait(self, client):
+        # Shutting the app down must be immediate, not "after the backoff".
+        async def connect():
+            client.connects += 1
+            if client.connects >= 3:
+                client._stop.set()
+
+        client._connect_and_listen = connect
+
+        await client._session_loop()
+
+        assert len(client.slept) == 2  # two reconnects, no wait after the stop
+
+    async def test_every_session_starts_from_a_clean_slate(self, client):
+        # The expired session died mid-sentence with audio suppressed; the new
+        # one must not inherit that or it comes back mute.
+        seen = []
+
+        async def connect():
+            client.connects += 1
+            seen.append(client._suppress)
+            client._suppress = True
+            client._responding = True
+            if client.connects >= 2:
+                client._stop.set()
+
+        client._connect_and_listen = connect
+
+        await client._session_loop()
+
+        assert seen == [False, False]
+
+    async def test_stop_ends_the_loop(self, client):
+        client._stop.set()
+
+        async def connect():
+            client.connects += 1
+
+        client._connect_and_listen = connect
+
+        await client._session_loop()
+
+        assert client.connects == 0  # a deliberate shutdown stays shut down
+
+    async def test_an_instant_close_is_also_backed_off(self, client):
+        # A session that dies on arrival must not become a reconnect storm.
+        async def connect():
+            client.connects += 1
+            if client.connects >= 3:
+                client._stop.set()
+
+        client._connect_and_listen = connect
+
+        await client._session_loop()
+
+        assert client.slept and client.slept[0] >= 1.0
+
+
+@pytest.mark.asyncio
+class TestResumeIsSilentAndFaithful:
+    async def test_the_new_session_does_not_greet_again(self, client):
+        sent = []
+        client._safe_send = lambda m: sent.append(m) or asyncio.sleep(0)
+        client._ready.set()  # already greeted in the session that just expired
+
+        await client._handle_event({"type": "session.created"})
+
+        assert sent == []  # the child is mid-homework: resume, don't re-introduce
+
+    async def test_a_resumed_session_starts_unmuted(self, client):
+        # The session died while Buddy was mid-sentence: the leftover suppression
+        # would silence the whole next session.
+        client._suppress = True
+        client._responding = True
+        client._fast_requested = True
+        client._stopped_on_partial = True
+        client._partial_user = "half a sentence"
+
+        client._reset_session_state()
+
+        assert not client._suppress and not client._responding
+        assert not client._fast_requested and not client._stopped_on_partial
+        assert client._partial_user == ""
+
+    async def test_a_resumed_session_keeps_the_child_at_rest(self, client):
+        # "Zitto" survives a reconnect: coming back talking would be the exact
+        # insistence the rest posture exists to prevent.
+        client._asleep = True
+        client._quiet = True
+
+        client._reset_session_state()
+
+        assert client._asleep and client._quiet

--- a/robot/tests/test_session_resume.py
+++ b/robot/tests/test_session_resume.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-
 from reachy_mini_mirrorbuddy.azure_realtime import AzureRealtimeClient
 
 

--- a/robot/tests/test_stop_word.py
+++ b/robot/tests/test_stop_word.py
@@ -84,7 +84,7 @@ async def test_a_new_turn_can_be_stopped_again(client):
     await client._handle_event({"type": DELTA, "delta": "zitto"})
     client._asleep = False  # woken by name
     await client._handle_event({"type": "input_audio_buffer.speech_started"})
-    await client._handle_event({"type": DELTA, "delta": "basta"})
+    await client._handle_event({"type": DELTA, "delta": "zitta"})
 
     assert client._quiet is True and client.slept == 2
 
@@ -92,7 +92,7 @@ async def test_a_new_turn_can_be_stopped_again(client):
 @pytest.mark.asyncio
 async def test_stop_still_works_from_the_final_transcript(client):
     """Deployments without partial transcription must keep the old guarantee."""
-    await client._handle_event({"type": DONE, "transcript": "basta"})
+    await client._handle_event({"type": DONE, "transcript": "zitto"})
 
     assert client._quiet and client._asleep
     assert client.slept == 1


### PR DESCRIPTION
## Perché

«Il robot si blocca ogni tanto» / «non dà segni di vita» erano **due bug diversi**, entrambi trovati con evidenza sul dispositivo.

### 1. Ogni parola di silenzio lo addormentava

Una sola risposta per qualunque parola di silenzio: muto **e** addormentato finché il bambino non ridiceva «Buddy». Ma *aspetta* e *basta* sono riempitivi di italiano quotidiano («aspetta che scrivo»), e l'intento di chiusura scattava su «ci vediamo **dopo pranzo**».

### 2. La sessione Azure muore a 60 minuti e l'app usciva

Dal journal del robot, alle 10:51:42:

```
ERROR rt_events | Azure Realtime error: {"code": "session_expired",
  "message": "Your session hit the maximum duration of 60 minutes."}
INFO azure_realtime | WebSocket closed
INFO audio_io | Microphone loop stopped
INFO App reachy_mini_mirrorbuddy finished
```

Il thread del client finiva, `main` smetteva di aspettare e **l'app usciva**. Da lì il robot è sordo: nemmeno la wake word arriva, perché non ascolta più nessuno. Serve un riavvio manuale. Questo è il "non dà segni di vita".

## Cosa cambia

**Due livelli di silenzio**, perché il costo dell'errore è diverso:

| Livello | Parole | Effetto |
| --- | --- | --- |
| **PAUSE** | aspetta, basta, fermati, un attimo, pausa, stop | ferma la frase in corso, **resta sveglio**: il turno dopo è risposto normalmente |
| **REST** | zitto, silenzio, taci, dormi, riposati, spegniti | invariato: muto, posizione di riposo, torna **solo** col nome |

I saluti chiudono la sessione solo se **terminano** la frase.

**Sessione che si riconnette**: un socket chiuso è una riconnessione, non un'uscita. Ritorno entro un secondo, backoff esponenziale (max 30s) se Azure è davvero irraggiungibile, e solo `stop()` ferma davvero. La sessione ripresa è **silenziosa** (niente secondo saluto in mezzo ai compiti) e lo stato di sessione (risposta in volo, audio soppresso) viene azzerato, così la nuova sessione non nasce muta. Ciò che ha chiesto il bambino sopravvive: dopo «zitto» torna **ancora a riposo**.

## Cosa NON cambia (accessibilità)

Entrambi i livelli scattano ancora sul **transcript parziale** in streaming, cancellano il turno in volo e svuotano l'audio locale, senza mai chiedere al modello di cedere. Un bambino può sempre fermare il robot all'istante.

## Verifica

- `220 passed, 1 skipped` (suite robot, venv con numpy/scipy)
- **12 mutazioni** introdotte apposta, **12 catturate** — 4 hanno scoperto buchi reali nei miei stessi test (backoff costante, stop ignorato, reset di sessione mancante), chiusi aggiungendo asserzioni
- ruff: 110 findings sul branch = 110 su `main` — nessun debito nuovo
- README + ADR 0170 aggiornati
