### PR TITLE
chore(graphify): exclude pure-data JSON from graph, ignore graphify-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ kanban/todo/
 kanban/doing/
 kanban/done/
 handoff/latest.md
+
+# graphify knowledge graph output (regenerable, ~30k nodes)
+graphify-out/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,36 @@
+# graphify — pure-data JSON excluded from the knowledge graph.
+# These files parse fine but contain no code symbols, so they contribute
+# zero nodes and only produce "produced zero nodes" warnings (#1666).
+# package.json / tsconfig.json / turbo.json are deliberately NOT listed:
+# they do produce nodes and carry the dependency graph.
+
+# i18n message catalogs — translation data
+apps/web/messages/**/*.json
+apps/web/src/i18n/messages/*.json
+
+# focus-group stimulus payloads — generated text/tts data
+# (manifest.json in the same dirs DOES produce nodes: not excluded)
+docs/focus-group/**/s*.json
+
+# Grafana / monitoring dashboard definitions
+grafana/**/*.json
+docs/grafana/*.json
+monitoring/**/*.json
+apps/web/src/lib/observability/grafana-dashboards/*.json
+
+# editor, tooling and generated reports
+.copilot/*.json
+.cursor/mcp.local.example.json
+.openclaude/*.json
+.vscode/*.json
+.lighthouseci/*.json
+.file-line-limit.json
+.lintstagedrc.json
+apps/web/e2e/.auth/*.json
+
+# iOS asset catalog metadata
+ios/**/Contents.json
+
+# baseline snapshots
+scripts/azure-models-baseline.json
+scripts/vercel-baseline-snapshot.json


### PR DESCRIPTION
## What

Two config-only changes to clean up graphify knowledge-graph extraction:

1. **`.graphifyignore`** — excludes 199 data-only JSON files (i18n message catalogs, focus-group stimulus payloads, Grafana dashboards, editor config, iOS asset catalogs). They parse fine but contribute **zero nodes**, producing a noisy warning on every extraction run.
2. **`.gitignore`** — adds `graphify-out/`, which was untracked *and* unignored (a regenerable ~30k-node graph + HTML + backups, one `git add .` away from being committed).

## Why the rules are narrow

A blanket `*.json` exclude would have cost real signal. Kept in the corpus on purpose:

- `package.json` / `tsconfig.json` / `turbo.json` — they carry the dependency graph (376 nodes from `package.json` alone)
- `docs/focus-group/**/manifest.json` — excluded only `s*.json` stimulus payloads
- `.cursor/mcp.json` — excluded only `mcp.local.example.json`

A first draft of the rules wrongly caught those 10 files; caught by diffing the exclusion set against nodes actually present in `graph.json`, then narrowed.

## Verification

Ran `graphify.detect` with and without the file and diffed against `graphify-out/graph.json`:

```
excluded: 199
false positives (produce nodes): 0
empty files still NOT excluded: 0
```

No source code, tests, CI or runtime behaviour touched.