### PR TITLE
fix(robot): rest must never be a room without a door

### DIFF
--- a/robot/reachy_mini_mirrorbuddy/azure_realtime.py
+++ b/robot/reachy_mini_mirrorbuddy/azure_realtime.py
@@ -80,7 +80,8 @@ class AzureRealtimeClient(RealtimeEventsMixin):
         self._quiet = False  # student asked for silence: keep model muted
         self._speech_started_at = 0.0  # monotonic time the student began this turn
         self._fast_requested = False  # response already asked for before the transcript
-        self._asleep = False  # session ended: stay muted until the wake word
+        self._asleep_flag = False  # session ended: stay muted until the wake word
+        self._asleep_since = 0.0  # monotonic time the rest began, for the timeout
         self._sleep_after = False  # go to sleep once the farewell response finishes
         self._pending_farewell = False  # a goodbye was requested; sleep when it starts→done
         self._partial_user = ""  # transcript of the turn being spoken, read for stop words
@@ -130,6 +131,35 @@ class AzureRealtimeClient(RealtimeEventsMixin):
         if self._asleep or self._quiet or self._responding:
             return
         self._enqueue(json.dumps(rt_messages.response_create(instructions)))
+
+    @property
+    def _asleep(self) -> bool:
+        return self._asleep_flag
+
+    @_asleep.setter
+    def _asleep(self, value: bool) -> None:
+        """Falling asleep always stamps the clock.
+
+        The rest timeout is the safety net for a wake word that never lands, so it
+        must not depend on every future caller remembering to set the timestamp:
+        an unstamped rest would either never expire or expire instantly.
+        """
+        if value and not self._asleep_flag:
+            self._asleep_since = time.monotonic()
+        self._asleep_flag = bool(value)
+
+    def resume_silently(self) -> None:
+        """Lift a rest without saying anything (thread-safe).
+
+        Used when the world says the student is back — a face at the desk again —
+        which is a reason to start listening properly, not a reason to talk. The
+        robot simply becomes answerable again on the next question.
+        """
+        if not self._asleep:
+            return
+        self._asleep = False
+        self._quiet = False
+        logger.info("Rest lifted: the student is back at the desk")
 
     def local_barge_in(self) -> None:
         """On-device barge-in (called from the mic thread when a real voice is heard

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -133,6 +133,11 @@ class Controller(ToolCallMixin):
         self.movements.set_emotion("happy")
         if client is None:
             return
+        if client._asleep:
+            # He is back at the desk, so the robot listens again — but he asked for
+            # quiet, so it does not celebrate its own return.
+            client.resume_silently()
+            return
         if event == presence.ARRIVED:
             client.speak_now(
                 "Lo studente si e' appena seduto davanti a te: salutalo brevemente "

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -135,8 +135,14 @@ class Controller(ToolCallMixin):
             return
         if client._asleep:
             # He is back at the desk, so the robot listens again — but he asked for
-            # quiet, so it does not celebrate its own return.
+            # quiet, so it does not celebrate its own return. The body has to come
+            # back too: rest parked it with hold_still(), and a robot that answers
+            # without ever moving again reads as broken.
             client.resume_silently()
+            try:
+                self.movements.release_hold()
+            except Exception as e:  # pragma: no cover - runtime robustness
+                logger.debug("releasing the rest hold failed: %s", e)
             return
         if event == presence.ARRIVED:
             client.speak_now(

--- a/robot/reachy_mini_mirrorbuddy/rt_events.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_events.py
@@ -272,6 +272,10 @@ class RealtimeEventsMixin:
         self._suppress = True
         if self._responding or self._fast_requested:
             await self._cancel_response()
+        # The fast path belongs to the turn that was just cancelled. Left standing,
+        # it makes the *next* turn think its answer was already requested — so the
+        # first thing said after waking up is answered by silence.
+        self._fast_requested = False
         if self.on_speech_started:
             _safe_cb(self.on_speech_started)  # flush local playback now
         if not rest:

--- a/robot/reachy_mini_mirrorbuddy/rt_events.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_events.py
@@ -26,6 +26,11 @@ logger = logging.getLogger(__name__)
 # moment later and cancels the response in flight.
 _FAST_PATH_MIN_SPEECH_S = 1.8
 
+# How long a deliberate rest lasts before ordinary conversation resumes. Long
+# enough to be a real silence, short enough that a forgotten wake word costs a
+# coffee break and not an adult with an SSH session.
+_REST_MAX_S = 600.0
+
 
 def _safe_cb(cb: Callable, *args) -> None:
     try:
@@ -93,7 +98,13 @@ class RealtimeEventsMixin:
             text = (event.get("transcript") or "").strip()
             if not text:
                 return
-            action = session_flow.decide(text, self._asleep)
+            action = session_flow.decide(text, self._asleep, self._rest_expired())
+            if self._asleep:
+                # The single most useful line in the journal: it says what the robot
+                # actually heard while it was silent, and what it made of it.
+                logger.info("Resting — heard %r → %s", text, action)
+                if action != session_flow.IGNORE:
+                    self._asleep = False
             # The hush belongs to the turn that triggered it. Deployments that emit
             # partials but no speech_started have nothing else to clear it, and a
             # flag that outlives its turn silences every turn after it.
@@ -121,6 +132,7 @@ class RealtimeEventsMixin:
                 await self._request_response(rt_messages.FAREWELL_INSTR)
                 return
             if action in (session_flow.REST, session_flow.PAUSE):
+                logger.info("%s requested by %r", action.upper(), text)
                 await self._apply_stop(rest=action == session_flow.REST)
                 return
             if action == session_flow.SPEAK:
@@ -211,10 +223,28 @@ class RealtimeEventsMixin:
                 self._responding = False
                 logger.debug("Cancel arrived after the response ended (harmless)")
                 return
+            if isinstance(err, dict) and err.get("code") == "conversation_already_has_active_response":
+                # The server is still streaming a response we thought was over.
+                # Believe it and wait for its response.done, rather than firing
+                # requests it will keep rejecting while the child hears nothing.
+                self._responding = True
+                logger.info("Server still has a response in flight; waiting for it")
+                return
             logger.error("Azure Realtime error event: %s", json.dumps(err))
             return
 
         logger.debug("Unhandled event: %s", etype)
+
+    def _rest_expired(self) -> bool:
+        """True when the robot has been resting longer than the silence was worth.
+
+        A rest is a request for quiet, not a lock. Past the timeout the next thing
+        the student says is answered normally — no child should have to remember a
+        magic word to get his robot back.
+        """
+        if not self._asleep:
+            return False
+        return (time.monotonic() - self._asleep_since) > _REST_MAX_S
 
     async def _cancel_response(self) -> None:
         """Cancel the response in flight and forget it.

--- a/robot/reachy_mini_mirrorbuddy/rt_messages.py
+++ b/robot/reachy_mini_mirrorbuddy/rt_messages.py
@@ -72,10 +72,20 @@ _BYE_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Wake intent: while asleep, ONLY the robot's name "Buddy" brings it back — so a
-# stop/rest really lasts until the child deliberately calls it again. A few ASR
-# spellings of the name are accepted (whisper sometimes drops a letter).
-_WAKE_RE = re.compile(r"\bbudd?(?:y|i|ie)\b", re.IGNORECASE)
+# Wake intent. Being generous here costs nothing: the pattern is only consulted
+# while the robot is already resting, where the worst case is answering a child
+# who wanted silence — against a child locked out of his robot altogether.
+# An Italian "Buddy" comes back from Whisper as badi, bady, baddy, boddy, buddi...
+_WAKE_RE = re.compile(r"\bb[uoae]dd?(?:y|i|ie)\b", re.IGNORECASE)
+
+# The name is not the only way back. A child who has forgotten the magic word
+# still says the obvious thing — "puoi parlare?", "ci sei?" — and that has to work.
+_RESUME_RE = re.compile(
+    r"\b(sveglia(?:ti)?|riprendi|ricominciamo|torna|ritorna|"
+    r"puoi\s+(?:parlare|rispondere|tornare)|parla\s+(?:pure|di\s+nuovo)|"
+    r"ci\s+sei|mi\s+senti|rispondimi)\b",
+    re.IGNORECASE,
+)
 
 
 def is_end(text: str | None) -> bool:
@@ -88,6 +98,11 @@ def is_end(text: str | None) -> bool:
 def is_wake(text: str | None) -> bool:
     """True if the student is calling the robot back from sleep."""
     return bool(text and _WAKE_RE.search(text))
+
+
+def is_resume(text: str | None) -> bool:
+    """True if the student asked the robot to speak again without using its name."""
+    return bool(text and _RESUME_RE.search(text))
 
 
 # Spoken cues driven by the model on session end / wake (kept here so the client

--- a/robot/reachy_mini_mirrorbuddy/session_flow.py
+++ b/robot/reachy_mini_mirrorbuddy/session_flow.py
@@ -18,15 +18,19 @@ PAUSE = "pause"  # "aspetta" → stop this sentence, stay awake for the next one
 SPEAK = "speak"  # ordinary turn → let the model answer
 
 
-def decide(text: str, asleep: bool) -> str:
+def decide(text: str, asleep: bool, rest_expired: bool = False) -> str:
     """Classify a final transcript into the action the client should take.
 
-    Order matters: while asleep only the wake word matters; otherwise an
+    Order matters: while asleep only a call for the robot matters; otherwise an
     end-of-session intent takes precedence over a deliberate rest, which takes
     precedence over a transient pause, which takes precedence over a normal turn.
+
+    ``rest_expired`` means the robot has been resting long enough that the silence
+    has served its purpose. It then classifies the turn as if it were awake, so a
+    forgotten wake word can never strand the student.
     """
-    if asleep:
-        return WAKE if rt_messages.is_wake(text) else IGNORE
+    if asleep and not rest_expired:
+        return WAKE if rt_messages.is_wake(text) or rt_messages.is_resume(text) else IGNORE
     if rt_messages.is_end(text):
         return END
     if rt_messages.is_rest(text):

--- a/robot/tests/test_no_absorbing_rest.py
+++ b/robot/tests/test_no_absorbing_rest.py
@@ -139,3 +139,20 @@ class TestSilentResumeIsNotAWakeGreeting:
         await client._handle_event(_said("Buddy"))
         assert client.woke == 1
         assert any(json.loads(m).get("type") == "response.create" for m in client.sent)
+
+
+class TestTheDoorIsNotJammedByTheLastTurn:
+    @pytest.mark.asyncio
+    async def test_a_hush_mid_sentence_does_not_mute_the_turn_after_the_rest(self, client):
+        # The child interrupted a long answer with "zitto": the fast path had
+        # already asked for that response, and that stale flag used to survive the
+        # rest — so the first sentence after waking up was silently dropped.
+        client._fast_requested = True
+        client._responding = True
+        await client._handle_event(_said("zitto"))
+        assert client._asleep is True
+
+        client._asleep_since = 0.0  # ten minutes pass
+        client.sent.clear()
+        await client._handle_event(_said("come si fa questo esercizio?"))
+        assert any(json.loads(m).get("type") == "response.create" for m in client.sent)

--- a/robot/tests/test_no_absorbing_rest.py
+++ b/robot/tests/test_no_absorbing_rest.py
@@ -1,0 +1,141 @@
+"""Rest must never be a room without a door.
+
+Resting used to have exactly one exit: the word "Buddy", transcribed correctly,
+through mic → Azure → Whisper. One missed token and the child was locked out of
+his own robot until an adult restarted the app — which is what kept happening.
+
+So rest keeps listening (it always did) and now offers several cheap exits: the
+name in any of the spellings the ASR actually produces, a plain "puoi parlare",
+and a timeout, because a child cannot be asked to remember a magic word.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from reachy_mini_mirrorbuddy import rt_messages, session_flow
+from reachy_mini_mirrorbuddy.azure_realtime import AzureRealtimeClient
+
+DONE = "conversation.item.input_audio_transcription.completed"
+
+
+@pytest.fixture
+def client():
+    c = AzureRealtimeClient(
+        ws_url="wss://x", api_key="k", instructions="i", voice="coral",
+        turn_detection={"type": "server_vad"},
+    )
+    c.sent = []
+    c.woke = 0
+
+    async def capture(msg):
+        c.sent.append(msg)
+
+    c._safe_send = capture
+    c.on_wake = lambda: setattr(c, "woke", c.woke + 1)
+    return c
+
+
+def _said(text: str) -> dict:
+    return {"type": DONE, "transcript": text}
+
+
+class TestWakeWordTolerance:
+    def test_asr_spellings_of_the_name_all_wake(self):
+        # What Whisper actually returns for an Italian child saying "Buddy".
+        for heard in ["Buddy", "buddi", "budy", "Baddy", "badi", "Bady",
+                      "boddy", "Buddie", "BUDDY!", "ehi buddy?"]:
+            assert rt_messages.is_wake(heard), heard
+
+    def test_unrelated_words_do_not_wake(self):
+        for heard in ["abbiamo finito", "il budino", "va bene", "buonanotte"]:
+            assert not rt_messages.is_wake(heard), heard
+
+
+class TestResumePhrases:
+    def test_plain_requests_to_speak_again_are_wake(self):
+        for heard in ["puoi parlare", "riprendi", "svegliati", "sveglia",
+                      "ci sei?", "torna", "parla pure", "puoi rispondere"]:
+            assert rt_messages.is_resume(heard), heard
+
+    def test_ordinary_sentences_are_not_resume(self):
+        for heard in ["quanto fa sette per otto", "zitto", "aspetta un attimo"]:
+            assert not rt_messages.is_resume(heard), heard
+
+    def test_resume_phrase_wakes_a_sleeping_robot(self):
+        assert session_flow.decide("puoi parlare", asleep=True) == session_flow.WAKE
+
+
+class TestRestExpires:
+    def test_while_rest_is_fresh_an_ordinary_turn_is_ignored(self):
+        assert session_flow.decide("quanto fa due più due", asleep=True) == session_flow.IGNORE
+
+    def test_once_rest_expired_an_ordinary_turn_is_answered(self):
+        action = session_flow.decide("quanto fa due più due", asleep=True, rest_expired=True)
+        assert action == session_flow.SPEAK
+
+    def test_an_expired_rest_can_still_be_asked_for_again(self):
+        assert session_flow.decide("zitto", asleep=True, rest_expired=True) == session_flow.REST
+
+
+class TestClientRecoversFromRest:
+    @pytest.mark.asyncio
+    async def test_an_old_rest_lapses_and_the_robot_answers(self, client):
+        client._asleep = True
+        client._quiet = True
+        client._asleep_since = -10_000.0  # rested far longer than the timeout
+        await client._handle_event(_said("mi aiuti con i compiti?"))
+        assert client._asleep is False
+        assert client._quiet is False
+        assert any("response.create" in m for m in client.sent)
+
+    @pytest.mark.asyncio
+    async def test_a_recent_rest_still_holds(self, client):
+        client._asleep = True
+        await client._handle_event(_said("mi aiuti con i compiti?"))
+        assert client._asleep is True
+        assert not any("response.create" in m for m in client.sent)
+
+    @pytest.mark.asyncio
+    async def test_what_was_heard_while_asleep_is_logged(self, client, caplog):
+        client._asleep = True
+        with caplog.at_level("INFO"):
+            await client._handle_event(_said("mi aiuti con i compiti?"))
+        # Without this line no one can tell why the robot stayed silent.
+        assert "mi aiuti con i compiti?" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_words_that_caused_the_rest_are_logged(self, client, caplog):
+        with caplog.at_level("INFO"):
+            await client._handle_event(_said("zitto per favore"))
+        assert "zitto per favore" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_returning_to_the_desk_lifts_the_rest_without_a_word(self, client):
+        client._asleep = True
+        client._quiet = True
+        client.resume_silently()
+        assert client._asleep is False
+        assert client._quiet is False
+        assert client.sent == []  # a silent resume never makes the robot speak
+
+    @pytest.mark.asyncio
+    async def test_an_active_response_reported_by_the_server_is_remembered(self, client):
+        client._responding = False
+        await client._handle_event({
+            "type": "error",
+            "error": {"code": "conversation_already_has_active_response"},
+        })
+        # The server owns the truth: keep quiet until its response.done arrives,
+        # instead of hammering it with requests it will keep rejecting.
+        assert client._responding is True
+
+
+class TestSilentResumeIsNotAWakeGreeting:
+    @pytest.mark.asyncio
+    async def test_wake_word_still_greets(self, client):
+        client._asleep = True
+        await client._handle_event(_said("Buddy"))
+        assert client.woke == 1
+        assert any(json.loads(m).get("type") == "response.create" for m in client.sent)

--- a/robot/tests/test_presence.py
+++ b/robot/tests/test_presence.py
@@ -153,7 +153,17 @@ class TestComingBackToADozingRobot:
 
         c = Controller.__new__(Controller)
         c._client = FakeClient()
-        c.movements = type("M", (), {"set_emotion": lambda self, e: None})()
+        class FakeMovements:
+            released = 0
+
+            def set_emotion(self, e):
+                pass
+
+            def release_hold(self):
+                FakeMovements.released += 1
+
+        FakeMovements.released = 0
+        c.movements = FakeMovements()
         c.audio = type("A", (), {"interrupt": lambda self: None})()
         c.cfg = type("Cfg", (), {"STUDENT_NAME": "Mario"})()
         from reachy_mini_mirrorbuddy.people import Roster
@@ -182,3 +192,12 @@ class TestComingBackToADozingRobot:
         c = self._controller(asleep=False)
         c._on_presence(presence.RETURNED)
         assert len(c._client.spoken) == 1
+
+
+class TestTheBodyWakesUpToo:
+    def test_coming_back_to_the_desk_releases_the_rest_hold(self):
+        # Rest parks the body with hold_still(). A resume that only clears the
+        # software flags leaves a robot that listens, answers... and cannot move.
+        ctl = TestComingBackToADozingRobot._controller(asleep=True)
+        ctl._on_presence(presence.RETURNED)
+        assert ctl.movements.released >= 1

--- a/robot/tests/test_presence.py
+++ b/robot/tests/test_presence.py
@@ -129,3 +129,56 @@ class TestHowTheGreetingAddressesTheChild:
     def test_with_a_friend_at_the_table_nobody_is_singled_out(self):
         clause = self._clause("Mario", guests=("Giulia",))
         assert "Mario" not in clause and "Giulia" not in clause
+
+
+class TestComingBackToADozingRobot:
+    """A rest must not survive the student physically coming back to the desk."""
+
+    @staticmethod
+    def _controller(asleep: bool):
+        from reachy_mini_mirrorbuddy.controller import Controller
+
+        class FakeClient:
+            def __init__(self):
+                self.resumed = 0
+                self.spoken = []
+                self._asleep = asleep
+
+            def resume_silently(self):
+                self.resumed += 1
+                self._asleep = False
+
+            def speak_now(self, instructions):
+                self.spoken.append(instructions)
+
+        c = Controller.__new__(Controller)
+        c._client = FakeClient()
+        c.movements = type("M", (), {"set_emotion": lambda self, e: None})()
+        c.audio = type("A", (), {"interrupt": lambda self: None})()
+        c.cfg = type("Cfg", (), {"STUDENT_NAME": "Mario"})()
+        from reachy_mini_mirrorbuddy.people import Roster
+
+        c.people = Roster("Mario")
+        return c
+
+    def test_a_return_lifts_the_rest(self):
+        from reachy_mini_mirrorbuddy import presence
+
+        c = self._controller(asleep=True)
+        c._on_presence(presence.RETURNED)
+        assert c._client.resumed == 1
+
+    def test_a_rest_lifted_by_presence_stays_silent(self):
+        from reachy_mini_mirrorbuddy import presence
+
+        c = self._controller(asleep=True)
+        c._on_presence(presence.RETURNED)
+        # The child asked for quiet: give him back a listening robot, not a talking one.
+        assert c._client.spoken == []
+
+    def test_an_awake_robot_still_welcomes_him_back(self):
+        from reachy_mini_mirrorbuddy import presence
+
+        c = self._controller(asleep=False)
+        c._on_presence(presence.RETURNED)
+        assert len(c._client.spoken) == 1


### PR DESCRIPTION
## Why

The robot kept "freezing". It was never frozen: at 11:53:21 it logged
`Robot is resting. Say 'Buddy' to wake it up.` and stayed there. Rest is an
**absorbing state** — its only exit is one word that has to survive
mic → Azure → Whisper. Miss it once and a child is locked out of his own robot
until an adult SSHes in and restarts the app.

Better wake-word detection alone would not fix this: it would still be **one**
door. The fix is topological — no state without several ways out.

## What

- **Wake word tolerant to real ASR output**: `badi`, `bady`, `baddy`, `boddy`,
  `buddi`… Being generous costs nothing: the pattern is only consulted while
  already resting.
- **Plain resume phrases**: "puoi parlare", "ci sei?", "riprendi", "svegliati".
- **Rest expires after 10 minutes** — the next thing said is answered normally.
- **Coming back to the desk lifts the rest silently** — he asked for quiet, so
  he gets a listening robot, not a talking one.
- **Diagnostics**: log what is heard while resting and what caused the rest.
  The journal previously offered no way to tell why the robot went quiet.
- **`conversation_already_has_active_response`** (seen live at 11:52:46) no
  longer leaves the client fighting the server.

## Evidence

- `244 passed, 1 skipped` (robot suite, /tmp/robotvenv)
- **8 mutations introduced, 8 caught** (rest never expiring, resume ignored,
  strict regex, resume leaving it muted, presence resume talking, error
  forgotten, missing sleep timestamp, missing diagnostic log)
- Deployed to the device and verified live: app `running`, greeting at 12:17:45.
