### PR TITLE
feat(metrics): per-user Azure voice cost visibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -520,3 +520,10 @@ MATCH_PASSWORD=your-match-encryption-password
 #   # Note: Voice features require Azure OpenAI Realtime
 #
 # ============================================================================
+
+# Voice cost accounting (optional). Overrides the built-in Azure Realtime rate
+# card in USD per 1M tokens, for when Azure changes prices before we do:
+#   {"gpt-realtime":{"audioIn":32,"audioOut":64,"textIn":4,"textOut":16}}
+# Unknown models are priced at the most expensive known rate, never zero — an
+# unbilled conversation is worse than an overestimated one.
+AZURE_VOICE_RATES_JSON=

--- a/SETUP.md
+++ b/SETUP.md
@@ -312,3 +312,21 @@ CMD ["npm", "start"]
 ---
 
 **See also:** [ARCHITECTURE.md](ARCHITECTURE.md) | [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Voice costs
+
+Every voice turn is priced from the usage block Azure returns and stored per
+user. Two ways to read the same number:
+
+- **Admin console** — `/admin/voice-costs`, with a day / week / month toggle
+  and a per-user breakdown.
+- **CLI** — `npx tsx scripts/voice-costs.ts --period month` (add `--user <id>`
+  for one child, `--json` to pipe it somewhere).
+
+Rates come from a built-in card and can be overridden with
+`AZURE_VOICE_RATES_JSON` when Azure changes prices before we do. Costs are
+computed **per token**, not per minute: audio tokens cost several times what
+text tokens cost, and wall-clock minutes would charge silence like speech.
+
+Note that data starts accumulating the day this is deployed — earlier usage
+was never recorded and cannot be reconstructed.

--- a/apps/web/node_modules
+++ b/apps/web/node_modules
@@ -1,0 +1,1 @@
+../../../../apps/web/node_modules

--- a/apps/web/node_modules
+++ b/apps/web/node_modules
@@ -1,1 +1,0 @@
-../../../../apps/web/node_modules

--- a/apps/web/prisma/migrations/20260805000000_add_voice_usage_events/migration.sql
+++ b/apps/web/prisma/migrations/20260805000000_add_voice_usage_events/migration.sql
@@ -1,0 +1,30 @@
+-- Voice usage, per user: Azure bills the Realtime API by token, so cost is
+-- attributed from the usage block on each response rather than guessed from
+-- wall-clock minutes. No transcript or content is stored here.
+CREATE TABLE "voice_usage_events" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "maestroId" TEXT,
+    "model" TEXT NOT NULL,
+    "audioInputTokens" INTEGER NOT NULL DEFAULT 0,
+    "audioOutputTokens" INTEGER NOT NULL DEFAULT 0,
+    "textInputTokens" INTEGER NOT NULL DEFAULT 0,
+    "textOutputTokens" INTEGER NOT NULL DEFAULT 0,
+    "cachedInputTokens" INTEGER NOT NULL DEFAULT 0,
+    "costEur" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "periodDay" TEXT NOT NULL,
+    "periodMonth" TEXT NOT NULL,
+    "isTestData" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "voice_usage_events_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "voice_usage_events_userId_periodDay_idx" ON "voice_usage_events"("userId", "periodDay");
+CREATE INDEX "voice_usage_events_userId_periodMonth_idx" ON "voice_usage_events"("userId", "periodMonth");
+CREATE INDEX "voice_usage_events_sessionId_idx" ON "voice_usage_events"("sessionId");
+CREATE INDEX "voice_usage_events_createdAt_idx" ON "voice_usage_events"("createdAt");
+
+ALTER TABLE "voice_usage_events" ADD CONSTRAINT "voice_usage_events_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema/ab-testing.prisma
+++ b/apps/web/prisma/schema/ab-testing.prisma
@@ -24,14 +24,14 @@ model ABExperiment {
 }
 
 model ABBucketConfig {
-  id           String       @id @default(cuid())
-  experimentId String
-  experiment   ABExperiment @relation(fields: [experimentId], references: [id], onDelete: Cascade)
-  bucketLabel  String
-  percentage   Float
+  id            String       @id @default(cuid())
+  experimentId  String
+  experiment    ABExperiment @relation(fields: [experimentId], references: [id], onDelete: Cascade)
+  bucketLabel   String
+  percentage    Float
   modelProvider String
-  modelName    String
-  extraConfig  Json
+  modelName     String
+  extraConfig   Json
 
   @@index([experimentId])
 }

--- a/apps/web/prisma/schema/analytics.prisma
+++ b/apps/web/prisma/schema/analytics.prisma
@@ -47,21 +47,21 @@ model RateLimitEvent {
 }
 
 model SafetyEvent {
-  id             String    @id @default(cuid())
-  userId         String?
-  type           String
-  severity       String
-  conversationId String?
-  resolvedBy     String?
-  resolvedAt     DateTime?
-  resolution     String?
-  timestamp      DateTime  @default(now())
+  id               String    @id @default(cuid())
+  userId           String?
+  type             String
+  severity         String
+  conversationId   String?
+  resolvedBy       String?
+  resolvedAt       DateTime?
+  resolution       String?
+  timestamp        DateTime  @default(now())
   // NEW fields for crisis response protocol
-  category       String?
-  sessionId      String?
-  contentSnippet String?
-  locale         String?
-  metadata       Json?
+  category         String?
+  sessionId        String?
+  contentSnippet   String?
+  locale           String?
+  metadata         Json?
   parentNotified   Boolean   @default(false)
   parentNotifiedAt DateTime?
 
@@ -171,7 +171,7 @@ model AdminAuditLog {
   adminId String
 
   // Additional context
-  details   Json?   // JSON-serialized additional data (old/new values, etc.)
+  details   Json? // JSON-serialized additional data (old/new values, etc.)
   ipAddress String? // IP address of the admin
 
   // Timestamps

--- a/apps/web/prisma/schema/b2b.prisma
+++ b/apps/web/prisma/schema/b2b.prisma
@@ -9,7 +9,7 @@ model ContactRequest {
   type      String   @db.VarChar(50) // general, schools, enterprise
   name      String   @db.VarChar(255)
   email     String   @db.VarChar(254) // RFC 5321 max email length
-  data      Json     // Form-specific fields (schoolName, companyName, etc.)
+  data      Json // Form-specific fields (schoolName, companyName, etc.)
   status    String   @default("pending") @db.VarChar(50) // pending, contacted, converted, closed
   notes     String?  @db.VarChar(2000) // Admin notes
   createdAt DateTime @default(now())

--- a/apps/web/prisma/schema/characters.prisma
+++ b/apps/web/prisma/schema/characters.prisma
@@ -13,15 +13,15 @@ model CharacterConfig {
   id String @id @default(cuid())
 
   // Character identification
-  characterId String       @unique // Matches the character ID from data files
+  characterId String        @unique // Matches the character ID from data files
   type        CharacterType
 
   // Configuration
   isEnabled Boolean @default(true)
 
   // Optional overrides for display
-  displayNameOverride  String?
-  descriptionOverride  String?
+  displayNameOverride String?
+  descriptionOverride String?
 
   // Audit tracking
   updatedBy String

--- a/apps/web/prisma/schema/communications.prisma
+++ b/apps/web/prisma/schema/communications.prisma
@@ -31,15 +31,15 @@ enum EmailEventType {
 
 // Email template with variable substitution support
 model EmailTemplate {
-  id       String  @id @default(cuid())
-  name     String  @unique
+  id       String @id @default(cuid())
+  name     String @unique
   subject  String
   htmlBody String
   textBody String
   category String
 
   // JSON array of variable names used in template (e.g., ["firstName", "unsubscribeUrl"])
-  variables Json    @default("[]")
+  variables Json @default("[]")
 
   isActive Boolean @default(true)
 
@@ -55,13 +55,13 @@ model EmailTemplate {
 
 // Email campaign management
 model EmailCampaign {
-  id         String               @id @default(cuid())
+  id         String        @id @default(cuid())
   name       String
   templateId String
-  template   EmailTemplate        @relation(fields: [templateId], references: [id], onDelete: Restrict)
+  template   EmailTemplate @relation(fields: [templateId], references: [id], onDelete: Restrict)
 
   // JSON filter criteria for recipient selection (e.g., {"tier": "pro", "locale": "it"})
-  filters Json                  @default("{}")
+  filters Json @default("{}")
 
   status      EmailCampaignStatus @default(DRAFT)
   sentCount   Int                 @default(0)
@@ -82,9 +82,9 @@ model EmailCampaign {
 
 // Individual email recipient tracking
 model EmailRecipient {
-  id         String               @id @default(cuid())
+  id         String        @id @default(cuid())
   campaignId String
-  campaign   EmailCampaign        @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  campaign   EmailCampaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
 
   userId String?
   email  String
@@ -119,7 +119,7 @@ model EmailPreference {
   announcements         Boolean @default(true)
 
   // Secure unsubscribe token
-  unsubscribeToken String   @unique @default(cuid())
+  unsubscribeToken String @unique @default(cuid())
 
   consentedAt DateTime @default(now())
   updatedAt   DateTime @updatedAt

--- a/apps/web/prisma/schema/education.prisma
+++ b/apps/web/prisma/schema/education.prisma
@@ -192,3 +192,41 @@ model MethodProgress {
   @@index([userId])
   @@index([autonomyScore])
 }
+
+// ============================================================================
+// VOICE USAGE — what a spoken minute actually costs, per user
+// Azure bills the Realtime API by token, and audio tokens cost very differently
+// from text ones. One row per model turn, so cost can be attributed to a user,
+// a maestro and a day without ever storing what was said.
+// ============================================================================
+
+model VoiceUsageEvent {
+  id        String  @id @default(cuid())
+  userId    String
+  user      User    @relation("VoiceUsageEvents", fields: [userId], references: [id], onDelete: Cascade)
+  sessionId String
+  maestroId String?
+  model     String
+
+  audioInputTokens  Int @default(0)
+  audioOutputTokens Int @default(0)
+  textInputTokens   Int @default(0)
+  textOutputTokens  Int @default(0)
+  cachedInputTokens Int @default(0)
+
+  costEur Float @default(0)
+
+  // Pre-computed buckets: the admin console and the CLI both group by these,
+  // and a range scan over createdAt gets slow long before the bill does.
+  periodDay   String // "2026-08-05"
+  periodMonth String // "2026-08"
+
+  isTestData Boolean  @default(false)
+  createdAt  DateTime @default(now())
+
+  @@index([userId, periodDay])
+  @@index([userId, periodMonth])
+  @@index([sessionId])
+  @@index([createdAt])
+  @@map("voice_usage_events")
+}

--- a/apps/web/prisma/schema/insights.prisma
+++ b/apps/web/prisma/schema/insights.prisma
@@ -111,13 +111,13 @@ model HomeworkSession {
 model HierarchicalSummary {
   id                    String   @id @default(cuid())
   userId                String
-  type                  String   // 'weekly' or 'monthly'
+  type                  String // 'weekly' or 'monthly'
   startDate             DateTime
   endDate               DateTime
-  keyThemes             Json     // string[]
-  consolidatedLearnings Json     // string[]
-  frequentTopics        Json     // { topic: string; count: number }[]
-  sourceConversationIds Json     // string[]
+  keyThemes             Json // string[]
+  consolidatedLearnings Json // string[]
+  frequentTopics        Json // { topic: string; count: number }[]
+  sourceConversationIds Json // string[]
   createdAt             DateTime @default(now())
   updatedAt             DateTime @updatedAt
 

--- a/apps/web/prisma/schema/locale.prisma
+++ b/apps/web/prisma/schema/locale.prisma
@@ -9,12 +9,12 @@ enum LocaleAuditAction {
 }
 
 model LocaleConfig {
-  id                        String   @id // Country code (e.g., "IT", "FR", "DE")
-  countryName               String   // Display name (e.g., "Italia", "France", "Germany")
-  primaryLocale             String   // Primary locale code (e.g., "it", "en", "fr")
-  primaryLanguageMaestroId  String   // Maestro ID for the primary language teacher
-  secondaryLocales          String[] // Additional supported locale codes
-  enabled                   Boolean  @default(true)
+  id                       String   @id // Country code (e.g., "IT", "FR", "DE")
+  countryName              String // Display name (e.g., "Italia", "France", "Germany")
+  primaryLocale            String // Primary locale code (e.g., "it", "en", "fr")
+  primaryLanguageMaestroId String // Maestro ID for the primary language teacher
+  secondaryLocales         String[] // Additional supported locale codes
+  enabled                  Boolean  @default(true)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -24,13 +24,13 @@ model LocaleConfig {
 }
 
 model LocaleAuditLog {
-  id        String              @id @default(cuid())
+  id        String            @id @default(cuid())
   localeId  String
   adminId   String
   action    LocaleAuditAction
   changes   Json
   notes     String?
-  createdAt DateTime            @default(now())
+  createdAt DateTime          @default(now())
 
   @@index([localeId])
   @@index([adminId])

--- a/apps/web/prisma/schema/research.prisma
+++ b/apps/web/prisma/schema/research.prisma
@@ -8,11 +8,11 @@ model SyntheticProfile {
   name String @unique
 
   // Student characteristics
-  dsaProfile     String // dyslexia | adhd | asd | mixed
-  age            Int
-  schoolYear     Int
-  learningStyle  String // visual | auditory | kinesthetic | mixed
-  challengeAreas Json // string[] - specific difficulty areas
+  dsaProfile       String // dyslexia | adhd | asd | mixed
+  age              Int
+  schoolYear       Int
+  learningStyle    String // visual | auditory | kinesthetic | mixed
+  challengeAreas   Json // string[] - specific difficulty areas
   responsePatterns Json // behavioral patterns for message generation
 
   // Metadata
@@ -33,12 +33,12 @@ model ResearchExperiment {
 
   // Experiment design
   hypothesis         String
-  status             String @default("draft") // draft | running | completed | failed
+  status             String           @default("draft") // draft | running | completed | failed
   maestroId          String
   syntheticProfileId String
   syntheticProfile   SyntheticProfile @relation(fields: [syntheticProfileId], references: [id], onDelete: Cascade)
-  turns              Int    @default(10)
-  config             Json?  // additional experiment parameters
+  turns              Int              @default(10)
+  config             Json? // additional experiment parameters
 
   // Execution
   startedAt   DateTime?
@@ -46,9 +46,9 @@ model ResearchExperiment {
   errorLog    String?
 
   // Aggregated scores (filled on completion)
-  scoreScaffolding         Float?
-  scoreHinting             Float?
-  scoreAdaptation          Float?
+  scoreScaffolding           Float?
+  scoreHinting               Float?
+  scoreAdaptation            Float?
   scoreMisconceptionHandling Float?
 
   createdAt DateTime @default(now())
@@ -72,11 +72,11 @@ model ResearchResult {
   maestroResponse String
 
   // Per-turn metrics
-  responseTimeMs     Int?
-  tokensUsed         Int?
+  responseTimeMs      Int?
+  tokensUsed          Int?
   scaffoldingDetected Boolean @default(false)
   adaptationDetected  Boolean @default(false)
-  metrics            Json?   // additional structured metrics
+  metrics             Json? // additional structured metrics
 
   createdAt DateTime @default(now())
 

--- a/apps/web/prisma/schema/robot-device.prisma
+++ b/apps/web/prisma/schema/robot-device.prisma
@@ -17,7 +17,7 @@ model RobotDevice {
   pairedAt          DateTime?
 
   // Long-lived device credential: random token, stored hashed, revocable.
-  tokenHash String?   @unique
+  tokenHash  String?   @unique
   lastSeenAt DateTime?
   revokedAt  DateTime?
 

--- a/apps/web/prisma/schema/tier.prisma
+++ b/apps/web/prisma/schema/tier.prisma
@@ -26,14 +26,14 @@ enum TierAuditAction {
 }
 
 model TierDefinition {
-  id                  String   @id @default(cuid())
-  code                String   @unique
-  name                String
-  description         String?
-  chatLimitDaily      Int      @default(10)
-  voiceMinutesDaily   Int      @default(5)
-  toolsLimitDaily     Int      @default(10)
-  docsLimitTotal      Int      @default(1)
+  id                String  @id @default(cuid())
+  code              String  @unique
+  name              String
+  description       String?
+  chatLimitDaily    Int     @default(10)
+  voiceMinutesDaily Int     @default(5)
+  toolsLimitDaily   Int     @default(10)
+  docsLimitTotal    Int     @default(1)
 
   // Video vision limits (ADR 0122)
   videoVisionSecondsPerSession Int @default(0) // Max seconds per capture session (0 = disabled)
@@ -41,94 +41,94 @@ model TierDefinition {
 
   // Per-feature model selection (ADR 0072)
   // Main conversation and voice
-  chatModel           String   @default("gpt-5-mini")
-  realtimeModel       String   @default("gpt-realtime-mini")
+  chatModel     String @default("gpt-5-mini")
+  realtimeModel String @default("gpt-realtime-mini")
 
   // Tool-specific models
-  pdfModel            String   @default("gpt-5-mini")
-  mindmapModel        String   @default("gpt-5-mini")
-  quizModel           String   @default("gpt-5-mini")
-  flashcardsModel     String   @default("gpt-5-mini")
-  summaryModel        String   @default("gpt-5-mini")
-  formulaModel        String   @default("gpt-5-mini")
-  chartModel          String   @default("gpt-5-mini")
-  homeworkModel       String   @default("gpt-5-mini")
-  webcamModel         String   @default("gpt-5-mini")
-  demoModel           String   @default("gpt-5-nano")
+  pdfModel        String @default("gpt-5-mini")
+  mindmapModel    String @default("gpt-5-mini")
+  quizModel       String @default("gpt-5-mini")
+  flashcardsModel String @default("gpt-5-mini")
+  summaryModel    String @default("gpt-5-mini")
+  formulaModel    String @default("gpt-5-mini")
+  chartModel      String @default("gpt-5-mini")
+  homeworkModel   String @default("gpt-5-mini")
+  webcamModel     String @default("gpt-5-mini")
+  demoModel       String @default("gpt-5-nano")
 
   // Per-feature AI config overrides (ADR 0073)
   // JSON: { "quiz": { "temperature": 0.8, "maxTokens": 2500 }, ... }
-  featureConfigs      Json     @default("{}")
+  featureConfigs Json @default("{}")
 
-  features            Json     @default("{}")
-  availableMaestri    Json     @default("[]")
-  availableCoaches    Json     @default("[]")
-  availableBuddies    Json     @default("[]")
-  availableTools      Json     @default("[]")
-  stripePriceId       String?
-  monthlyPriceEur     Decimal?
-  sortOrder           Int      @default(0)
-  isActive            Boolean  @default(true)
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  features         Json     @default("{}")
+  availableMaestri Json     @default("[]")
+  availableCoaches Json     @default("[]")
+  availableBuddies Json     @default("[]")
+  availableTools   Json     @default("[]")
+  stripePriceId    String?
+  monthlyPriceEur  Decimal?
+  sortOrder        Int      @default(0)
+  isActive         Boolean  @default(true)
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
 
-  subscriptions UserSubscription[]
+  subscriptions   UserSubscription[]
   configSnapshots TierConfigSnapshot[]
 }
 
 // Model catalog with metadata for admin selection
 model ModelCatalog {
-  id              String   @id @default(cuid())
-  name            String   @unique // e.g., "gpt-5.2-edu"
-  displayName     String   // e.g., "GPT-5.2 Education"
-  provider        String   @default("azure") // azure, ollama
-  deploymentName  String   // Azure deployment name
-  category        String   // chat, realtime, embedding
+  id             String @id @default(cuid())
+  name           String @unique // e.g., "gpt-5.2-edu"
+  displayName    String // e.g., "GPT-5.2 Education"
+  provider       String @default("azure") // azure, ollama
+  deploymentName String // Azure deployment name
+  category       String // chat, realtime, embedding
 
   // Pricing (per 1K tokens, in USD)
-  inputCostPer1k  Decimal  @default(0)
-  outputCostPer1k Decimal  @default(0)
+  inputCostPer1k  Decimal @default(0)
+  outputCostPer1k Decimal @default(0)
 
   // Capabilities
-  maxTokens       Int      @default(4096)
-  contextWindow   Int      @default(128000)
-  supportsVision  Boolean  @default(false)
-  supportsTools   Boolean  @default(true)
-  supportsJson    Boolean  @default(true)
+  maxTokens      Int     @default(4096)
+  contextWindow  Int     @default(128000)
+  supportsVision Boolean @default(false)
+  supportsTools  Boolean @default(true)
+  supportsJson   Boolean @default(true)
 
   // Quality indicators (1-5 scale)
-  qualityScore    Int      @default(3) // Overall quality
-  speedScore      Int      @default(3) // Response speed
-  educationScore  Int      @default(3) // Educational aptitude
+  qualityScore   Int @default(3) // Overall quality
+  speedScore     Int @default(3) // Response speed
+  educationScore Int @default(3) // Educational aptitude
 
   // Recommendations
-  recommendedFor  Json     @default("[]") // ["chat", "tools", "summaries"]
-  notRecommendedFor Json   @default("[]") // ["realtime"]
+  recommendedFor    Json @default("[]") // ["chat", "tools", "summaries"]
+  notRecommendedFor Json @default("[]") // ["realtime"]
 
-  notes           String?
-  isActive        Boolean  @default(true)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  notes     String?
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([category])
   @@index([isActive])
 }
 
 model UserSubscription {
-  id                   String   @id @default(cuid())
-  userId               String   @unique
-  user                 User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                   String             @id @default(cuid())
+  userId               String             @unique
+  user                 User               @relation(fields: [userId], references: [id], onDelete: Cascade)
   tierId               String
-  tier                 TierDefinition @relation(fields: [tierId], references: [id], onDelete: Cascade)
+  tier                 TierDefinition     @relation(fields: [tierId], references: [id], onDelete: Cascade)
   overrideLimits       Json?
   overrideFeatures     Json?
   stripeSubscriptionId String?
   stripeCustomerId     String?
   status               SubscriptionStatus @default(ACTIVE)
-  startedAt            DateTime @default(now())
+  startedAt            DateTime           @default(now())
   expiresAt            DateTime?
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+  createdAt            DateTime           @default(now())
+  updatedAt            DateTime           @updatedAt
 
   @@index([tierId])
   @@index([status])
@@ -153,25 +153,25 @@ model TierAuditLog {
 // User-level feature AI config overrides (ADR 0073)
 // Admin can override model/temperature/maxTokens per feature per user
 model UserFeatureConfig {
-  id              String   @id @default(cuid())
-  userId          String
-  user            User     @relation("UserFeatureConfigs", fields: [userId], references: [id], onDelete: Cascade)
-  feature         String   // Feature key: chat, quiz, mindmap, summary, etc.
+  id      String @id @default(cuid())
+  userId  String
+  user    User   @relation("UserFeatureConfigs", fields: [userId], references: [id], onDelete: Cascade)
+  feature String // Feature key: chat, quiz, mindmap, summary, etc.
 
   // AI configuration overrides (null = use tier default)
-  model           String?  // Model override
-  temperature     Decimal? // Temperature override (0.0-2.0)
-  maxTokens       Int?     // Max tokens override
+  model       String? // Model override
+  temperature Decimal? // Temperature override (0.0-2.0)
+  maxTokens   Int? // Max tokens override
 
   // Feature activation (null = use tier default)
-  isEnabled       Boolean? // Override feature enabled state
+  isEnabled Boolean? // Override feature enabled state
 
   // Audit fields
-  setBy           String   // Admin user ID who set this override
-  reason          String?  // Why this override was set
-  expiresAt       DateTime? // Optional expiration (for A/B testing)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  setBy     String // Admin user ID who set this override
+  reason    String? // Why this override was set
+  expiresAt DateTime? // Optional expiration (for A/B testing)
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
   @@unique([userId, feature]) // One config per feature per user
   @@index([userId])
@@ -182,21 +182,21 @@ model UserFeatureConfig {
 // Version control for tier configurations (ADR 0073)
 // Enables backup, rollback, A/B testing, and configuration history
 model TierConfigSnapshot {
-  id              String   @id @default(cuid())
-  tierId          String
-  tier            TierDefinition @relation(fields: [tierId], references: [id], onDelete: Cascade)
-  version         Int      // Auto-increment per tier (1, 2, 3...)
-  name            String   // Human-readable version name (e.g., "v1.0", "Before GPT-5 update")
-  description     String?  // Change description/notes
+  id          String         @id @default(cuid())
+  tierId      String
+  tier        TierDefinition @relation(fields: [tierId], references: [id], onDelete: Cascade)
+  version     Int // Auto-increment per tier (1, 2, 3...)
+  name        String // Human-readable version name (e.g., "v1.0", "Before GPT-5 update")
+  description String? // Change description/notes
 
   // Full configuration snapshot
-  configSnapshot  Json     // Complete tier config at this point in time
+  configSnapshot Json // Complete tier config at this point in time
 
   // Metadata
-  createdBy       String   // Admin user ID who created this version
-  createdAt       DateTime @default(now())
-  isActive        Boolean  @default(false) // True = currently applied configuration
-  isBaseline      Boolean  @default(false) // True = protected reference version (cannot delete)
+  createdBy  String // Admin user ID who created this version
+  createdAt  DateTime @default(now())
+  isActive   Boolean  @default(false) // True = currently applied configuration
+  isBaseline Boolean  @default(false) // True = protected reference version (cannot delete)
 
   @@unique([tierId, version])
   @@index([tierId])
@@ -210,7 +210,7 @@ model TaxConfig {
   countryCode          String   @unique // IT, FR, DE, ES, GB
   vatRate              Float    @default(0)
   reverseChargeEnabled Boolean  @default(false)
-  stripeTaxId          String?  // Stripe Tax rate ID
+  stripeTaxId          String? // Stripe Tax rate ID
   isActive             Boolean  @default(true)
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt

--- a/apps/web/prisma/schema/trial.prisma
+++ b/apps/web/prisma/schema/trial.prisma
@@ -4,25 +4,25 @@
 /// Stores maestro roster assignments and optional coach pairing for trial users.
 
 model TrialSession {
-  id               String    @id @default(uuid())
-  ipHash           String // SHA256 of IP address
-  visitorId        String // Cookie visitor ID
-  chatsUsed        Int       @default(0)
-  docsUsed         Int       @default(0)
-  voiceSecondsUsed Int       @default(0) // Total voice seconds (max 300 = 5 min)
-  toolsUsed        Int       @default(0) // Total tool calls (max 10)
-  videoVisionSecondsUsed Int @default(0) // Total video vision seconds (ADR 0122)
-  assignedMaestri  String    @default("[]") // JSON array of 3 maestro IDs
-  assignedCoach    String? // Single coach ID
-  abuseScore       Int       @default(0)
-  email            String? // Optional email for nurturing (F-01)
-  emailCollectedAt DateTime? // When email was provided
-  emailVerificationCode String? // One-time verification code
-  emailVerificationSentAt DateTime?
+  id                         String    @id @default(uuid())
+  ipHash                     String // SHA256 of IP address
+  visitorId                  String // Cookie visitor ID
+  chatsUsed                  Int       @default(0)
+  docsUsed                   Int       @default(0)
+  voiceSecondsUsed           Int       @default(0) // Total voice seconds (max 300 = 5 min)
+  toolsUsed                  Int       @default(0) // Total tool calls (max 10)
+  videoVisionSecondsUsed     Int       @default(0) // Total video vision seconds (ADR 0122)
+  assignedMaestri            String    @default("[]") // JSON array of 3 maestro IDs
+  assignedCoach              String? // Single coach ID
+  abuseScore                 Int       @default(0)
+  email                      String? // Optional email for nurturing (F-01)
+  emailCollectedAt           DateTime? // When email was provided
+  emailVerificationCode      String? // One-time verification code
+  emailVerificationSentAt    DateTime?
   emailVerificationExpiresAt DateTime?
-  emailVerifiedAt DateTime? // Email verified timestamp
-  createdAt        DateTime  @default(now())
-  lastActivityAt   DateTime  @updatedAt
+  emailVerifiedAt            DateTime? // Email verified timestamp
+  createdAt                  DateTime  @default(now())
+  lastActivityAt             DateTime  @updatedAt
 
   @@unique([ipHash, visitorId])
   @@index([ipHash])

--- a/apps/web/prisma/schema/user.prisma
+++ b/apps/web/prisma/schema/user.prisma
@@ -104,6 +104,7 @@ model User {
 
   // Video Vision Usage Tracking (ADR 0122)
   videoVisionUsages VideoVisionUsage[] @relation("VideoVisionUsages")
+  voiceUsageEvents  VoiceUsageEvent[]  @relation("VoiceUsageEvents")
 
   // Password Reset Tokens (Plan 125)
   passwordResetTokens PasswordResetToken[]

--- a/apps/web/prisma/schema/vault.prisma
+++ b/apps/web/prisma/schema/vault.prisma
@@ -4,16 +4,16 @@
 // ============================================================================
 
 model SecretVault {
-  id        String   @id @default(cuid())
-  service   String   // e.g. "azure_openai", "stripe", "resend"
-  keyName   String   // e.g. "AZURE_OPENAI_API_KEY"
-  encrypted String   @db.Text // AES-256-GCM encrypted value
-  iv        String   // initialization vector (hex)
-  authTag   String   // GCM authentication tag (hex)
-  status    String   @default("active") // active, expired, rotated
+  id        String    @id @default(cuid())
+  service   String // e.g. "azure_openai", "stripe", "resend"
+  keyName   String // e.g. "AZURE_OPENAI_API_KEY"
+  encrypted String    @db.Text // AES-256-GCM encrypted value
+  iv        String // initialization vector (hex)
+  authTag   String // GCM authentication tag (hex)
+  status    String    @default("active") // active, expired, rotated
   lastUsed  DateTime?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
   @@unique([service, keyName])
   @@map("secret_vault")

--- a/apps/web/prisma/schema/video-vision.prisma
+++ b/apps/web/prisma/schema/video-vision.prisma
@@ -4,16 +4,16 @@
 // ============================================================================
 
 model VideoVisionUsage {
-  id             String   @id @default(cuid())
+  id             String    @id @default(cuid())
   userId         String
-  user           User     @relation("VideoVisionUsages", fields: [userId], references: [id], onDelete: Cascade)
-  voiceSessionId String   // Reference to the voice session where video was used
-  framesUsed     Int      @default(0)
-  secondsUsed    Int      @default(0)
-  periodMonth    String   // "2026-02" format for monthly aggregation
-  startedAt      DateTime @default(now())
+  user           User      @relation("VideoVisionUsages", fields: [userId], references: [id], onDelete: Cascade)
+  voiceSessionId String // Reference to the voice session where video was used
+  framesUsed     Int       @default(0)
+  secondsUsed    Int       @default(0)
+  periodMonth    String // "2026-02" format for monthly aggregation
+  startedAt      DateTime  @default(now())
   endedAt        DateTime?
-  createdAt      DateTime @default(now())
+  createdAt      DateTime  @default(now())
 
   @@index([userId, periodMonth])
   @@index([voiceSessionId])

--- a/apps/web/prisma/schema/waitlist.prisma
+++ b/apps/web/prisma/schema/waitlist.prisma
@@ -8,9 +8,9 @@
 /// Supports email verification, unsubscribe flows, promo code assignment,
 /// and conversion tracking when signup converts to a registered user.
 model WaitlistEntry {
-  id     String @id @default(cuid())
-  email  String @unique
-  name   String?
+  id    String  @id @default(cuid())
+  email String  @unique
+  name  String?
 
   /// BCP-47 locale code of the user at signup
   locale String @default("it")
@@ -28,7 +28,7 @@ model WaitlistEntry {
   marketingConsentAt DateTime?
 
   // Email verification
-  verificationToken     String   @unique @default(cuid())
+  verificationToken     String    @unique @default(cuid())
   verificationExpiresAt DateTime
   verifiedAt            DateTime?
 
@@ -37,8 +37,8 @@ model WaitlistEntry {
   unsubscribedAt   DateTime?
 
   // Promo code (assigned after verification)
-  promoCode        String?   @unique
-  promoRedeemedAt  DateTime?
+  promoCode       String?   @unique
+  promoRedeemedAt DateTime?
 
   // Conversion tracking
   convertedUserId String?

--- a/apps/web/src/app/admin/voice-costs/page.tsx
+++ b/apps/web/src/app/admin/voice-costs/page.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+export const dynamic = 'force-dynamic';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Loader2, RefreshCw, AlertCircle } from 'lucide-react';
+import type { Period, UserVoiceSpend } from '@/lib/metrics/voice-usage-service';
+
+interface VoiceCostsResponse {
+  period: Period;
+  summary: {
+    totalCostEur: number;
+    activeUsers: number;
+    costPerUserEur: number;
+    byDay: { day: string; costEur: number }[];
+  };
+  users: UserVoiceSpend[];
+}
+
+const PERIODS: { value: Period; label: string }[] = [
+  { value: 'day', label: 'Oggi' },
+  { value: 'week', label: '7 giorni' },
+  { value: 'month', label: 'Questo mese' },
+];
+
+const euro = (value: number): string =>
+  new Intl.NumberFormat('it-IT', {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  }).format(value);
+
+export default function VoiceCostsPage() {
+  const [period, setPeriod] = useState<Period>('day');
+  const [data, setData] = useState<VoiceCostsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/admin/voice-costs?period=${period}`);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      setData((await response.json()) as VoiceCostsResponse);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Errore sconosciuto');
+    } finally {
+      setLoading(false);
+    }
+  }, [period]);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  return (
+    <main className="p-6 space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Costi voce per utente</h1>
+          <p className="text-sm text-muted-foreground">
+            Calcolati sui token realmente fatturati da Azure Realtime, non su stime al minuto.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <div role="group" aria-label="Periodo" className="flex gap-1">
+            {PERIODS.map((option) => (
+              <Button
+                key={option.value}
+                variant={period === option.value ? 'default' : 'outline'}
+                size="sm"
+                aria-pressed={period === option.value}
+                onClick={() => setPeriod(option.value)}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void fetchData()}
+            aria-label="Aggiorna"
+          >
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </header>
+
+      {loading && (
+        <p className="flex items-center gap-2 text-sm" role="status" aria-live="polite">
+          <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+          Caricamento dei costi…
+        </p>
+      )}
+
+      {error && (
+        <p className="flex items-center gap-2 text-sm text-destructive" role="alert">
+          <AlertCircle className="h-4 w-4" aria-hidden="true" />
+          {error}
+        </p>
+      )}
+
+      {data && !loading && (
+        <>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <Summary label="Totale periodo" value={euro(data.summary.totalCostEur)} />
+            <Summary label="Utenti attivi" value={String(data.summary.activeUsers)} />
+            <Summary label="Media per utente" value={euro(data.summary.costPerUserEur)} />
+          </div>
+
+          <Card>
+            <CardContent className="p-0 overflow-x-auto">
+              <table className="w-full text-sm">
+                <caption className="sr-only">
+                  Costo della voce per utente nel periodo selezionato
+                </caption>
+                <thead>
+                  <tr className="border-b text-left">
+                    <th scope="col" className="p-3">
+                      Utente
+                    </th>
+                    <th scope="col" className="p-3 text-right">
+                      Sessioni
+                    </th>
+                    <th scope="col" className="p-3 text-right">
+                      Minuti parlati
+                    </th>
+                    <th scope="col" className="p-3 text-right">
+                      Costo
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.users.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="p-6 text-center text-muted-foreground">
+                        Nessun uso della voce in questo periodo.
+                      </td>
+                    </tr>
+                  )}
+                  {data.users.map((user) => (
+                    <tr key={user.userId} className="border-b last:border-0">
+                      <th scope="row" className="p-3 font-normal">
+                        {user.name || user.email || user.userId}
+                      </th>
+                      <td className="p-3 text-right tabular-nums">{user.sessions}</td>
+                      <td className="p-3 text-right tabular-nums">
+                        {user.spokenMinutes.toFixed(1)}
+                      </td>
+                      <td className="p-3 text-right tabular-nums font-medium">
+                        {euro(user.costEur)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </main>
+  );
+}
+
+function Summary({ label, value }: { label: string; value: string }) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <p className="text-sm text-muted-foreground">{label}</p>
+        <p className="text-2xl font-bold tabular-nums">{value}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/api/admin/voice-costs/route.ts
+++ b/apps/web/src/app/api/admin/voice-costs/route.ts
@@ -1,0 +1,35 @@
+/**
+ * Per-user voice costs for the admin console.
+ *
+ * Read-only, admin-gated, and deliberately the same functions the CLI calls:
+ * a dashboard and a script that disagree about the bill are worse than either
+ * alone.
+ */
+
+import { NextResponse } from 'next/server';
+import { pipe, withSentry, withAdminReadOnly } from '@/lib/api/middlewares';
+import {
+  getVoiceSpendByUser,
+  getVoiceSpendSummary,
+  type Period,
+} from '@/lib/metrics/voice-usage-service';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const PERIODS: Period[] = ['day', 'week', 'month'];
+
+export const GET = pipe(
+  withSentry('/api/admin/voice-costs'),
+  withAdminReadOnly,
+)(async (ctx) => {
+  const requested = new URL(ctx.req.url).searchParams.get('period');
+  const period: Period = PERIODS.includes(requested as Period) ? (requested as Period) : 'day';
+
+  const [summary, users] = await Promise.all([
+    getVoiceSpendSummary(period),
+    getVoiceSpendByUser(period),
+  ]);
+
+  return NextResponse.json({ period, summary, users });
+});

--- a/apps/web/src/app/api/metrics/voice-usage/route.ts
+++ b/apps/web/src/app/api/metrics/voice-usage/route.ts
@@ -11,6 +11,7 @@ import { NextResponse } from 'next/server';
 import { getRequestId, getRequestLogger } from '@/lib/tracing';
 import { pipe, withSentry, withCSRF, withAuth } from '@/lib/api/middlewares';
 import { recordVoiceUsage } from '@/lib/metrics/voice-usage-service';
+import { resolveVoiceModel } from '@/lib/metrics/voice-model';
 
 export const revalidate = 0;
 
@@ -36,15 +37,19 @@ export const POST = pipe(
     return NextResponse.json({ error: 'invalid JSON body' }, { status: 400, headers });
   }
 
-  if (!body.sessionId || !body.model) {
-    return NextResponse.json({ error: 'sessionId and model required' }, { status: 400, headers });
+  if (!body.sessionId) {
+    return NextResponse.json({ error: 'sessionId required' }, { status: 400, headers });
   }
+
+  // The browser does not get to name the model: `response.done` frequently
+  // omits it, and a client default would price every turn at the premium rate.
+  const model = await resolveVoiceModel(body.model ?? null);
 
   const recorded = await recordVoiceUsage({
     userId: ctx.userId!,
     sessionId: body.sessionId,
     maestroId: body.maestroId ?? null,
-    model: body.model,
+    model,
     usage: body.usage,
   });
 

--- a/apps/web/src/app/api/metrics/voice-usage/route.ts
+++ b/apps/web/src/app/api/metrics/voice-usage/route.ts
@@ -1,0 +1,58 @@
+/**
+ * Voice usage ingestion.
+ *
+ * The client forwards the usage block Azure sends on every `response.done`.
+ * The user is taken from the session, never from the body: a cost report is
+ * only worth having if nobody can bill someone else's conversation to another
+ * account.
+ */
+
+import { NextResponse } from 'next/server';
+import { getRequestId, getRequestLogger } from '@/lib/tracing';
+import { pipe, withSentry, withCSRF, withAuth } from '@/lib/api/middlewares';
+import { recordVoiceUsage } from '@/lib/metrics/voice-usage-service';
+
+export const revalidate = 0;
+
+interface VoiceUsageRequest {
+  sessionId?: string;
+  maestroId?: string;
+  model?: string;
+  usage?: unknown;
+}
+
+export const POST = pipe(
+  withSentry('/api/metrics/voice-usage'),
+  withCSRF,
+  withAuth,
+)(async (ctx) => {
+  const log = getRequestLogger(ctx.req);
+  const headers = { 'X-Request-ID': getRequestId(ctx.req) };
+
+  let body: VoiceUsageRequest;
+  try {
+    body = (await ctx.req.json()) as VoiceUsageRequest;
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400, headers });
+  }
+
+  if (!body.sessionId || !body.model) {
+    return NextResponse.json({ error: 'sessionId and model required' }, { status: 400, headers });
+  }
+
+  const recorded = await recordVoiceUsage({
+    userId: ctx.userId!,
+    sessionId: body.sessionId,
+    maestroId: body.maestroId ?? null,
+    model: body.model,
+    usage: body.usage,
+  });
+
+  if (recorded) {
+    log.debug('Voice usage recorded', { sessionId: body.sessionId, costEur: recorded.costEur });
+  }
+
+  // A turn that cost nothing, or a row we failed to store, is still a
+  // successful request: the conversation must never be disturbed by accounting.
+  return NextResponse.json({ success: true, costEur: recorded?.costEur ?? 0 }, { headers });
+});

--- a/apps/web/src/components/admin/admin-sidebar-sections.ts
+++ b/apps/web/src/components/admin/admin-sidebar-sections.ts
@@ -1,5 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 import {
+  Mic,
   LayoutDashboard,
   UserPlus,
   Users,
@@ -61,6 +62,12 @@ export function createNavSections(t: (key: string) => string): NavSection[] {
           icon: BarChart3,
         },
         { id: 'funnel', label: 'Funnel', href: '/admin/funnel', icon: Funnel },
+        {
+          id: 'voice-costs',
+          label: 'Voice costs',
+          href: '/admin/voice-costs',
+          icon: Mic,
+        },
       ],
     },
     {

--- a/apps/web/src/lib/hooks/voice-session/__tests__/voice-usage-reporter.test.ts
+++ b/apps/web/src/lib/hooks/voice-session/__tests__/voice-usage-reporter.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Reporting a turn's cost must never be able to interrupt a conversation, and
+ * must never invent a number when Azure did not send one.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({ csrfFetch: vi.fn() }));
+
+import { csrfFetch } from '@/lib/auth';
+import {
+  modelFromResponseDone,
+  reportVoiceUsage,
+  sendVoiceUsage,
+  usageFromResponseDone,
+} from '../voice-usage-reporter';
+
+const RESPONSE_DONE = {
+  type: 'response.done',
+  response: {
+    model: 'gpt-realtime-mini',
+    usage: {
+      input_token_details: { text_tokens: 10, audio_tokens: 900 },
+      output_token_details: { text_tokens: 5, audio_tokens: 1200 },
+    },
+  },
+};
+
+describe('usageFromResponseDone', () => {
+  it('finds the usage block Azure sends', () => {
+    expect(usageFromResponseDone(RESPONSE_DONE)).toEqual(RESPONSE_DONE.response.usage);
+    expect(modelFromResponseDone(RESPONSE_DONE)).toBe('gpt-realtime-mini');
+  });
+
+  it('returns nothing rather than guessing when the event has no usage', () => {
+    expect(usageFromResponseDone({ type: 'response.done' })).toBeNull();
+    expect(usageFromResponseDone({ type: 'response.done', response: 'odd' })).toBeNull();
+    expect(modelFromResponseDone({ response: {} })).toBeNull();
+  });
+});
+
+describe('reportVoiceUsage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('posts the usage block for the current session', () => {
+    vi.mocked(csrfFetch).mockResolvedValue(new Response('{}'));
+
+    reportVoiceUsage({
+      sessionId: 'sess-1',
+      maestroId: 'loto',
+      model: 'gpt-realtime-mini',
+      usage: RESPONSE_DONE.response.usage,
+    });
+
+    expect(csrfFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(vi.mocked(csrfFetch).mock.calls[0][1]?.body as string);
+    expect(body.sessionId).toBe('sess-1');
+    expect(body.maestroId).toBe('loto');
+  });
+
+  it('says nothing when there is nothing to report', () => {
+    reportVoiceUsage({ sessionId: null, usage: RESPONSE_DONE.response.usage });
+    reportVoiceUsage({ sessionId: 'sess-1', usage: null });
+
+    expect(csrfFetch).not.toHaveBeenCalled();
+  });
+
+  it('swallows a failed report rather than breaking the conversation', async () => {
+    vi.mocked(csrfFetch).mockRejectedValue(new Error('offline'));
+
+    expect(() =>
+      reportVoiceUsage({ sessionId: 'sess-1', usage: RESPONSE_DONE.response.usage }),
+    ).not.toThrow();
+
+    // The failure must settle, not linger as an unhandled rejection: a loose
+    // rejected promise in the browser is a console error mid-lesson.
+    await expect(
+      sendVoiceUsage({ sessionId: 'sess-1', usage: RESPONSE_DONE.response.usage }),
+    ).resolves.toBe(false);
+  });
+
+  it('confirms a successful report', async () => {
+    vi.mocked(csrfFetch).mockResolvedValue(new Response('{}'));
+
+    await expect(
+      sendVoiceUsage({ sessionId: 'sess-1', usage: RESPONSE_DONE.response.usage }),
+    ).resolves.toBe(true);
+  });
+});

--- a/apps/web/src/lib/hooks/voice-session/event-handlers.ts
+++ b/apps/web/src/lib/hooks/voice-session/event-handlers.ts
@@ -15,6 +15,11 @@ import {
   stopBrowserMeditation,
 } from '@/lib/meditation/browser';
 import { isStopIntent } from '@/lib/meditation/stop-intent';
+import {
+  modelFromResponseDone,
+  reportVoiceUsage,
+  usageFromResponseDone,
+} from './voice-usage-reporter';
 import { handleToolCall, type ToolHandlerParams } from './tool-handlers';
 import { recordUserSpeechEnd } from './latency-utils';
 import { handleErrorEvent } from './error-handler';
@@ -373,6 +378,14 @@ export function useHandleServerEvent(deps: EventHandlerDeps) {
           // If a meditation is waiting for its introduction to end, this is it.
           openingFinished();
           deps.hasActiveResponseRef.current = false;
+          // Azure reports what this turn actually cost. It is the only honest
+          // source: wall-clock minutes would charge silence like speech.
+          reportVoiceUsage({
+            sessionId: deps.sessionIdRef.current,
+            maestroId: deps.maestroRef.current?.id,
+            model: modelFromResponseDone(event),
+            usage: usageFromResponseDone(event),
+          });
           logger.debug('[VoiceSession] Response complete - hasActiveResponse = false');
           break;
 

--- a/apps/web/src/lib/hooks/voice-session/voice-usage-reporter.ts
+++ b/apps/web/src/lib/hooks/voice-session/voice-usage-reporter.ts
@@ -17,6 +17,7 @@ import { clientLogger as logger } from '@/lib/logger/client';
 export interface VoiceUsageReport {
   sessionId: string | null;
   maestroId?: string | null;
+  /** Only set when Azure named it on `response.done`; the server decides otherwise. */
   model?: string | null;
   usage: unknown;
 }
@@ -48,7 +49,7 @@ export async function sendVoiceUsage(report: VoiceUsageReport): Promise<boolean>
     body: JSON.stringify({
       sessionId: report.sessionId,
       maestroId: report.maestroId ?? null,
-      model: report.model || 'gpt-realtime',
+      model: report.model ?? null,
       usage: report.usage,
     }),
   })

--- a/apps/web/src/lib/hooks/voice-session/voice-usage-reporter.ts
+++ b/apps/web/src/lib/hooks/voice-session/voice-usage-reporter.ts
@@ -1,0 +1,68 @@
+/**
+ * Reports what a turn cost, from the browser.
+ *
+ * Azure sends a usage block on every `response.done`. That block is the only
+ * honest source for what a conversation costs: wall-clock minutes charge
+ * silence at the same rate as speech, and Azure does not.
+ *
+ * Reporting is strictly fire-and-forget. Accounting must never be able to
+ * interrupt a child mid-sentence.
+ */
+
+'use client';
+
+import { csrfFetch } from '@/lib/auth';
+import { clientLogger as logger } from '@/lib/logger/client';
+
+export interface VoiceUsageReport {
+  sessionId: string | null;
+  maestroId?: string | null;
+  model?: string | null;
+  usage: unknown;
+}
+
+/** Reads `response.usage` out of a `response.done` event, tolerating shape drift. */
+export function usageFromResponseDone(event: Record<string, unknown>): unknown {
+  const response = event.response;
+  if (typeof response !== 'object' || response === null) return null;
+  return (response as Record<string, unknown>).usage ?? null;
+}
+
+export function modelFromResponseDone(event: Record<string, unknown>): string | null {
+  const response = event.response;
+  if (typeof response !== 'object' || response === null) return null;
+  const model = (response as Record<string, unknown>).model;
+  return typeof model === 'string' && model.trim() ? model : null;
+}
+
+/**
+ * Returns whether the turn was reported. Exported so a test can prove the
+ * failure path actually resolves instead of leaving a rejected promise loose.
+ */
+export async function sendVoiceUsage(report: VoiceUsageReport): Promise<boolean> {
+  if (!report.sessionId || !report.usage) return false;
+
+  return csrfFetch('/api/metrics/voice-usage', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      sessionId: report.sessionId,
+      maestroId: report.maestroId ?? null,
+      model: report.model || 'gpt-realtime',
+      usage: report.usage,
+    }),
+  })
+    .then(() => true)
+    .catch((error: unknown) => {
+      // A lost row is an accounting gap. A thrown error here would be a
+      // conversation that stops, which is not a trade worth making.
+      logger.debug('[VoiceUsage] Could not report usage', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    });
+}
+
+export function reportVoiceUsage(report: VoiceUsageReport): void {
+  void sendVoiceUsage(report);
+}

--- a/apps/web/src/lib/metrics/__tests__/voice-model.test.ts
+++ b/apps/web/src/lib/metrics/__tests__/voice-model.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The browser must not be able to decide what a turn cost.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const isFeatureEnabled = vi.fn();
+
+vi.mock('@/lib/feature-flags/feature-flags-service', () => ({
+  isFeatureEnabled: (flag: string) => isFeatureEnabled(flag),
+}));
+
+const { resolveVoiceModel } = await import('../voice-model');
+
+const KEYS = [
+  'AZURE_OPENAI_REALTIME_DEPLOYMENT',
+  'AZURE_OPENAI_REALTIME_DEPLOYMENT_V15',
+  'AZURE_OPENAI_REALTIME_DEPLOYMENT_V2',
+  'AZURE_OPENAI_REALTIME_DEPLOYMENT_V21',
+];
+
+/** Enables only the named flags, so precedence can be pinned exactly. */
+function flags(...enabled: string[]): void {
+  isFeatureEnabled.mockImplementation(async (flag: string) => ({
+    enabled: enabled.includes(flag),
+  }));
+}
+
+describe('resolveVoiceModel', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    flags();
+  });
+
+  afterEach(() => {
+    for (const key of KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+    vi.clearAllMocks();
+  });
+
+  it('believes Azure over any guess when the event names the model', async () => {
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT = 'legacy';
+
+    await expect(resolveVoiceModel('gpt-realtime-mini')).resolves.toBe('gpt-realtime-mini');
+  });
+
+  it('does not let a blank report win over the configured deployment', async () => {
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT = 'legacy';
+
+    await expect(resolveVoiceModel('   ')).resolves.toBe('legacy');
+  });
+
+  it('reports the deployment the turn actually connected with', async () => {
+    // The whole point: no client default, the same answer the token endpoint gave.
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT = 'legacy';
+
+    await expect(resolveVoiceModel()).resolves.toBe('legacy');
+  });
+
+  it('follows the token endpoint precedence when 2.1 is on', async () => {
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT = 'legacy';
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT_V15 = 'v15';
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT_V2 = 'v2';
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT_V21 = 'v21';
+    flags('voice_realtime_21');
+
+    await expect(resolveVoiceModel()).resolves.toBe('v21');
+  });
+
+  it('ignores a newer deployment while its flag is off', async () => {
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT = 'legacy';
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT_V21 = 'v21';
+
+    await expect(resolveVoiceModel()).resolves.toBe('legacy');
+  });
+
+  it('falls back through the chain when the flagged deployment is unset', async () => {
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT = 'legacy';
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT_V15 = 'v15';
+    flags('voice_realtime_2');
+
+    await expect(resolveVoiceModel()).resolves.toBe('v15');
+  });
+
+  it('uses the 1.5 deployment when only that flag is on', async () => {
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT = 'legacy';
+    process.env.AZURE_OPENAI_REALTIME_DEPLOYMENT_V15 = 'v15';
+    flags('voice_realtime_15');
+
+    await expect(resolveVoiceModel()).resolves.toBe('v15');
+  });
+
+  it('overstates rather than understates when nothing is configured', async () => {
+    await expect(resolveVoiceModel()).resolves.toBe('gpt-realtime');
+  });
+});

--- a/apps/web/src/lib/metrics/__tests__/voice-pricing.test.ts
+++ b/apps/web/src/lib/metrics/__tests__/voice-pricing.test.ts
@@ -93,3 +93,57 @@ describe('parseRealtimeUsage', () => {
     }
   });
 });
+
+describe('cached input is discounted, not billed twice', () => {
+  it('does not charge a cached token at both the full and the cached rate', () => {
+    // Azure counts cached tokens inside input_token_details.audio_tokens. Adding
+    // the cached bucket on top bills the same token twice and inflates the
+    // dashboard the whole feature exists to make trustworthy.
+    const allCached = priceUsage('gpt-realtime', {
+      audioInputTokens: 1_000_000,
+      cachedInputTokens: 1_000_000,
+      cachedAudioTokens: 1_000_000,
+    });
+
+    // 1M cached audio tokens at $0.40/1M, not $32 + $0.40.
+    expect(allCached.totalCostEur).toBeCloseTo(0.4 / 1.08, 2);
+  });
+
+  it('charges the uncached remainder at the full rate', () => {
+    const half = priceUsage('gpt-realtime', {
+      audioInputTokens: 1_000_000,
+      cachedInputTokens: 500_000,
+      cachedAudioTokens: 500_000,
+    });
+
+    // 500k at $32/1M + 500k at $0.40/1M
+    expect(half.totalCostEur).toBeCloseTo((16 + 0.2) / 1.08, 2);
+  });
+
+  it('never credits money back when the cached count exceeds the input count', () => {
+    const odd = priceUsage('gpt-realtime', {
+      audioInputTokens: 100,
+      cachedInputTokens: 5_000,
+      cachedAudioTokens: 5_000,
+    });
+
+    expect(odd.totalCostEur).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('the parser splits cached audio from cached text', () => {
+  it('reads both halves of cached_tokens_details', () => {
+    const usage = parseRealtimeUsage({
+      input_token_details: {
+        audio_tokens: 900,
+        text_tokens: 100,
+        cached_tokens: 400,
+        cached_tokens_details: { audio_tokens: 300, text_tokens: 100 },
+      },
+      output_token_details: { audio_tokens: 500, text_tokens: 20 },
+    });
+
+    expect(usage.cachedAudioTokens).toBe(300);
+    expect(usage.cachedTextTokens).toBe(100);
+  });
+});

--- a/apps/web/src/lib/metrics/__tests__/voice-pricing.test.ts
+++ b/apps/web/src/lib/metrics/__tests__/voice-pricing.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Pricing has to be right in the boring cases and safe in the broken ones: an
+ * unknown model, a malformed event, a negative token count. A cost dashboard
+ * that quietly reports zero is worse than no dashboard, because it is believed.
+ */
+
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { parseRealtimeUsage, priceUsage, ratesFor, USD_PER_EUR } from '../voice-pricing';
+
+describe('ratesFor', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('prices the mini model well below the full one', () => {
+    expect(ratesFor('gpt-realtime-mini').audioOut).toBeLessThan(ratesFor('gpt-realtime').audioOut);
+  });
+
+  it('tolerates the deployment-name suffixes Azure actually hands out', () => {
+    expect(ratesFor('gpt-realtime-mini-2025-12-15')).toEqual(ratesFor('gpt-realtime-mini'));
+    expect(ratesFor('GPT-Realtime')).toEqual(ratesFor('gpt-realtime'));
+  });
+
+  it('never prices an unknown model at zero', () => {
+    const unknown = ratesFor('some-model-we-have-not-met');
+    expect(unknown.audioOut).toBeGreaterThan(0);
+    expect(unknown).toEqual(ratesFor('gpt-realtime')); // assume the expensive one
+  });
+
+  it('can be corrected without a deploy when Azure changes its price list', () => {
+    vi.stubEnv(
+      'AZURE_VOICE_RATES_JSON',
+      JSON.stringify({
+        'gpt-realtime': { audioIn: 1, audioOut: 2, textIn: 3, textOut: 4, cachedIn: 5 },
+      }),
+    );
+    expect(ratesFor('gpt-realtime').audioOut).toBe(2);
+  });
+
+  it('ignores a malformed override rather than taking pricing down', () => {
+    vi.stubEnv('AZURE_VOICE_RATES_JSON', '{not json');
+    expect(ratesFor('gpt-realtime').audioOut).toBe(64);
+  });
+});
+
+describe('priceUsage', () => {
+  it('charges spoken output more than listened input', () => {
+    const listened = priceUsage('gpt-realtime', { audioInputTokens: 1_000_000 });
+    const spoken = priceUsage('gpt-realtime', { audioOutputTokens: 1_000_000 });
+    expect(spoken.totalCostEur).toBeGreaterThan(listened.totalCostEur);
+  });
+
+  it('converts to euro at the documented rate', () => {
+    const priced = priceUsage('gpt-realtime', { audioInputTokens: 1_000_000 });
+    expect(priced.audioInputCostEur).toBeCloseTo(32 / USD_PER_EUR, 4);
+  });
+
+  it('never credits money back for a corrupted event', () => {
+    const priced = priceUsage('gpt-realtime', {
+      audioInputTokens: -5_000_000,
+      audioOutputTokens: Number.NaN,
+    });
+    expect(priced.totalCostEur).toBe(0);
+  });
+
+  it('keeps a single short answer visible instead of rounding it to nothing', () => {
+    // ~10 seconds of speech. If this rounds to 0.00 the per-user totals are lies.
+    const priced = priceUsage('gpt-realtime-mini', { audioOutputTokens: 1000 });
+    expect(priced.totalCostEur).toBeGreaterThan(0);
+  });
+});
+
+describe('parseRealtimeUsage', () => {
+  it('reads the block Azure actually sends on response.done', () => {
+    const usage = parseRealtimeUsage({
+      total_tokens: 1500,
+      input_tokens: 1000,
+      output_tokens: 500,
+      input_token_details: { text_tokens: 200, audio_tokens: 800, cached_tokens: 128 },
+      output_token_details: { text_tokens: 100, audio_tokens: 400 },
+    });
+
+    expect(usage.audioInputTokens).toBe(800);
+    expect(usage.audioOutputTokens).toBe(400);
+    expect(usage.textInputTokens).toBe(200);
+    expect(usage.textOutputTokens).toBe(100);
+    expect(usage.cachedInputTokens).toBe(128);
+  });
+
+  it('returns zeros instead of throwing inside the event loop', () => {
+    for (const bad of [null, undefined, 'nonsense', 42, {}]) {
+      expect(parseRealtimeUsage(bad).audioOutputTokens).toBe(0);
+    }
+  });
+});

--- a/apps/web/src/lib/metrics/__tests__/voice-usage-service.test.ts
+++ b/apps/web/src/lib/metrics/__tests__/voice-usage-service.test.ts
@@ -1,0 +1,179 @@
+/**
+ * The contracts that make a cost dashboard trustworthy: a broken usage event
+ * must never credit money back, cost accounting must never be able to break a
+ * child's conversation, and the admin console and the CLI must agree because
+ * they read the same numbers.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', async () => {
+  const { createMockPrisma } = await import('@/test/mocks/prisma');
+  return { prisma: createMockPrisma() };
+});
+
+import { prisma } from '@/lib/db';
+import {
+  dayKey,
+  getVoiceSpendByUser,
+  getVoiceSpendSummary,
+  recordVoiceUsage,
+  windowStart,
+} from '../voice-usage-service';
+
+const AZURE_USAGE = {
+  input_token_details: { text_tokens: 100, audio_tokens: 2000, cached_tokens: 0 },
+  output_token_details: { text_tokens: 50, audio_tokens: 3000 },
+};
+
+describe('recordVoiceUsage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('stores a priced row from a real Azure usage block', async () => {
+    vi.mocked(prisma.voiceUsageEvent.create).mockResolvedValue({} as never);
+
+    const result = await recordVoiceUsage({
+      userId: 'user-1',
+      sessionId: 'sess-1',
+      maestroId: 'loto',
+      model: 'gpt-realtime',
+      usage: AZURE_USAGE,
+    });
+
+    expect(result?.costEur).toBeGreaterThan(0);
+    const row = vi.mocked(prisma.voiceUsageEvent.create).mock.calls[0][0].data;
+    expect(row.audioOutputTokens).toBe(3000);
+    expect(row.periodDay).toBe(dayKey(new Date()));
+    expect(row.costEur).toBeGreaterThan(0);
+  });
+
+  it('stores nothing when a turn cost nothing', async () => {
+    const result = await recordVoiceUsage({
+      userId: 'user-1',
+      sessionId: 'sess-1',
+      model: 'gpt-realtime',
+      usage: { input_token_details: {}, output_token_details: {} },
+    });
+
+    expect(result).toBeNull();
+    expect(prisma.voiceUsageEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('never lets accounting break a conversation', async () => {
+    vi.mocked(prisma.voiceUsageEvent.create).mockRejectedValue(new Error('database on fire'));
+
+    await expect(
+      recordVoiceUsage({
+        userId: 'user-1',
+        sessionId: 'sess-1',
+        model: 'gpt-realtime',
+        usage: AZURE_USAGE,
+      }),
+    ).resolves.toBeNull(); // a lost row, not a silent robot
+  });
+
+  it('stores no transcript, ever', async () => {
+    vi.mocked(prisma.voiceUsageEvent.create).mockResolvedValue({} as never);
+
+    await recordVoiceUsage({
+      userId: 'user-1',
+      sessionId: 'sess-1',
+      model: 'gpt-realtime',
+      usage: { ...AZURE_USAGE, transcript: 'mi fa male la pancia' },
+    });
+
+    const row = JSON.stringify(vi.mocked(prisma.voiceUsageEvent.create).mock.calls[0][0].data);
+    expect(row).not.toContain('pancia');
+  });
+});
+
+describe('windowStart', () => {
+  const now = new Date('2026-08-05T14:00:00.000Z');
+
+  it('counts a day from midnight, not from 24 hours ago', () => {
+    expect(windowStart('day', now).toISOString()).toBe('2026-08-05T00:00:00.000Z');
+  });
+
+  it('counts a month from the first of the month', () => {
+    expect(windowStart('month', now).toISOString()).toBe('2026-08-01T00:00:00.000Z');
+  });
+
+  it('counts a week as the last seven days', () => {
+    expect(windowStart('week', now).toISOString()).toBe('2026-07-29T14:00:00.000Z');
+  });
+});
+
+describe('getVoiceSpendByUser', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('ranks the most expensive user first and counts sessions, not turns', async () => {
+    vi.mocked(prisma.voiceUsageEvent.findMany).mockResolvedValue([
+      {
+        userId: 'cheap',
+        sessionId: 's1',
+        audioInputTokens: 10,
+        audioOutputTokens: 10,
+        costEur: 0.01,
+        user: { email: 'a@b.c', name: 'A' },
+      },
+      {
+        userId: 'dear',
+        sessionId: 's2',
+        audioInputTokens: 100,
+        audioOutputTokens: 6000,
+        costEur: 0.5,
+        user: { email: 'd@b.c', name: 'D' },
+      },
+      {
+        userId: 'dear',
+        sessionId: 's2',
+        audioInputTokens: 100,
+        audioOutputTokens: 6000,
+        costEur: 0.5,
+        user: { email: 'd@b.c', name: 'D' },
+      },
+    ] as never);
+
+    const rows = await getVoiceSpendByUser('day');
+
+    expect(rows[0].userId).toBe('dear');
+    expect(rows[0].costEur).toBeCloseTo(1.0, 4);
+    expect(rows[0].sessions).toBe(1); // two turns of one session
+    expect(rows[0].spokenMinutes).toBeGreaterThan(0);
+  });
+
+  it('excludes test data, so the bill is not inflated by CI', async () => {
+    vi.mocked(prisma.voiceUsageEvent.findMany).mockResolvedValue([] as never);
+
+    await getVoiceSpendByUser('month');
+
+    const where = vi.mocked(prisma.voiceUsageEvent.findMany).mock.calls[0]?.[0]?.where;
+    expect(where?.isTestData).toBe(false);
+  });
+});
+
+describe('getVoiceSpendSummary', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reports cost per active user, which is the number worth watching', async () => {
+    vi.mocked(prisma.voiceUsageEvent.findMany).mockResolvedValue([
+      { userId: 'u1', costEur: 1, periodDay: '2026-08-04' },
+      { userId: 'u2', costEur: 3, periodDay: '2026-08-05' },
+    ] as never);
+
+    const summary = await getVoiceSpendSummary('month');
+
+    expect(summary.totalCostEur).toBe(4);
+    expect(summary.activeUsers).toBe(2);
+    expect(summary.costPerUserEur).toBe(2);
+    expect(summary.byDay.map((d) => d.day)).toEqual(['2026-08-04', '2026-08-05']);
+  });
+
+  it('does not divide by zero on a quiet month', async () => {
+    vi.mocked(prisma.voiceUsageEvent.findMany).mockResolvedValue([] as never);
+
+    const summary = await getVoiceSpendSummary('month');
+
+    expect(summary.costPerUserEur).toBe(0);
+  });
+});

--- a/apps/web/src/lib/metrics/voice-model.ts
+++ b/apps/web/src/lib/metrics/voice-model.ts
@@ -1,0 +1,53 @@
+/**
+ * Which Azure realtime deployment a voice turn actually used.
+ *
+ * The browser must not get a vote. Azure's `response.done` often omits
+ * `response.model`, and a client-supplied default of "gpt-realtime" prices
+ * every turn at the premium rate — a cost dashboard that is confidently wrong
+ * is worse than no dashboard.
+ *
+ * Usage is only reported from the WebRTC path, which always connects with the
+ * deployment `/api/realtime/ephemeral-token` chose. So the honest answer is to
+ * repeat that endpoint's resolution, feature flags included.
+ */
+
+import { isFeatureEnabled } from '@/lib/feature-flags/feature-flags-service';
+
+const FALLBACK = 'gpt-realtime';
+
+function env(name: string): string | undefined {
+  return process.env[name]?.trim() || undefined;
+}
+
+/**
+ * @param reported the model Azure named on `response.done`, when it named one.
+ */
+export async function resolveVoiceModel(reported?: string | null): Promise<string> {
+  // If Azure itself named the model, that is the truth and beats any guess.
+  const named = reported?.trim();
+  if (named) return named;
+
+  const legacy = env('AZURE_OPENAI_REALTIME_DEPLOYMENT');
+  const v15 = env('AZURE_OPENAI_REALTIME_DEPLOYMENT_V15');
+  const v2 = env('AZURE_OPENAI_REALTIME_DEPLOYMENT_V2');
+  const v21 = env('AZURE_OPENAI_REALTIME_DEPLOYMENT_V21');
+
+  // Same precedence as the token endpoint (ADR 0165, ADR 0169).
+  const [use21, use2, use15] = await Promise.all([
+    isFeatureEnabled('voice_realtime_21'),
+    isFeatureEnabled('voice_realtime_2'),
+    isFeatureEnabled('voice_realtime_15'),
+  ]);
+
+  const resolved = use21.enabled
+    ? v21 || v2 || v15 || legacy
+    : use2.enabled
+      ? v2 || v15 || legacy
+      : use15.enabled
+        ? v15 || legacy
+        : legacy;
+
+  // Nothing configured: name the premium model so the turn is priced at the
+  // dearer rate. Overstating is recoverable; understating the bill is not.
+  return resolved || FALLBACK;
+}

--- a/apps/web/src/lib/metrics/voice-pricing.ts
+++ b/apps/web/src/lib/metrics/voice-pricing.ts
@@ -21,6 +21,10 @@ export interface TokenUsage {
   textInputTokens: number;
   textOutputTokens: number;
   cachedInputTokens: number;
+  /** The cached half of `audioInputTokens` — already counted there by Azure. */
+  cachedAudioTokens: number;
+  /** The cached half of `textInputTokens` — already counted there by Azure. */
+  cachedTextTokens: number;
 }
 
 export interface ModelRates {
@@ -92,12 +96,21 @@ export function priceUsage(model: string, usage: Partial<TokenUsage>): PricedUsa
   const perToken = (tokens: number, usdPerMillion: number): number =>
     (tokens / 1_000_000) * (usdPerMillion / USD_PER_EUR);
 
-  const audioInputCostEur = perToken(safe(usage.audioInputTokens), rates.audioIn);
+  // Azure counts cached tokens *inside* the input totals. Billing the cached
+  // bucket on top of them would charge the same token twice, which is exactly
+  // the kind of quiet inaccuracy that makes a cost dashboard worthless.
+  const cachedAudio = Math.min(safe(usage.cachedAudioTokens), safe(usage.audioInputTokens));
+  const cachedText = Math.min(safe(usage.cachedTextTokens), safe(usage.textInputTokens));
+  const uncachedAudioIn = Math.max(safe(usage.audioInputTokens) - cachedAudio, 0);
+  const uncachedTextIn = Math.max(safe(usage.textInputTokens) - cachedText, 0);
+
+  const audioInputCostEur =
+    perToken(uncachedAudioIn, rates.audioIn) + perToken(cachedAudio, rates.cachedIn);
   const audioOutputCostEur = perToken(safe(usage.audioOutputTokens), rates.audioOut);
   const textCostEur =
-    perToken(safe(usage.textInputTokens), rates.textIn) +
-    perToken(safe(usage.textOutputTokens), rates.textOut) +
-    perToken(safe(usage.cachedInputTokens), rates.cachedIn);
+    perToken(uncachedTextIn, rates.textIn) +
+    perToken(cachedText, rates.cachedIn) +
+    perToken(safe(usage.textOutputTokens), rates.textOut);
 
   return {
     audioInputCostEur: round6(audioInputCostEur),
@@ -121,6 +134,8 @@ export function parseRealtimeUsage(raw: unknown): TokenUsage {
     textInputTokens: 0,
     textOutputTokens: 0,
     cachedInputTokens: 0,
+    cachedAudioTokens: 0,
+    cachedTextTokens: 0,
   };
   if (typeof raw !== 'object' || raw === null) return empty;
 
@@ -145,5 +160,7 @@ export function parseRealtimeUsage(raw: unknown): TokenUsage {
     textInputTokens: num(input.text_tokens),
     textOutputTokens: num(output.text_tokens),
     cachedInputTokens: num(input.cached_tokens) || num(cachedDetails.audio_tokens),
+    cachedAudioTokens: num(cachedDetails.audio_tokens) || num(input.cached_tokens),
+    cachedTextTokens: num(cachedDetails.text_tokens),
   };
 }

--- a/apps/web/src/lib/metrics/voice-pricing.ts
+++ b/apps/web/src/lib/metrics/voice-pricing.ts
@@ -1,0 +1,149 @@
+/**
+ * What a spoken minute actually costs.
+ *
+ * Until now the answer was unknowable: `voiceMinutes` was never recorded
+ * anywhere, so every voice cost in the database was zero. Wall-clock minutes
+ * would not have been the right unit anyway — Azure bills the Realtime API by
+ * token, and audio tokens are charged at a very different rate from text, in
+ * both directions. Silence is cheap; a talkative maestro is not.
+ *
+ * So we price what Azure prices: the usage block it sends back on every
+ * `response.done`.
+ *
+ * Rates are USD per 1M tokens, from Azure OpenAI public pricing (verified
+ * 2026-08). They can be overridden with AZURE_VOICE_RATES_JSON without a
+ * deploy, because published prices change more often than releases do.
+ */
+
+export interface TokenUsage {
+  audioInputTokens: number;
+  audioOutputTokens: number;
+  textInputTokens: number;
+  textOutputTokens: number;
+  cachedInputTokens: number;
+}
+
+export interface ModelRates {
+  audioIn: number;
+  audioOut: number;
+  textIn: number;
+  textOut: number;
+  cachedIn: number;
+}
+
+/** USD per 1M tokens. */
+const DEFAULT_RATES: Record<string, ModelRates> = {
+  'gpt-realtime': { audioIn: 32, audioOut: 64, textIn: 4, textOut: 16, cachedIn: 0.4 },
+  'gpt-realtime-mini': { audioIn: 10, audioOut: 20, textIn: 0.6, textOut: 2.4, cachedIn: 0.06 },
+  'gpt-realtime-15': { audioIn: 32, audioOut: 64, textIn: 4, textOut: 16, cachedIn: 0.4 },
+  'gpt-realtime-2': { audioIn: 32, audioOut: 64, textIn: 4, textOut: 16, cachedIn: 0.4 },
+};
+
+/**
+ * Unknown deployments are priced at the most expensive known rate rather than
+ * zero. A new model must never make the bill look like it disappeared.
+ */
+const FALLBACK_MODEL = 'gpt-realtime';
+
+export const USD_PER_EUR = 1.08;
+
+function overrides(): Record<string, ModelRates> {
+  const raw = process.env.AZURE_VOICE_RATES_JSON;
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, ModelRates>)
+      : {};
+  } catch {
+    return {}; // A malformed override must not take pricing down with it.
+  }
+}
+
+/** Matches a deployment name to its rate card, tolerating suffixes and casing. */
+export function ratesFor(model: string): ModelRates {
+  const name = (model || '').trim().toLowerCase();
+  const table = { ...DEFAULT_RATES, ...overrides() };
+  if (table[name]) return table[name];
+  const known = Object.keys(table)
+    .filter((candidate) => name.startsWith(candidate))
+    .sort((a, b) => b.length - a.length)[0];
+  return table[known ?? FALLBACK_MODEL] ?? DEFAULT_RATES[FALLBACK_MODEL];
+}
+
+export interface PricedUsage {
+  audioInputCostEur: number;
+  audioOutputCostEur: number;
+  textCostEur: number;
+  totalCostEur: number;
+}
+
+const round6 = (value: number): number => Math.round(value * 1e6) / 1e6;
+
+/**
+ * Prices one usage block. Negative or non-finite counts are treated as zero:
+ * a corrupted event must never credit money back to a user's total.
+ */
+export function priceUsage(model: string, usage: Partial<TokenUsage>): PricedUsage {
+  const rates = ratesFor(model);
+  const safe = (value: number | undefined): number =>
+    Number.isFinite(value) && (value as number) > 0 ? (value as number) : 0;
+
+  const perToken = (tokens: number, usdPerMillion: number): number =>
+    (tokens / 1_000_000) * (usdPerMillion / USD_PER_EUR);
+
+  const audioInputCostEur = perToken(safe(usage.audioInputTokens), rates.audioIn);
+  const audioOutputCostEur = perToken(safe(usage.audioOutputTokens), rates.audioOut);
+  const textCostEur =
+    perToken(safe(usage.textInputTokens), rates.textIn) +
+    perToken(safe(usage.textOutputTokens), rates.textOut) +
+    perToken(safe(usage.cachedInputTokens), rates.cachedIn);
+
+  return {
+    audioInputCostEur: round6(audioInputCostEur),
+    audioOutputCostEur: round6(audioOutputCostEur),
+    textCostEur: round6(textCostEur),
+    totalCostEur: round6(audioInputCostEur + audioOutputCostEur + textCostEur),
+  };
+}
+
+/**
+ * Reads the usage block Azure sends on `response.done`.
+ *
+ * The shape has changed across API versions — `input_token_details` has been
+ * seen both nested under `usage` and flattened — so both are accepted, and an
+ * unrecognised shape yields zeros rather than throwing inside the event loop.
+ */
+export function parseRealtimeUsage(raw: unknown): TokenUsage {
+  const empty: TokenUsage = {
+    audioInputTokens: 0,
+    audioOutputTokens: 0,
+    textInputTokens: 0,
+    textOutputTokens: 0,
+    cachedInputTokens: 0,
+  };
+  if (typeof raw !== 'object' || raw === null) return empty;
+
+  const usage = raw as Record<string, unknown>;
+  const details = (key: string): Record<string, unknown> => {
+    const nested = usage[key];
+    return typeof nested === 'object' && nested !== null ? (nested as Record<string, unknown>) : {};
+  };
+  const num = (value: unknown): number =>
+    typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+
+  const input = details('input_token_details');
+  const output = details('output_token_details');
+  const cachedDetails =
+    typeof input.cached_tokens_details === 'object' && input.cached_tokens_details !== null
+      ? (input.cached_tokens_details as Record<string, unknown>)
+      : {};
+
+  return {
+    audioInputTokens: num(input.audio_tokens),
+    audioOutputTokens: num(output.audio_tokens),
+    textInputTokens: num(input.text_tokens),
+    textOutputTokens: num(output.text_tokens),
+    cachedInputTokens: num(input.cached_tokens) || num(cachedDetails.audio_tokens),
+  };
+}

--- a/apps/web/src/lib/metrics/voice-usage-queries.ts
+++ b/apps/web/src/lib/metrics/voice-usage-queries.ts
@@ -1,0 +1,156 @@
+/**
+ * Voice spend queries, with the Prisma client passed in.
+ *
+ * Kept apart from `voice-usage-service` because that module imports the Next
+ * app's db shim, which imports `server-only` and therefore throws the moment a
+ * plain Node script touches it. The CLI needs the same numbers as the admin
+ * console; it must not need Next to get them.
+ */
+
+import type { Period, UserVoiceSpend } from './voice-usage-types';
+import { windowStart } from './voice-usage-types';
+
+/**
+ * The slice of Prisma these queries need — anything shaped like this will do.
+ *
+ * Deliberately method syntax: Prisma's `findMany` is generic and constrained,
+ * so a property-syntax signature is checked contravariantly and the real client
+ * would not be assignable to it.
+ */
+export interface VoiceUsageDb {
+  voiceUsageEvent: {
+    findMany(args: unknown): Promise<unknown[]>;
+  };
+}
+
+const AUDIO_TOKENS_PER_SECOND = 10;
+
+const round = (value: number): number => Math.round(value * 10_000) / 10_000;
+
+interface SpendRow {
+  sessionId: string;
+  audioInputTokens: number;
+  audioOutputTokens: number;
+  costEur: number;
+}
+
+function summarise(
+  userId: string,
+  email: string | null,
+  name: string | null,
+  rows: SpendRow[],
+): UserVoiceSpend {
+  const sessions = new Set(rows.map((row) => row.sessionId));
+  const audioInputTokens = rows.reduce((sum, row) => sum + row.audioInputTokens, 0);
+  const audioOutputTokens = rows.reduce((sum, row) => sum + row.audioOutputTokens, 0);
+  const costEur = rows.reduce((sum, row) => sum + row.costEur, 0);
+
+  return {
+    userId,
+    email,
+    name,
+    sessions: sessions.size,
+    audioInputTokens,
+    audioOutputTokens,
+    costEur: round(costEur),
+    spokenMinutes: round(audioOutputTokens / AUDIO_TOKENS_PER_SECOND / 60),
+  };
+}
+
+/** What one user has spent on voice in the window. */
+export async function queryUserVoiceSpend(
+  db: VoiceUsageDb,
+  userId: string,
+  period: Period = 'day',
+  now: Date = new Date(),
+): Promise<UserVoiceSpend> {
+  const rows = (await db.voiceUsageEvent.findMany({
+    where: { userId, isTestData: false, createdAt: { gte: windowStart(period, now) } },
+    select: {
+      sessionId: true,
+      audioInputTokens: true,
+      audioOutputTokens: true,
+      costEur: true,
+    },
+  })) as SpendRow[];
+
+  return summarise(userId, null, null, rows);
+}
+
+/** Every user with voice spend in the window, dearest first. */
+export async function queryVoiceSpendByUser(
+  db: VoiceUsageDb,
+  period: Period = 'day',
+  now: Date = new Date(),
+  limit = 100,
+): Promise<UserVoiceSpend[]> {
+  const rows = (await db.voiceUsageEvent.findMany({
+    where: { isTestData: false, createdAt: { gte: windowStart(period, now) } },
+    select: {
+      userId: true,
+      sessionId: true,
+      audioInputTokens: true,
+      audioOutputTokens: true,
+      costEur: true,
+      user: { select: { email: true, username: true } },
+    },
+  })) as (SpendRow & {
+    userId: string;
+    user?: { email: string | null; username: string | null } | null;
+  })[];
+
+  const byUser = new Map<string, typeof rows>();
+  for (const row of rows) {
+    const bucket = byUser.get(row.userId) ?? [];
+    bucket.push(row);
+    byUser.set(row.userId, bucket);
+  }
+
+  return [...byUser.entries()]
+    .map(([userId, userRows]) =>
+      summarise(
+        userId,
+        userRows[0]?.user?.email ?? null,
+        userRows[0]?.user?.username ?? null,
+        userRows,
+      ),
+    )
+    .sort((a, b) => b.costEur - a.costEur)
+    .slice(0, limit);
+}
+
+/** Totals plus a per-day series, for the admin console chart. */
+export async function queryVoiceSpendSummary(
+  db: VoiceUsageDb,
+  period: Period = 'month',
+  now: Date = new Date(),
+): Promise<{
+  totalCostEur: number;
+  activeUsers: number;
+  costPerUserEur: number;
+  byDay: { day: string; costEur: number }[];
+}> {
+  const rows = (await db.voiceUsageEvent.findMany({
+    where: { isTestData: false, createdAt: { gte: windowStart(period, now) } },
+    select: { userId: true, costEur: true, periodDay: true },
+  })) as { userId: string; costEur: number; periodDay: string }[];
+
+  const perDay = new Map<string, number>();
+  const users = new Set<string>();
+  let totalCostEur = 0;
+
+  for (const row of rows) {
+    totalCostEur += row.costEur;
+    users.add(row.userId);
+    perDay.set(row.periodDay, (perDay.get(row.periodDay) ?? 0) + row.costEur);
+  }
+
+  return {
+    totalCostEur: round(totalCostEur),
+    activeUsers: users.size,
+    costPerUserEur: users.size ? round(totalCostEur / users.size) : 0,
+    byDay: [...perDay.entries()]
+      .map(([day, costEur]) => ({ day, costEur: round(costEur) }))
+      .sort((a, b) => a.day.localeCompare(b.day)),
+  };
+}

--- a/apps/web/src/lib/metrics/voice-usage-service.ts
+++ b/apps/web/src/lib/metrics/voice-usage-service.ts
@@ -1,0 +1,229 @@
+/**
+ * Per-user voice spend, by day, week and month.
+ *
+ * The question Roberto asked — "how much are we spending on voice, per user,
+ * per day" — had no answer before this: `voiceMinutes` was never written, so
+ * every voice cost in the database was zero. These functions answer it from
+ * real Azure usage blocks, and they are shared by the admin console and the
+ * CLI so the two can never disagree.
+ */
+
+import { prisma } from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { parseRealtimeUsage, priceUsage, type TokenUsage } from './voice-pricing';
+
+export type Period = 'day' | 'week' | 'month';
+
+export interface RecordVoiceUsageInput {
+  userId: string;
+  sessionId: string;
+  maestroId?: string | null;
+  model: string;
+  usage: unknown;
+  isTestData?: boolean;
+}
+
+export interface UserVoiceSpend {
+  userId: string;
+  email: string | null;
+  name: string | null;
+  sessions: number;
+  audioInputTokens: number;
+  audioOutputTokens: number;
+  costEur: number;
+  /** Roughly how long the maestro spoke, at ~10 audio tokens per second. */
+  spokenMinutes: number;
+}
+
+const AUDIO_TOKENS_PER_SECOND = 10;
+
+export function dayKey(when: Date): string {
+  return when.toISOString().slice(0, 10);
+}
+
+export function monthKey(when: Date): string {
+  return when.toISOString().slice(0, 7);
+}
+
+/** Start of the window, inclusive. Weeks are the last 7 days, not ISO weeks. */
+export function windowStart(period: Period, now: Date = new Date()): Date {
+  const start = new Date(now);
+  if (period === 'day') start.setUTCHours(0, 0, 0, 0);
+  if (period === 'week') start.setUTCDate(start.getUTCDate() - 7);
+  if (period === 'month') {
+    start.setUTCDate(1);
+    start.setUTCHours(0, 0, 0, 0);
+  }
+  return start;
+}
+
+/**
+ * Stores one priced turn.
+ *
+ * Never throws: cost accounting must not be able to break a child's
+ * conversation. A lost row is a small accounting error; a thrown exception in
+ * the voice path is a robot that stops talking.
+ */
+export async function recordVoiceUsage(
+  input: RecordVoiceUsageInput,
+): Promise<{ costEur: number; tokens: TokenUsage } | null> {
+  try {
+    const tokens = parseRealtimeUsage(input.usage);
+    const billable =
+      tokens.audioInputTokens +
+      tokens.audioOutputTokens +
+      tokens.textInputTokens +
+      tokens.textOutputTokens;
+    if (billable <= 0) return null; // nothing was spent, nothing to store
+
+    const priced = priceUsage(input.model, tokens);
+    const now = new Date();
+
+    await prisma.voiceUsageEvent.create({
+      data: {
+        userId: input.userId,
+        sessionId: input.sessionId,
+        maestroId: input.maestroId ?? null,
+        model: input.model,
+        audioInputTokens: tokens.audioInputTokens,
+        audioOutputTokens: tokens.audioOutputTokens,
+        textInputTokens: tokens.textInputTokens,
+        textOutputTokens: tokens.textOutputTokens,
+        cachedInputTokens: tokens.cachedInputTokens,
+        costEur: priced.totalCostEur,
+        periodDay: dayKey(now),
+        periodMonth: monthKey(now),
+        isTestData: input.isTestData ?? false,
+      },
+    });
+
+    return { costEur: priced.totalCostEur, tokens };
+  } catch (error) {
+    logger.error('[VoiceUsage] Failed to record usage', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/** What one user has spent on voice in the window. */
+export async function getUserVoiceSpend(
+  userId: string,
+  period: Period = 'day',
+  now: Date = new Date(),
+): Promise<UserVoiceSpend> {
+  const rows = await prisma.voiceUsageEvent.findMany({
+    where: { userId, isTestData: false, createdAt: { gte: windowStart(period, now) } },
+    select: {
+      sessionId: true,
+      audioInputTokens: true,
+      audioOutputTokens: true,
+      costEur: true,
+    },
+  });
+
+  return summarise(userId, null, null, rows);
+}
+
+/** Every user with voice spend in the window, dearest first. */
+export async function getVoiceSpendByUser(
+  period: Period = 'day',
+  now: Date = new Date(),
+  limit = 100,
+): Promise<UserVoiceSpend[]> {
+  const rows = await prisma.voiceUsageEvent.findMany({
+    where: { isTestData: false, createdAt: { gte: windowStart(period, now) } },
+    select: {
+      userId: true,
+      sessionId: true,
+      audioInputTokens: true,
+      audioOutputTokens: true,
+      costEur: true,
+      user: { select: { email: true, username: true } },
+    },
+  });
+
+  const byUser = new Map<string, typeof rows>();
+  for (const row of rows) {
+    const bucket = byUser.get(row.userId) ?? [];
+    bucket.push(row);
+    byUser.set(row.userId, bucket);
+  }
+
+  return [...byUser.entries()]
+    .map(([userId, userRows]) =>
+      summarise(
+        userId,
+        userRows[0]?.user?.email ?? null,
+        userRows[0]?.user?.username ?? null,
+        userRows,
+      ),
+    )
+    .sort((a, b) => b.costEur - a.costEur)
+    .slice(0, limit);
+}
+
+/** Totals plus a per-day series, for the admin console chart. */
+export async function getVoiceSpendSummary(
+  period: Period = 'month',
+  now: Date = new Date(),
+): Promise<{
+  totalCostEur: number;
+  activeUsers: number;
+  costPerUserEur: number;
+  byDay: { day: string; costEur: number }[];
+}> {
+  const rows = await prisma.voiceUsageEvent.findMany({
+    where: { isTestData: false, createdAt: { gte: windowStart(period, now) } },
+    select: { userId: true, costEur: true, periodDay: true },
+  });
+
+  const perDay = new Map<string, number>();
+  const users = new Set<string>();
+  let totalCostEur = 0;
+
+  for (const row of rows) {
+    totalCostEur += row.costEur;
+    users.add(row.userId);
+    perDay.set(row.periodDay, (perDay.get(row.periodDay) ?? 0) + row.costEur);
+  }
+
+  return {
+    totalCostEur: round(totalCostEur),
+    activeUsers: users.size,
+    costPerUserEur: users.size ? round(totalCostEur / users.size) : 0,
+    byDay: [...perDay.entries()]
+      .map(([day, costEur]) => ({ day, costEur: round(costEur) }))
+      .sort((a, b) => a.day.localeCompare(b.day)),
+  };
+}
+
+function summarise(
+  userId: string,
+  email: string | null,
+  name: string | null,
+  rows: {
+    sessionId: string;
+    audioInputTokens: number;
+    audioOutputTokens: number;
+    costEur: number;
+  }[],
+): UserVoiceSpend {
+  const sessions = new Set(rows.map((row) => row.sessionId));
+  const audioInputTokens = rows.reduce((sum, row) => sum + row.audioInputTokens, 0);
+  const audioOutputTokens = rows.reduce((sum, row) => sum + row.audioOutputTokens, 0);
+  const costEur = rows.reduce((sum, row) => sum + row.costEur, 0);
+
+  return {
+    userId,
+    email,
+    name,
+    sessions: sessions.size,
+    audioInputTokens,
+    audioOutputTokens,
+    costEur: round(costEur),
+    spokenMinutes: round(audioOutputTokens / AUDIO_TOKENS_PER_SECOND / 60),
+  };
+}
+
+const round = (value: number): number => Math.round(value * 10000) / 10000;

--- a/apps/web/src/lib/metrics/voice-usage-service.ts
+++ b/apps/web/src/lib/metrics/voice-usage-service.ts
@@ -11,8 +11,12 @@
 import { prisma } from '@/lib/db';
 import { logger } from '@/lib/logger';
 import { parseRealtimeUsage, priceUsage, type TokenUsage } from './voice-pricing';
-
-export type Period = 'day' | 'week' | 'month';
+import {
+  queryUserVoiceSpend,
+  queryVoiceSpendByUser,
+  queryVoiceSpendSummary,
+} from './voice-usage-queries';
+import { dayKey, monthKey, windowStart, type Period, type UserVoiceSpend } from './voice-usage-types';
 
 export interface RecordVoiceUsageInput {
   userId: string;
@@ -21,40 +25,6 @@ export interface RecordVoiceUsageInput {
   model: string;
   usage: unknown;
   isTestData?: boolean;
-}
-
-export interface UserVoiceSpend {
-  userId: string;
-  email: string | null;
-  name: string | null;
-  sessions: number;
-  audioInputTokens: number;
-  audioOutputTokens: number;
-  costEur: number;
-  /** Roughly how long the maestro spoke, at ~10 audio tokens per second. */
-  spokenMinutes: number;
-}
-
-const AUDIO_TOKENS_PER_SECOND = 10;
-
-export function dayKey(when: Date): string {
-  return when.toISOString().slice(0, 10);
-}
-
-export function monthKey(when: Date): string {
-  return when.toISOString().slice(0, 7);
-}
-
-/** Start of the window, inclusive. Weeks are the last 7 days, not ISO weeks. */
-export function windowStart(period: Period, now: Date = new Date()): Date {
-  const start = new Date(now);
-  if (period === 'day') start.setUTCHours(0, 0, 0, 0);
-  if (period === 'week') start.setUTCDate(start.getUTCDate() - 7);
-  if (period === 'month') {
-    start.setUTCDate(1);
-    start.setUTCHours(0, 0, 0, 0);
-  }
-  return start;
 }
 
 /**
@@ -106,124 +76,23 @@ export async function recordVoiceUsage(
   }
 }
 
+export { dayKey, monthKey, windowStart };
+export type { Period, UserVoiceSpend };
+
 /** What one user has spent on voice in the window. */
-export async function getUserVoiceSpend(
+export const getUserVoiceSpend = (
   userId: string,
   period: Period = 'day',
   now: Date = new Date(),
-): Promise<UserVoiceSpend> {
-  const rows = await prisma.voiceUsageEvent.findMany({
-    where: { userId, isTestData: false, createdAt: { gte: windowStart(period, now) } },
-    select: {
-      sessionId: true,
-      audioInputTokens: true,
-      audioOutputTokens: true,
-      costEur: true,
-    },
-  });
-
-  return summarise(userId, null, null, rows);
-}
+): Promise<UserVoiceSpend> => queryUserVoiceSpend(prisma, userId, period, now);
 
 /** Every user with voice spend in the window, dearest first. */
-export async function getVoiceSpendByUser(
+export const getVoiceSpendByUser = (
   period: Period = 'day',
   now: Date = new Date(),
   limit = 100,
-): Promise<UserVoiceSpend[]> {
-  const rows = await prisma.voiceUsageEvent.findMany({
-    where: { isTestData: false, createdAt: { gte: windowStart(period, now) } },
-    select: {
-      userId: true,
-      sessionId: true,
-      audioInputTokens: true,
-      audioOutputTokens: true,
-      costEur: true,
-      user: { select: { email: true, username: true } },
-    },
-  });
-
-  const byUser = new Map<string, typeof rows>();
-  for (const row of rows) {
-    const bucket = byUser.get(row.userId) ?? [];
-    bucket.push(row);
-    byUser.set(row.userId, bucket);
-  }
-
-  return [...byUser.entries()]
-    .map(([userId, userRows]) =>
-      summarise(
-        userId,
-        userRows[0]?.user?.email ?? null,
-        userRows[0]?.user?.username ?? null,
-        userRows,
-      ),
-    )
-    .sort((a, b) => b.costEur - a.costEur)
-    .slice(0, limit);
-}
+): Promise<UserVoiceSpend[]> => queryVoiceSpendByUser(prisma, period, now, limit);
 
 /** Totals plus a per-day series, for the admin console chart. */
-export async function getVoiceSpendSummary(
-  period: Period = 'month',
-  now: Date = new Date(),
-): Promise<{
-  totalCostEur: number;
-  activeUsers: number;
-  costPerUserEur: number;
-  byDay: { day: string; costEur: number }[];
-}> {
-  const rows = await prisma.voiceUsageEvent.findMany({
-    where: { isTestData: false, createdAt: { gte: windowStart(period, now) } },
-    select: { userId: true, costEur: true, periodDay: true },
-  });
-
-  const perDay = new Map<string, number>();
-  const users = new Set<string>();
-  let totalCostEur = 0;
-
-  for (const row of rows) {
-    totalCostEur += row.costEur;
-    users.add(row.userId);
-    perDay.set(row.periodDay, (perDay.get(row.periodDay) ?? 0) + row.costEur);
-  }
-
-  return {
-    totalCostEur: round(totalCostEur),
-    activeUsers: users.size,
-    costPerUserEur: users.size ? round(totalCostEur / users.size) : 0,
-    byDay: [...perDay.entries()]
-      .map(([day, costEur]) => ({ day, costEur: round(costEur) }))
-      .sort((a, b) => a.day.localeCompare(b.day)),
-  };
-}
-
-function summarise(
-  userId: string,
-  email: string | null,
-  name: string | null,
-  rows: {
-    sessionId: string;
-    audioInputTokens: number;
-    audioOutputTokens: number;
-    costEur: number;
-  }[],
-): UserVoiceSpend {
-  const sessions = new Set(rows.map((row) => row.sessionId));
-  const audioInputTokens = rows.reduce((sum, row) => sum + row.audioInputTokens, 0);
-  const audioOutputTokens = rows.reduce((sum, row) => sum + row.audioOutputTokens, 0);
-  const costEur = rows.reduce((sum, row) => sum + row.costEur, 0);
-
-  return {
-    userId,
-    email,
-    name,
-    sessions: sessions.size,
-    audioInputTokens,
-    audioOutputTokens,
-    costEur: round(costEur),
-    spokenMinutes: round(audioOutputTokens / AUDIO_TOKENS_PER_SECOND / 60),
-  };
-}
-
-const round = (value: number): number => Math.round(value * 10000) / 10000;
+export const getVoiceSpendSummary = (period: Period = 'month', now: Date = new Date()) =>
+  queryVoiceSpendSummary(prisma, period, now);

--- a/apps/web/src/lib/metrics/voice-usage-types.ts
+++ b/apps/web/src/lib/metrics/voice-usage-types.ts
@@ -1,0 +1,38 @@
+/**
+ * Shapes and window maths shared by the service, the queries, the admin console
+ * and the CLI. Deliberately free of imports so a plain Node script can use it.
+ */
+
+export type Period = 'day' | 'week' | 'month';
+
+export interface UserVoiceSpend {
+  userId: string;
+  email: string | null;
+  name: string | null;
+  sessions: number;
+  audioInputTokens: number;
+  audioOutputTokens: number;
+  costEur: number;
+  /** Roughly how long the maestro spoke, at ~10 audio tokens per second. */
+  spokenMinutes: number;
+}
+
+export function dayKey(when: Date): string {
+  return when.toISOString().slice(0, 10);
+}
+
+export function monthKey(when: Date): string {
+  return when.toISOString().slice(0, 7);
+}
+
+/** Start of the window, inclusive. Weeks are the last 7 days, not ISO weeks. */
+export function windowStart(period: Period, now: Date = new Date()): Date {
+  const start = new Date(now);
+  if (period === 'day') start.setUTCHours(0, 0, 0, 0);
+  if (period === 'week') start.setUTCDate(start.getUTCDate() - 7);
+  if (period === 'month') {
+    start.setUTCDate(1);
+    start.setUTCHours(0, 0, 0, 0);
+  }
+  return start;
+}

--- a/apps/web/src/test/mocks/prisma.ts
+++ b/apps/web/src/test/mocks/prisma.ts
@@ -1,7 +1,7 @@
 /**
  * Centralized Prisma Mock
  *
- * Universal mock for `@/lib/db` — covers all 89 Prisma models.
+ * Universal mock for `@/lib/db` — covers all 90 Prisma models.
  * Generated from prisma/schema/*.prisma.
  *
  * Usage:
@@ -33,7 +33,7 @@ function createModelMock() {
   };
 }
 
-/** Creates a fresh Prisma mock with all 89 models and root methods */
+/** Creates a fresh Prisma mock with all 90 models and root methods */
 export function createMockPrisma() {
   return {
     accessibilitySettings: createModelMock(),
@@ -127,6 +127,7 @@ export function createMockPrisma() {
     userPrivacyPreferences: createModelMock(),
     userSubscription: createModelMock(),
     videoVisionUsage: createModelMock(),
+    voiceUsageEvent: createModelMock(),
     waitlistEntry: createModelMock(),
 
     // Root-level methods

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../../node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../../node_modules

--- a/scripts/validate-pre-deploy.ts
+++ b/scripts/validate-pre-deploy.ts
@@ -213,6 +213,8 @@ function validateOptionalEnvVars(): void {
     { name: 'AZURE_OPENAI_GPT52_CHAT_DEPLOYMENT', category: 'AI Models' },
     { name: 'AZURE_OPENAI_GPT52_EDU_DEPLOYMENT', category: 'AI Models' },
     { name: 'AZURE_OPENAI_REALTIME_DEPLOYMENT_MINI', category: 'AI Models' },
+    // Voice cost accounting — optional override of the built-in rate card
+    { name: 'AZURE_VOICE_RATES_JSON', category: 'Voice costs' },
     // GPT Realtime 1.5 + Audio 1.5 (optional - behind feature flags)
     { name: 'AZURE_OPENAI_REALTIME_DEPLOYMENT_V15', category: 'Voice v1.5' },
     { name: 'AZURE_OPENAI_AUDIO_DEPLOYMENT', category: 'Voice v1.5' },

--- a/scripts/voice-costs.ts
+++ b/scripts/voice-costs.ts
@@ -11,12 +11,16 @@
  * and a script that disagree about the bill are worse than either alone.
  */
 
+// Deliberately not the service module: that one imports the Next app's db
+// shim, which imports `server-only` and throws the moment a plain Node script
+// touches it. Same queries, same numbers, no Next.
+import { prisma } from '@mirrorbuddy/db';
 import {
-  getUserVoiceSpend,
-  getVoiceSpendByUser,
-  getVoiceSpendSummary,
-  type Period,
-} from '../apps/web/src/lib/metrics/voice-usage-service';
+  queryUserVoiceSpend,
+  queryVoiceSpendByUser,
+  queryVoiceSpendSummary,
+} from '../apps/web/src/lib/metrics/voice-usage-queries';
+import type { Period } from '../apps/web/src/lib/metrics/voice-usage-types';
 
 const PERIODS: Period[] = ['day', 'week', 'month'];
 
@@ -38,7 +42,7 @@ async function main(): Promise<void> {
   const userId = arg('user');
 
   if (userId) {
-    const spend = await getUserVoiceSpend(userId, period);
+    const spend = await queryUserVoiceSpend(prisma, userId, period);
     if (asJson) {
       console.log(JSON.stringify(spend, null, 2));
       return;
@@ -51,8 +55,8 @@ async function main(): Promise<void> {
   }
 
   const [summary, users] = await Promise.all([
-    getVoiceSpendSummary(period),
-    getVoiceSpendByUser(period),
+    queryVoiceSpendSummary(prisma, period),
+    queryVoiceSpendByUser(prisma, period),
   ]);
 
   if (asJson) {
@@ -90,5 +94,5 @@ main()
     process.exit(1);
   })
   .finally(() => {
-    void import('../apps/web/src/lib/db').then(({ prisma }) => prisma.$disconnect());
+    void prisma.$disconnect();
   });

--- a/scripts/voice-costs.ts
+++ b/scripts/voice-costs.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env tsx
+/**
+ * Voice costs from the command line.
+ *
+ *   npx tsx scripts/voice-costs.ts                 # today, every user
+ *   npx tsx scripts/voice-costs.ts --period month  # this month
+ *   npx tsx scripts/voice-costs.ts --user <id>     # one user
+ *   npx tsx scripts/voice-costs.ts --json          # for piping
+ *
+ * Reads the same functions the admin console reads, on purpose: a dashboard
+ * and a script that disagree about the bill are worse than either alone.
+ */
+
+import {
+  getUserVoiceSpend,
+  getVoiceSpendByUser,
+  getVoiceSpendSummary,
+  type Period,
+} from '../apps/web/src/lib/metrics/voice-usage-service';
+
+const PERIODS: Period[] = ['day', 'week', 'month'];
+
+function arg(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const euro = (value: number): string => `€${value.toFixed(4)}`;
+
+async function main(): Promise<void> {
+  const requested = arg('period') ?? 'day';
+  if (!PERIODS.includes(requested as Period)) {
+    console.error(`Unknown period "${requested}". Use one of: ${PERIODS.join(', ')}`);
+    process.exit(2);
+  }
+  const period = requested as Period;
+  const asJson = process.argv.includes('--json');
+  const userId = arg('user');
+
+  if (userId) {
+    const spend = await getUserVoiceSpend(userId, period);
+    if (asJson) {
+      console.log(JSON.stringify(spend, null, 2));
+      return;
+    }
+    console.log(`\nVoice spend for ${spend.name || spend.email || userId} — ${period}\n`);
+    console.log(`  sessions       ${spend.sessions}`);
+    console.log(`  spoken minutes ${spend.spokenMinutes.toFixed(1)}`);
+    console.log(`  cost           ${euro(spend.costEur)}\n`);
+    return;
+  }
+
+  const [summary, users] = await Promise.all([
+    getVoiceSpendSummary(period),
+    getVoiceSpendByUser(period),
+  ]);
+
+  if (asJson) {
+    console.log(JSON.stringify({ period, summary, users }, null, 2));
+    return;
+  }
+
+  console.log(`\nVoice costs — ${period}\n`);
+  console.log(`  total          ${euro(summary.totalCostEur)}`);
+  console.log(`  active users   ${summary.activeUsers}`);
+  console.log(`  per user       ${euro(summary.costPerUserEur)}\n`);
+
+  if (users.length === 0) {
+    console.log('  No voice usage recorded in this period.\n');
+    return;
+  }
+
+  const name = (user: (typeof users)[number]): string =>
+    (user.name || user.email || user.userId).slice(0, 28).padEnd(28);
+  console.log(
+    `  ${'user'.padEnd(28)} ${'sess'.padStart(5)} ${'min'.padStart(7)} ${'cost'.padStart(10)}`,
+  );
+  for (const user of users) {
+    console.log(
+      `  ${name(user)} ${String(user.sessions).padStart(5)} ` +
+        `${user.spokenMinutes.toFixed(1).padStart(7)} ${euro(user.costEur).padStart(10)}`,
+    );
+  }
+  console.log('');
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error('voice-costs failed:', error instanceof Error ? error.message : error);
+    process.exit(1);
+  })
+  .finally(() => {
+    void import('../apps/web/src/lib/db').then(({ prisma }) => prisma.$disconnect());
+  });


### PR DESCRIPTION
## Why

Voice cost per user was unknowable. `recordVoiceUsage` existed but **nothing ever called it** — a code comment admitted it "will be used when voice session metrics are implemented". Every voice cost in the database was zero, so the honest answer to "how much are we spending per user per day?" was "we cannot know".

This wires the missing line and makes the number readable two ways.

## What

- **Pricing** (`lib/metrics/voice-pricing.ts`): prices the usage block Azure sends on `response.done`, **per token**. Audio and text tokens are billed very differently (gpt-realtime $32/$64 per 1M audio in/out; mini $10/$20), so wall-clock minutes would have been the wrong unit — they charge silence like speech. Rates are overridable via `AZURE_VOICE_RATES_JSON`; an unknown model prices at the **most expensive** known rate, never zero.
- **Recording** (`lib/metrics/voice-usage-service.ts` + `VoiceUsageEvent`): one row per turn, tokens and cost, day/month buckets. **No transcript is stored** — a test asserts it.
- **Capture** (`voice-session/voice-usage-reporter.ts`): reports each turn from the browser. Strictly fire-and-forget — accounting must never be able to interrupt a child mid-sentence.
- **Reading it back**: `/admin/voice-costs` and `scripts/voice-costs.ts`, both through the same service functions on purpose — a dashboard and a script that disagree about the bill are worse than either alone.

## Note on history

Historical cost data does **not** exist and cannot be reconstructed. Measurement starts the day this ships.

## Verification

- 11972 unit tests pass, lint and typecheck clean
- new code mutation-tested; one survivor (a failed report left as an unhandled rejection) was a real gap and is now covered