### PR TITLE
chore: ignore .serena tool cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ worktrees/
 testingcase/
 study-materials/
 .gstack/
+.serena/
 kanban/todo/
 kanban/doing/
 kanban/done/


### PR DESCRIPTION
Local agent-tooling artifact that was showing up as untracked noise in every `git status`. One line in `.gitignore`.