### PR TITLE
fix(robot): give Buddy the roster, and a body every Maestro can move

### DIFF
--- a/robot/README.md
+++ b/robot/README.md
@@ -75,6 +75,7 @@ model speech stream over a single Azure Realtime WebSocket (`azure_realtime`).
 | `movements.py`          | Expressive full-body motion + daemon face-follow while listening                                   |
 | `camera.py`             | On-demand JPEG capture + daemon head/face tracking helpers                                         |
 | `body_actions.py`       | Named, clamped gestures any Maestro can play (antennas, peekaboo, nod, bow)                        |
+| `body_control.py`       | Gesture dispatch + sustained postures, mixed into `Movements`                                      |
 | `people.py`             | Who is in the room right now — session-only, never written to disk                                 |
 | `tools.py`              | Voice tool schemas (professors, homework, friend/study, who is here, meditation, body) + resolver  |
 | `session_flow.py`       | Pure stop / end / wake decisions for the live loop (accessibility-critical)                        |

--- a/robot/README.md
+++ b/robot/README.md
@@ -74,8 +74,9 @@ model speech stream over a single Azure Realtime WebSocket (`azure_realtime`).
 | `audio_io.py`           | Robot mic ↔ speaker bridge (resampling, playback, barge-in)                                        |
 | `movements.py`          | Expressive full-body motion + daemon face-follow while listening                                   |
 | `camera.py`             | On-demand JPEG capture + daemon head/face tracking helpers                                         |
+| `body_actions.py`       | Named, clamped gestures any Maestro can play (antennas, peekaboo, nod, bow)                        |
 | `people.py`             | Who is in the room right now — session-only, never written to disk                                 |
-| `tools.py`              | Voice tool schemas (list/change professor, look at homework, friend/study, who is here) + resolver |
+| `tools.py`              | Voice tool schemas (professors, homework, friend/study, who is here, meditation, body) + resolver  |
 | `session_flow.py`       | Pure stop / end / wake decisions for the live loop (accessibility-critical)                        |
 | `controller.py`         | Tool dispatch, live professor switching, vision, sleep/wake                                        |
 | `settings_ui.py`        | Minimal in-app settings page (creds + Maestro/DSA selection)                                       |
@@ -87,7 +88,18 @@ Buddy is voice-only, so the model drives the robot through realtime **tools**:
 
 - **Change professor / subject** — say e.g. _«voglio matematica»_ or _«chiama Galileo»_.
   `call_professor` resolves the Maestro and reconnects the session with the new
-  **persona + voice**; the new professor greets. All 26 MirrorBuddy Maestri are available.
+  **persona + voice**; the new professor greets. All 27 MirrorBuddy Maestri are available.
+  The roster is written into the system prompt, so Buddy knows exactly who exists and
+  never claims a professor is unavailable when they are — that is what made
+  _«passami Fratello Loto»_ fail before the roster was injected.
+- **Move the body** — say e.g. _«abbassa le antenne»_, _«nasconditi»_, _«facciamo cucù»_.
+  `move_body` plays a real gesture: `antenne_giu`, `antenne_su`, `nascondi`, `cucu`,
+  `annuisci`, `scuoti`, `guarda_intorno`, `festeggia`, `inchino`, `riposo`. Every Maestro
+  and coach can use it, both on request and on its own initiative — celebrating a right
+  answer, or playing peekaboo. **Antennas stay where you put them** (they are a bias the
+  idle animation honours, not a one-shot pose); head gestures are one-shot, because the
+  head is shared with the face tracker. All poses are clamped well inside the arms' reach,
+  and every action returns to neutral even if the hardware refuses a frame.
 - **Look at homework** — say e.g. _«guarda questo compito»_. `look_at_homework` captures
   one camera frame and the model reads the exercise and helps step by step.
 - **Who is here** — `list_professors` enumerates the available Maestri and their subjects.

--- a/robot/reachy_mini_mirrorbuddy/body_actions.py
+++ b/robot/reachy_mini_mirrorbuddy/body_actions.py
@@ -1,0 +1,172 @@
+"""Named body actions any Maestro can ask the robot to perform.
+
+Roberto's request was simple to say and easy to get wrong: "if I tell it to lower
+its antennas it should lower them, if I say hide, it should hide" — so Mario can
+play peekaboo with Buddy instead of only talking to it.
+
+Two constraints shape everything here. The arms have a real reach, and the device
+already logs "IK error: Collision detected or head pose not achievable!" when we
+ask for too much — an unreachable pose means the robot silently stops mid-game.
+And every action must end where the idle animation expects to find the body,
+otherwise Buddy is left staring at the floor for the rest of the lesson.
+
+So: poses stay well inside the envelope, failures never propagate, and the last
+frame of every action is neutral — including the frames after something broke.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import unicodedata
+
+from .pose_writer import ANTENNA_MAX, ANTENNA_NEUTRAL, clamp_antenna
+
+logger = logging.getLogger(__name__)
+
+# Deliberately conservative: well inside what the arms can do, so a gesture never
+# ends with the robot frozen because the IK gave up.
+MAX_HEAD_Z = 0.022  # metres
+MAX_HEAD_ANGLE = 25.0  # degrees
+
+_NEUTRAL = {"z": 0.0, "pitch": 0.0, "yaw": 0.0}
+_UP = clamp_antenna(ANTENNA_MAX * 0.9)
+_DOWN = clamp_antenna(-ANTENNA_MAX * 0.75)
+
+# Each step is (head kwargs, [right, left] antennas, body_yaw, seconds).
+ACTIONS: dict[str, list[tuple[dict, list[float], float, float]]] = {
+    "antenne_giu": [
+        ({}, [_DOWN, _DOWN], 0.0, 0.6),
+    ],
+    "antenne_su": [
+        ({}, [_UP, _UP], 0.0, 0.4),
+    ],
+    "nascondi": [
+        ({"z": -MAX_HEAD_Z, "pitch": 22.0}, [_DOWN, _DOWN], 0.0, 0.7),
+    ],
+    "cucu": [
+        ({"z": -MAX_HEAD_Z, "pitch": 22.0}, [_DOWN, _DOWN], 0.0, 0.6),
+        ({"z": MAX_HEAD_Z, "pitch": -12.0}, [_UP, _UP], 0.0, 0.35),
+        ({"z": -MAX_HEAD_Z, "pitch": 22.0}, [_DOWN, _DOWN], 0.0, 0.5),
+        ({"z": MAX_HEAD_Z, "pitch": -12.0}, [_UP, _UP], 0.0, 0.35),
+    ],
+    "annuisci": [
+        ({"pitch": 18.0}, [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], 0.0, 0.3),
+        ({"pitch": -8.0}, [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], 0.0, 0.3),
+        ({"pitch": 18.0}, [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], 0.0, 0.3),
+    ],
+    "scuoti": [
+        ({"yaw": 20.0}, [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], 0.0, 0.3),
+        ({"yaw": -20.0}, [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], 0.0, 0.3),
+        ({"yaw": 20.0}, [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], 0.0, 0.3),
+    ],
+    "guarda_intorno": [
+        ({"yaw": 24.0}, [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], 0.25, 0.6),
+        ({"yaw": -24.0}, [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], -0.25, 0.6),
+    ],
+    "festeggia": [
+        ({"z": MAX_HEAD_Z, "pitch": -14.0}, [_UP, _DOWN], 0.2, 0.35),
+        ({"z": MAX_HEAD_Z, "pitch": -14.0}, [_DOWN, _UP], -0.2, 0.35),
+        ({"z": MAX_HEAD_Z, "pitch": -14.0}, [_UP, _UP], 0.0, 0.35),
+    ],
+    "inchino": [
+        ({"z": -MAX_HEAD_Z, "pitch": 24.0}, [_DOWN, _DOWN], 0.0, 0.8),
+    ],
+    "riposo": [
+        (_NEUTRAL, [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], 0.0, 0.6),
+    ],
+}
+
+_ALIASES = {
+    "cuccu": "cucu",
+    "peekaboo": "cucu",
+    "nasconditi": "nascondi",
+    "antenne_basse": "antenne_giu",
+    "antenne_alte": "antenne_su",
+    "guardati_intorno": "guarda_intorno",
+    "neutro": "riposo",
+    "fermo": "riposo",
+}
+
+# Postures that must outlive the gesture: the idle animation would otherwise undo
+# them within one frame. Only the antennas can be held this way — the head is
+# shared with the face tracker, so head poses stay one-shot.
+SUSTAINED: dict[str, float] = {
+    "antenne_giu": _DOWN,
+    "antenne_su": _UP,
+    "riposo": 0.0,
+}
+
+
+def normalise(name: str | None) -> str:
+    """Map whatever the model wrote to a canonical action name.
+
+    The model transcribes speech, so it produces "Antenne Giu", "cucù", "cucu'".
+    Accents are stripped rather than mapped one by one: a child saying "cucù" and
+    a model writing "cucu" must reach the same gesture.
+    """
+    text = (name or "").strip().lower().replace("-", " ").replace("'", "")
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(c for c in text if not unicodedata.combining(c))
+    key = "_".join(text.split())
+    return _ALIASES.get(key, key)
+
+
+def describe() -> str:
+    """The action list, for the prompt and the tool schema."""
+    return ", ".join(sorted(ACTIONS))
+
+
+def perform(name: str, robot, create_head_pose, pause=time.sleep) -> bool:
+    """Play one named action, then always return to neutral.
+
+    Returns False for an unknown action so the caller can tell the Maestro to say
+    something honest instead of pretending it moved.
+    """
+    action = normalise(name)
+    steps = ACTIONS.get(action)
+    if steps is None:
+        logger.info("Unknown body action requested: %r", name)
+        return False
+
+    logger.info("Body action: %s", action)
+    try:
+        for head_kwargs, antennas, body_yaw, seconds in steps:
+            _write(robot, create_head_pose, head_kwargs, antennas, body_yaw, seconds)
+            pause(seconds)
+    finally:
+        # Runs even if a step raised: the body must not be abandoned mid-pose.
+        _write(robot, create_head_pose, _NEUTRAL, [ANTENNA_NEUTRAL, ANTENNA_NEUTRAL], 0.0, 0.5)
+    return True
+
+
+def _write(robot, create_head_pose, head_kwargs, antennas, body_yaw, seconds) -> None:
+    """One frame, clamped and failure-proof."""
+    head = None
+    if create_head_pose is not None:
+        try:
+            head = create_head_pose(
+                x=0,
+                y=0,
+                z=_clamp(head_kwargs.get("z", 0.0), MAX_HEAD_Z),
+                roll=0,
+                pitch=_clamp(head_kwargs.get("pitch", 0.0), MAX_HEAD_ANGLE),
+                yaw=_clamp(head_kwargs.get("yaw", 0.0), MAX_HEAD_ANGLE),
+                degrees=True,
+            )
+        except Exception as e:
+            logger.debug("create_head_pose failed for body action: %s", e)
+    try:
+        robot.goto_target(
+            head=head,
+            antennas=[clamp_antenna(antennas[0]), clamp_antenna(antennas[1])],
+            body_yaw=float(body_yaw),
+            duration=max(0.2, float(seconds)),
+        )
+    except Exception as e:
+        # The device really does refuse poses; a game that stutters beats a crash.
+        logger.warning("Body action frame failed: %s", e)
+
+
+def _clamp(value: float, limit: float) -> float:
+    return max(-limit, min(limit, float(value)))

--- a/robot/reachy_mini_mirrorbuddy/body_control.py
+++ b/robot/reachy_mini_mirrorbuddy/body_control.py
@@ -1,0 +1,68 @@
+"""The part of the body that answers commands rather than moods.
+
+Split out of :mod:`movements` because the two have different jobs and different
+reasons to change: the animation loop is a continuous expression of how Buddy
+feels, while this is a small state machine driven by what a child just asked for.
+Keeping them in one file also pushed it past the repository's 250-line cap.
+
+Mixed into :class:`~reachy_mini_mirrorbuddy.movements.Movements`, which owns the
+robot handle, the pose writer and the hold/release mechanism this needs.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from . import body_actions
+from .pose_writer import clamp_antenna
+
+logger = logging.getLogger(__name__)
+
+
+class BodyControlMixin:
+    """Named gestures and sustained postures, on top of the idle animation."""
+
+    @property
+    def antenna_bias(self) -> float:
+        """A posture the animation keeps holding: negative is antennas down."""
+        return self._antenna_bias
+
+    def set_antenna_bias(self, value: float) -> None:
+        """Hold the antennas somewhere other than where the idle animation wants them.
+
+        A one-shot gesture is overwritten within one frame at 50Hz, so "keep your
+        antennas down" has to be an offset the loop itself respects. Non-numeric
+        arguments arrive from the model and are ignored rather than crashing the
+        animation thread.
+        """
+        try:
+            self._antenna_bias = clamp_antenna(float(value))
+        except (TypeError, ValueError):
+            logger.debug("Ignoring non-numeric antenna bias: %r", value)
+
+    def apply_antenna_bias(self, right: float, left: float) -> tuple[float, float]:
+        """Offset the animation's antenna values, still inside the mechanical limit."""
+        bias = self._antenna_bias
+        return clamp_antenna(right + bias), clamp_antenna(left + bias)
+
+    def play_body_action(self, name: str) -> bool:
+        """Perform a named gesture without the idle animation fighting it.
+
+        The animation writes every joint fifty times a second, so a scripted pose
+        has to own the body for its duration — the same mechanism the camera
+        capture uses. Sustained postures are handed to the animation afterwards
+        as a bias, so "keep your antennas down" actually keeps them down.
+        """
+        action = body_actions.normalise(name)
+        if action not in body_actions.ACTIONS:
+            logger.info("Unknown body action: %r", name)
+            return False
+        self.hold_still()
+        try:
+            body_actions.perform(action, self.robot, self._writer.create_head_pose)
+        finally:
+            bias = body_actions.SUSTAINED.get(action)
+            if bias is not None:
+                self.set_antenna_bias(bias)
+            self.release_hold()
+        return True

--- a/robot/reachy_mini_mirrorbuddy/controller.py
+++ b/robot/reachy_mini_mirrorbuddy/controller.py
@@ -99,6 +99,7 @@ class Controller(ToolCallMixin):
             dsa_profile=self.cfg.DSA_PROFILE,
             student_name=self.cfg.STUDENT_NAME,
             roster=self.people,
+            maestri=self.maestri,
         )
         return AzureRealtimeClient(
             ws_url=self.cfg.realtime_ws_url(),

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -15,10 +15,10 @@ import time
 
 import numpy as np
 
-from . import camera, gestures
+from . import body_actions, camera, gestures
 from .temperament import CALM, LIVELY, NEUTRAL, Temperament, temperament_for  # noqa: F401
 from .motion_shapes import idle_pose
-from .pose_writer import ANTENNA_NEUTRAL, PoseWriter
+from .pose_writer import ANTENNA_NEUTRAL, PoseWriter, clamp_antenna
 from .emotions import NEUTRAL as EMOTION_NEUTRAL, Emotion, blend_mood, infer as infer_emotion
 
 logger = logging.getLogger(__name__)
@@ -58,6 +58,7 @@ class Movements:
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._writer = PoseWriter(robot)
+        self._antenna_bias = 0.0
         self._track_weight = -1.0  # unset; managed on speaking transitions
         self._hold = threading.Event()  # when set, freeze all motion (e.g. camera capture)
         # Current mood and the eased values that actually reach the servos. Emotions
@@ -84,6 +85,51 @@ class Movements:
     def express(self, text: str | None) -> None:
         """Colour the body language from what Buddy is about to say."""
         self.set_emotion(infer_emotion(text))
+
+    @property
+    def antenna_bias(self) -> float:
+        """A posture the animation keeps holding: negative is antennas down."""
+        return self._antenna_bias
+
+    def set_antenna_bias(self, value: float) -> None:
+        """Hold the antennas somewhere other than where the idle animation wants them.
+
+        A one-shot gesture is overwritten within one frame at 50Hz, so "keep your
+        antennas down" has to be an offset the loop itself respects. Non-numeric
+        arguments arrive from the model and are ignored rather than crashing the
+        animation thread.
+        """
+        try:
+            self._antenna_bias = clamp_antenna(float(value))
+        except (TypeError, ValueError):
+            logger.debug("Ignoring non-numeric antenna bias: %r", value)
+
+    def apply_antenna_bias(self, right: float, left: float) -> tuple[float, float]:
+        """Offset the animation's antenna values, still inside the mechanical limit."""
+        bias = self._antenna_bias
+        return clamp_antenna(right + bias), clamp_antenna(left + bias)
+
+    def play_body_action(self, name: str) -> bool:
+        """Perform a named gesture without the idle animation fighting it.
+
+        The animation writes every joint fifty times a second, so a scripted pose
+        has to own the body for its duration — the same mechanism the camera
+        capture uses. Sustained postures are handed to the animation afterwards
+        as a bias, so "keep your antennas down" actually keeps them down.
+        """
+        action = body_actions.normalise(name)
+        if action not in body_actions.ACTIONS:
+            logger.info("Unknown body action: %r", name)
+            return False
+        self.hold_still()
+        try:
+            body_actions.perform(action, self.robot, self._writer.create_head_pose)
+        finally:
+            bias = body_actions.SUSTAINED.get(action)
+            if bias is not None:
+                self.set_antenna_bias(bias)
+            self.release_hold()
+        return True
 
     def hold_still(self) -> None:
         """Freeze head/body and pause tracking + wobbler so the camera gets a sharp frame."""
@@ -238,7 +284,8 @@ class Movements:
             # The daemon's face tracker owns the head whenever it is weighted in;
             # we only drive the head once it hands off, so we never fight it.
             drive_head = not (self.follow_face and self._track_weight > 0.0)
+            ant_r, ant_l = self.apply_antenna_bias(o["ant_r"], o["ant_l"])
             self._writer.write(z=o["z"], pitch=o["pitch"], yaw=o["yaw"], body_yaw=o["body"],
-                               antennas=(o["ant_r"], o["ant_l"]), drive_head=drive_head)
+                               antennas=(ant_r, ant_l), drive_head=drive_head)
             time.sleep(max(0.0, period - (time.monotonic() - now)))
 

--- a/robot/reachy_mini_mirrorbuddy/movements.py
+++ b/robot/reachy_mini_mirrorbuddy/movements.py
@@ -15,10 +15,11 @@ import time
 
 import numpy as np
 
-from . import body_actions, camera, gestures
+from . import camera, gestures
 from .temperament import CALM, LIVELY, NEUTRAL, Temperament, temperament_for  # noqa: F401
 from .motion_shapes import idle_pose
-from .pose_writer import ANTENNA_NEUTRAL, PoseWriter, clamp_antenna
+from .body_control import BodyControlMixin
+from .pose_writer import ANTENNA_NEUTRAL, PoseWriter
 from .emotions import NEUTRAL as EMOTION_NEUTRAL, Emotion, blend_mood, infer as infer_emotion
 
 logger = logging.getLogger(__name__)
@@ -43,7 +44,7 @@ def _ease(current: float, target: float, tau: float, dt: float) -> float:
     return current + (target - current) * alpha
 
 
-class Movements:
+class Movements(BodyControlMixin):
     """Background full-body animation driven by speech energy + idle liveliness."""
 
     def __init__(self, robot, enabled: bool = True, temperament: Temperament = NEUTRAL,
@@ -85,51 +86,6 @@ class Movements:
     def express(self, text: str | None) -> None:
         """Colour the body language from what Buddy is about to say."""
         self.set_emotion(infer_emotion(text))
-
-    @property
-    def antenna_bias(self) -> float:
-        """A posture the animation keeps holding: negative is antennas down."""
-        return self._antenna_bias
-
-    def set_antenna_bias(self, value: float) -> None:
-        """Hold the antennas somewhere other than where the idle animation wants them.
-
-        A one-shot gesture is overwritten within one frame at 50Hz, so "keep your
-        antennas down" has to be an offset the loop itself respects. Non-numeric
-        arguments arrive from the model and are ignored rather than crashing the
-        animation thread.
-        """
-        try:
-            self._antenna_bias = clamp_antenna(float(value))
-        except (TypeError, ValueError):
-            logger.debug("Ignoring non-numeric antenna bias: %r", value)
-
-    def apply_antenna_bias(self, right: float, left: float) -> tuple[float, float]:
-        """Offset the animation's antenna values, still inside the mechanical limit."""
-        bias = self._antenna_bias
-        return clamp_antenna(right + bias), clamp_antenna(left + bias)
-
-    def play_body_action(self, name: str) -> bool:
-        """Perform a named gesture without the idle animation fighting it.
-
-        The animation writes every joint fifty times a second, so a scripted pose
-        has to own the body for its duration — the same mechanism the camera
-        capture uses. Sustained postures are handed to the animation afterwards
-        as a bias, so "keep your antennas down" actually keeps them down.
-        """
-        action = body_actions.normalise(name)
-        if action not in body_actions.ACTIONS:
-            logger.info("Unknown body action: %r", name)
-            return False
-        self.hold_still()
-        try:
-            body_actions.perform(action, self.robot, self._writer.create_head_pose)
-        finally:
-            bias = body_actions.SUSTAINED.get(action)
-            if bias is not None:
-                self.set_antenna_bias(bias)
-            self.release_hold()
-        return True
 
     def hold_still(self) -> None:
         """Freeze head/body and pause tracking + wobbler so the camera gets a sharp frame."""

--- a/robot/reachy_mini_mirrorbuddy/prompt_builder.py
+++ b/robot/reachy_mini_mirrorbuddy/prompt_builder.py
@@ -36,12 +36,21 @@ _TOOLS_IT = (
     "- IMPORTANTE: se lo studente chiede un altro professore o un'altra materia (es. «voglio "
     "matematica», «chiama Galileo», «parliamo di storia»), DEVI usare SUBITO lo strumento "
     "'call_professor' con quel nome o materia. Non limitarti a rispondere a parole né a fingere "
-    "di cambiare: chiama davvero lo strumento, sarà lui a cambiare persona e voce.\n"
+    "di cambiare: chiama davvero lo strumento, sarà lui a cambiare persona e voce. Vale per "
+    "QUALSIASI richiesta di persona o argomento, anche se non ti sembra una materia scolastica "
+    "(meditazione, mindfulness, rilassamento, respirazione): prima chiami lo strumento, poi "
+    "eventualmente dici che non c'è. Non dire MAI che un professore non esiste senza aver "
+    "provato 'call_professor'.\n"
     "- Se ti mostra qualcosa da guardare — un compito, un esercizio, un foglio, la pagina di un "
     "quaderno o di un libro sul tavolo, oppure lo schermo del computer — usa 'look_at_homework'. "
     "Prima dì a voce che stai per guardare (es. «fammi dare un'occhiata»); poi resta fermo, non "
     "muovere la testa, perché il robot si ferma da solo per scattare una foto nitida. Non spiare "
-    "mai: usa la telecamera solo su richiesta, per aiutare con lo studio, e non descrivere le persone."
+    "mai: usa la telecamera solo su richiesta, per aiutare con lo studio, e non descrivere le persone.\n"
+    "- Hai un corpo vero e puoi muoverlo con 'move_body': antenne su e giu', nasconderti, il "
+    "gioco del cucu', annuire, scuotere la testa, guardarti intorno, festeggiare, fare un "
+    "inchino, tornare a riposo. Se ti chiedono di muoverti FALLO davvero chiamando lo "
+    "strumento, non limitarti a dire che l'hai fatto. Usalo anche di tua iniziativa per "
+    "giocare, per festeggiare una risposta giusta o per accompagnare quello che dici."
 )
 
 _PEOPLE_IT = (
@@ -72,18 +81,52 @@ _CONTROL_IT = (
 )
 
 
+def _roster_block(maestro: Maestro, maestri: list[Maestro] | None) -> str | None:
+    """The actual colleagues Buddy can hand over to.
+
+    Without this the model answers from its own idea of what a tutoring app
+    contains: Roberto asked for Fratello Loto by name and was told no meditation
+    teacher existed, while `call_professor` resolved him perfectly. A model that
+    does not believe a professor exists never reaches for the tool.
+    """
+    if not maestri:
+        return None
+    others = [m for m in maestri if m.id != maestro.id]
+    if not others:
+        return None
+    listed = "; ".join(
+        f"{m.display_name or m.name} ({m.specialty or m.subject})"
+        if (m.specialty or m.subject)
+        else (m.display_name or m.name)
+        for m in others
+    )
+    return (
+        "Puoi passare la parola SOLO a queste persone, che esistono davvero e sono "
+        f"tutte disponibili adesso: {listed}.\n"
+        "Questo e' l'elenco completo ed esatto: non inventare colleghi che non ci sono, "
+        "e non dire mai che un professore di questo elenco non esiste. Se lo studente "
+        "chiede una materia o un nome che e' in elenco — anche meditazione, mindfulness "
+        "o rilassamento — chiama subito 'call_professor'."
+    )
+
+
 def build_instructions(
     maestro: Maestro,
     locale: str = "it",
     dsa_profile: str | None = None,
     student_name: str | None = None,
     roster: Roster | None = None,
+    maestri: list[Maestro] | None = None,
 ) -> str:
     """Compose the full system instructions for the realtime session.
 
     ``roster`` carries the people Buddy has already met in this session, so a friend
     who introduced themselves five minutes ago is still known after a professor
     switch (which rebuilds these instructions from scratch).
+
+    ``maestri`` is the list of professors fetched from MirrorBuddy. It is optional
+    because the fetch can fail, and a robot without a roster must still be able to
+    hold a conversation.
     """
     parts: list[str] = []
 
@@ -109,6 +152,9 @@ def build_instructions(
     # 4. Robot embodiment + voice-driven tools + conversation control.
     parts.append(_EMBODIMENT_IT)
     parts.append(_TOOLS_IT)
+    block = _roster_block(maestro, maestri)
+    if block:
+        parts.append(block)
     parts.append(_PEOPLE_IT)
     parts.append(_CONTROL_IT)
 

--- a/robot/reachy_mini_mirrorbuddy/tool_handlers.py
+++ b/robot/reachy_mini_mirrorbuddy/tool_handlers.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import threading
 
-from . import camera, meditation, tools
+from . import body_actions, camera, meditation, tools
 from .azure_realtime import AzureRealtimeClient
 from .mirrorbuddy_client import friend_buddy, neutral_buddy
 
@@ -46,11 +46,38 @@ class ToolCallMixin:
                 self._start_meditation(client, args, call_id)
             elif name == "who_is_here":
                 client.send_function_result(call_id, self._room_summary())
+            elif name == "move_body":
+                self._handle_move_body(client, args, call_id)
             else:
                 client.send_function_result(call_id, "Ok.")
         except Exception as e:  # pragma: no cover - runtime robustness
             logger.warning("tool %s failed: %s", name, e)
             client.send_function_result(call_id, "Scusa, non ci sono riuscito.")
+
+    def _handle_move_body(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
+        """Play a gesture off the websocket loop.
+
+        The gesture takes seconds and calls ``hold_still``, which sleeps; doing it
+        inline would stop Buddy hearing the child mid-game. The result is sent
+        immediately so the model can keep talking over its own movement, which is
+        what makes peekaboo feel alive rather than turn-based.
+        """
+        action = body_actions.normalise(args.get("action"))
+        if action not in body_actions.ACTIONS:
+            client.send_function_result(
+                call_id, f"Non conosco quel movimento. So fare: {body_actions.describe()}."
+            )
+            return
+        client.send_function_result(call_id, f"Fatto: {action}.", respond=False)
+        threading.Thread(
+            target=self._run_body_action, args=(action,), daemon=True
+        ).start()
+
+    def _run_body_action(self, action: str) -> None:
+        try:
+            self.movements.play_body_action(action)
+        except Exception as e:  # pragma: no cover - hardware robustness
+            logger.warning("body action %s failed: %s", action, e)
 
     def _start_meditation(self, client: AzureRealtimeClient, args: dict, call_id: str) -> None:
         """Run a real guided session: bell, imposed silence, bell.

--- a/robot/reachy_mini_mirrorbuddy/tool_handlers.py
+++ b/robot/reachy_mini_mirrorbuddy/tool_handlers.py
@@ -59,8 +59,9 @@ class ToolCallMixin:
 
         The gesture takes seconds and calls ``hold_still``, which sleeps; doing it
         inline would stop Buddy hearing the child mid-game. The result is sent
-        immediately so the model can keep talking over its own movement, which is
-        what makes peekaboo feel alive rather than turn-based.
+        with ``respond=True`` so the Maestro speaks while the body is still
+        moving — a child who says "abbassa le antenne" and gets silence assumes
+        nothing happened, and would be left waiting for a turn that never comes.
         """
         action = body_actions.normalise(args.get("action"))
         if action not in body_actions.ACTIONS:
@@ -68,7 +69,7 @@ class ToolCallMixin:
                 call_id, f"Non conosco quel movimento. So fare: {body_actions.describe()}."
             )
             return
-        client.send_function_result(call_id, f"Fatto: {action}.", respond=False)
+        client.send_function_result(call_id, f"Fatto: {action}.")
         threading.Thread(
             target=self._run_body_action, args=(action,), daemon=True
         ).start()

--- a/robot/reachy_mini_mirrorbuddy/tools.py
+++ b/robot/reachy_mini_mirrorbuddy/tools.py
@@ -4,6 +4,7 @@ These tools let the student drive everything by voice — no screen needed:
 - ``list_professors``   → Buddy enumerates who is available.
 - ``call_professor``    → switch to another MirrorBuddy Maestro (persona + voice).
 - ``look_at_homework``  → capture one camera frame so Buddy can read the exercise.
+- ``move_body``         → real body actions any Maestro can play (antennas, peekaboo).
 
 The schemas are sent in ``session.update`` and the model calls them autonomously.
 """
@@ -14,7 +15,10 @@ import json
 import re
 from typing import Any
 
+from . import body_actions
 from .mirrorbuddy_client import Maestro
+
+_BODY_ACTIONS = set(body_actions.ACTIONS)
 
 TOOL_SCHEMAS: list[dict[str, Any]] = [
     {
@@ -159,6 +163,35 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
                 },
             },
             "required": ["practice"],
+        },
+    },
+    {
+        "type": "function",
+        "name": "move_body",
+        "description": (
+            "Muovi DAVVERO il corpo del robot. Usalo ogni volta che qualcuno ti chiede di "
+            "muoverti (es. «abbassa le antenne», «nasconditi», «facciamo cucu», «annuisci», "
+            "«guardati intorno»), e usalo anche di tua iniziativa per giocare, festeggiare "
+            "una risposta giusta o accompagnare quello che dici. Non fingere di muoverti: "
+            "chiama lo strumento. Le antenne restano dove le metti finche' non le rialzi o "
+            "non torni a 'riposo'."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": sorted(_BODY_ACTIONS),
+                    "description": (
+                        "antenne_giu (antenne abbassate, restano giu'), antenne_su (antenne "
+                        "alzate, restano su'), nascondi (testa giu', ti nascondi), cucu (il "
+                        "gioco del cucu': ti nascondi e riappari), annuisci (si' con la testa), "
+                        "scuoti (no con la testa), guarda_intorno, festeggia, inchino, riposo "
+                        "(torna alla posizione normale)."
+                    ),
+                },
+            },
+            "required": ["action"],
         },
     },
 ]

--- a/robot/tests/test_antenna_bias.py
+++ b/robot/tests/test_antenna_bias.py
@@ -1,0 +1,127 @@
+"""An antenna told to stay down must stay down.
+
+The idle animation writes every joint fifty times a second. So a one-shot gesture
+that lowers the antennas is overwritten within 20ms — Mario would say "lower your
+antennas", see them dip, and watch them spring back before he finished the
+sentence. Sustained postures have to live inside the animation, not fight it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reachy_mini_mirrorbuddy.movements import Movements  # noqa: E402
+from reachy_mini_mirrorbuddy.pose_writer import ANTENNA_MAX  # noqa: E402
+
+
+class DummyRobot:
+    def set_target(self, **kwargs):
+        pass
+
+    def goto_target(self, **kwargs):
+        pass
+
+
+def _movements() -> Movements:
+    return Movements(DummyRobot(), enabled=False)
+
+
+class TestSustainedAntennaPosture:
+    def test_it_starts_with_no_bias(self):
+        assert _movements().antenna_bias == pytest.approx(0.0)
+
+    def test_a_lowered_posture_is_remembered(self):
+        m = _movements()
+
+        m.set_antenna_bias(-0.4)
+
+        assert m.antenna_bias == pytest.approx(-0.4)
+
+    def test_the_bias_is_applied_to_what_the_animation_produced(self):
+        m = _movements()
+        m.set_antenna_bias(-0.3)
+
+        right, left = m.apply_antenna_bias(0.1, 0.1)
+
+        assert right == pytest.approx(-0.2)
+        assert left == pytest.approx(-0.2)
+
+    def test_the_bias_can_never_push_an_antenna_past_its_limit(self):
+        # Animation peak plus a full-down bias must still be a legal command.
+        m = _movements()
+        m.set_antenna_bias(-ANTENNA_MAX)
+
+        right, left = m.apply_antenna_bias(ANTENNA_MAX, -ANTENNA_MAX)
+
+        assert abs(right) <= ANTENNA_MAX + 1e-9
+        assert abs(left) <= ANTENNA_MAX + 1e-9
+
+    def test_a_bias_beyond_the_limit_is_clamped_when_it_is_set(self):
+        m = _movements()
+
+        m.set_antenna_bias(-99.0)
+
+        assert abs(m.antenna_bias) <= ANTENNA_MAX + 1e-9
+
+    def test_a_nonsense_bias_is_ignored_rather_than_crashing(self):
+        # Tool arguments come from a language model; they are not always numbers.
+        m = _movements()
+        m.set_antenna_bias(-0.4)
+
+        m.set_antenna_bias("giù")  # type: ignore[arg-type]
+
+        assert m.antenna_bias == pytest.approx(-0.4)
+
+    def test_returning_to_rest_clears_the_posture(self):
+        m = _movements()
+        m.set_antenna_bias(-0.4)
+
+        m.set_antenna_bias(0.0)
+
+        assert m.antenna_bias == pytest.approx(0.0)
+
+
+class RecordingRobot:
+    """Captures what the animation thread actually commands."""
+
+    def __init__(self) -> None:
+        self.antennas: list[list[float]] = []
+
+    def set_target(self, head=None, antennas=None, body_yaw=None):
+        self.antennas.append(list(antennas or []))
+
+    def goto_target(self, **kwargs):
+        pass
+
+    def enable_motors(self):
+        pass
+
+    def enable_wobbling(self):
+        pass
+
+    def disable_wobbling(self):
+        pass
+
+
+class TestTheBiasReachesTheMotors:
+    def test_the_running_animation_commands_the_lowered_antennas(self):
+        # The bias is only real if the 50Hz loop honours it; holding it in a
+        # field the loop ignores looks identical in every other test.
+        import time
+
+        robot = RecordingRobot()
+        m = Movements(robot, enabled=True, follow_face=False)
+        m.set_antenna_bias(-0.5)
+        m.start()
+        try:
+            time.sleep(0.4)
+        finally:
+            m.stop()
+
+        assert robot.antennas, "the animation never wrote a frame"
+        assert min(min(a) for a in robot.antennas) < -0.2

--- a/robot/tests/test_body_actions.py
+++ b/robot/tests/test_body_actions.py
@@ -1,0 +1,182 @@
+"""Every professor can move the robot's body, not just its voice.
+
+Roberto asked for this after watching Mario try to play with Buddy: "if I tell it
+to lower its antennas it should lower them; if I say hide, it should hide" — the
+peekaboo game a child plays with a puppet. Voice alone makes a speaker; a body
+that answers makes a companion.
+
+The tests below are about the two ways this feature hurts a child rather than
+helping: a pose the arms cannot reach (the robot freezes mid-game and says
+nothing), and a pose it never comes back from (the robot is left staring at the
+floor for the rest of the lesson).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reachy_mini_mirrorbuddy import body_actions  # noqa: E402
+from reachy_mini_mirrorbuddy.pose_writer import ANTENNA_MAX  # noqa: E402
+
+
+class FakeRobot:
+    def __init__(self, fail_on: int | None = None) -> None:
+        self.frames: list[dict] = []
+        self._n = 0
+        self._fail_on = fail_on
+
+    def goto_target(self, head=None, antennas=None, body_yaw=None, duration=None):
+        self._n += 1
+        if self._fail_on is not None and self._n == self._fail_on:
+            raise RuntimeError("IK error: Collision detected or head pose not achievable!")
+        self.frames.append(
+            {"head": head, "antennas": list(antennas or []), "body_yaw": body_yaw}
+        )
+
+
+def _pose(**kwargs):
+    return dict(kwargs)
+
+
+def _run(action: str, fail_on: int | None = None) -> FakeRobot:
+    robot = FakeRobot(fail_on=fail_on)
+    body_actions.perform(action, robot, _pose, pause=lambda _s: None)
+    return robot
+
+
+class TestTheActionsChildrenAskFor:
+    @pytest.mark.parametrize("action", sorted(body_actions.ACTIONS))
+    def test_every_action_moves_the_robot(self, action):
+        robot = _run(action)
+
+        assert robot.frames, f"{action} produced no motion at all"
+
+    @pytest.mark.parametrize("action", sorted(body_actions.ACTIONS))
+    def test_every_action_ends_back_at_a_neutral_pose(self, action):
+        # A robot left hiding after the game is over reads as broken, and the
+        # idle animation will fight whatever pose we abandoned it in.
+        robot = _run(action)
+
+        last = robot.frames[-1]
+        assert last["antennas"] == pytest.approx(
+            [body_actions.ANTENNA_NEUTRAL, body_actions.ANTENNA_NEUTRAL]
+        )
+        assert last["body_yaw"] == pytest.approx(0.0)
+
+    @pytest.mark.parametrize("action", sorted(body_actions.ACTIONS))
+    def test_no_action_ever_drives_an_antenna_past_its_limit(self, action):
+        robot = _run(action)
+
+        for frame in robot.frames:
+            for value in frame["antennas"]:
+                assert abs(value) <= ANTENNA_MAX + 1e-9
+
+    @pytest.mark.parametrize("action", sorted(body_actions.ACTIONS))
+    def test_no_action_asks_for_a_head_height_the_robot_cannot_reach(self, action):
+        robot = _run(action)
+
+        for frame in robot.frames:
+            head = frame["head"] or {}
+            assert abs(head.get("z", 0.0)) <= body_actions.MAX_HEAD_Z + 1e-9
+            assert abs(head.get("pitch", 0.0)) <= body_actions.MAX_HEAD_ANGLE + 1e-9
+            assert abs(head.get("yaw", 0.0)) <= body_actions.MAX_HEAD_ANGLE + 1e-9
+
+    def test_the_peekaboo_game_actually_hides_then_reappears(self):
+        robot = _run("nascondi")
+        hidden = min(f["head"].get("z", 0.0) for f in robot.frames if f["head"])
+
+        assert hidden < 0, "nascondi never lowered the head"
+
+        robot = _run("cucu")
+        heights = [f["head"].get("z", 0.0) for f in robot.frames if f["head"]]
+        assert min(heights) < 0 < max(heights), "cucu did not hide and pop back up"
+
+    def test_lowering_the_antennas_lowers_them(self):
+        robot = _run("antenne_giu")
+
+        assert min(min(f["antennas"]) for f in robot.frames) < body_actions.ANTENNA_NEUTRAL
+
+    def test_raising_the_antennas_raises_them(self):
+        robot = _run("antenne_su")
+
+        assert max(max(f["antennas"]) for f in robot.frames) > body_actions.ANTENNA_NEUTRAL
+
+
+class TestItNeverBreaksTheConversation:
+    def test_a_hardware_failure_mid_gesture_does_not_raise(self):
+        # goto_target really does throw on unreachable poses — the device logs it.
+        # This runs off the websocket loop, but a traceback still kills the game.
+        robot = FakeRobot(fail_on=1)
+
+        body_actions.perform("nascondi", robot, _pose, pause=lambda _s: None)
+
+        assert True  # reaching here is the assertion
+
+    def test_it_still_returns_to_neutral_after_a_failure(self):
+        robot = FakeRobot(fail_on=1)
+
+        body_actions.perform("nascondi", robot, _pose, pause=lambda _s: None)
+
+        assert robot.frames, "gave up entirely after one bad frame"
+        assert robot.frames[-1]["body_yaw"] == pytest.approx(0.0)
+
+    def test_an_unknown_action_is_reported_not_performed(self):
+        robot = FakeRobot()
+
+        ok = body_actions.perform("teletrasporto", robot, _pose, pause=lambda _s: None)
+
+        assert ok is False
+        assert robot.frames == []
+
+    def test_a_known_action_reports_success(self):
+        robot = FakeRobot()
+
+        assert body_actions.perform("annuisci", robot, _pose, pause=lambda _s: None) is True
+
+    def test_it_survives_a_robot_with_no_pose_factory(self):
+        # create_head_pose is None until the robot is fully up.
+        robot = FakeRobot()
+
+        assert body_actions.perform("annuisci", robot, None, pause=lambda _s: None) is True
+
+    def test_action_names_are_matched_regardless_of_case_or_spacing(self):
+        # The model writes what it hears: "Antenne Giu", "cucù".
+        assert body_actions.normalise("  Antenne Giu ") == "antenne_giu"
+        assert body_actions.normalise("cucù") == "cucu"
+
+
+class TestTheLimitsAreEnforcedNotJustRespected:
+    """The pose tables happen to be legal today. The clamp is what keeps them legal
+    when someone adds a more dramatic gesture next month — and an unreachable pose
+    means the robot silently stops moving mid-game."""
+
+    def test_a_pose_written_beyond_the_head_limits_is_clamped(self, monkeypatch):
+        robot = FakeRobot()
+        monkeypatch.setitem(
+            body_actions.ACTIONS,
+            "_reckless",
+            [({"z": 5.0, "pitch": 400.0, "yaw": -400.0}, [0.0, 0.0], 0.0, 0.2)],
+        )
+
+        body_actions.perform("_reckless", robot, _pose, pause=lambda _s: None)
+
+        head = robot.frames[0]["head"]
+        assert abs(head["z"]) <= body_actions.MAX_HEAD_Z + 1e-9
+        assert abs(head["pitch"]) <= body_actions.MAX_HEAD_ANGLE + 1e-9
+        assert abs(head["yaw"]) <= body_actions.MAX_HEAD_ANGLE + 1e-9
+
+    def test_an_antenna_written_beyond_its_limit_is_clamped(self, monkeypatch):
+        robot = FakeRobot()
+        monkeypatch.setitem(
+            body_actions.ACTIONS, "_reckless", [({}, [9.0, -9.0], 0.0, 0.2)]
+        )
+
+        body_actions.perform("_reckless", robot, _pose, pause=lambda _s: None)
+
+        for value in robot.frames[0]["antennas"]:
+            assert abs(value) <= ANTENNA_MAX + 1e-9

--- a/robot/tests/test_body_tool_wiring.py
+++ b/robot/tests/test_body_tool_wiring.py
@@ -1,0 +1,98 @@
+"""Wiring: the gesture the model asks for is the gesture the body performs.
+
+The unit tests cover the poses. These cover the two joins where the feature can
+be silently absent: the tool never reaching the model, and the gesture being
+overwritten by the idle animation the instant it finishes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reachy_mini_mirrorbuddy import body_actions, tools  # noqa: E402
+from reachy_mini_mirrorbuddy.movements import Movements  # noqa: E402
+
+
+class DummyRobot:
+    def __init__(self):
+        self.goto_calls = 0
+
+    def set_target(self, **kwargs):
+        pass
+
+    def goto_target(self, **kwargs):
+        self.goto_calls += 1
+
+    def disable_wobbling(self):
+        pass
+
+    def enable_wobbling(self):
+        pass
+
+
+class TestTheModelIsOfferedTheTool:
+    def test_move_body_is_in_the_schemas_sent_to_azure(self):
+        names = {s["name"] for s in tools.TOOL_SCHEMAS}
+
+        assert "move_body" in names
+
+    def test_the_enum_matches_the_actions_that_exist(self):
+        # An action advertised but unimplemented makes Buddy claim it moved.
+        schema = next(s for s in tools.TOOL_SCHEMAS if s["name"] == "move_body")
+        advertised = set(schema["parameters"]["properties"]["action"]["enum"])
+
+        assert advertised == set(body_actions.ACTIONS)
+
+    def test_the_things_roberto_asked_for_are_available(self):
+        for wanted in ("antenne_giu", "nascondi", "cucu"):
+            assert wanted in body_actions.ACTIONS
+
+
+class TestThePostureSurvivesTheAnimation:
+    def test_lowering_the_antennas_leaves_them_lowered(self):
+        m = Movements(DummyRobot(), enabled=False)
+
+        assert m.play_body_action("Antenne Giu") is True
+        assert m.antenna_bias < 0
+
+    def test_rest_clears_a_held_posture(self):
+        m = Movements(DummyRobot(), enabled=False)
+        m.play_body_action("antenne_giu")
+
+        m.play_body_action("riposo")
+
+        assert m.antenna_bias == pytest.approx(0.0)
+
+    def test_a_one_shot_gesture_does_not_change_the_held_posture(self):
+        # Nodding while the antennas are deliberately down must not raise them.
+        m = Movements(DummyRobot(), enabled=False)
+        m.play_body_action("antenne_giu")
+        held = m.antenna_bias
+
+        m.play_body_action("annuisci")
+
+        assert m.antenna_bias == pytest.approx(held)
+
+    def test_an_unknown_gesture_moves_nothing(self):
+        robot = DummyRobot()
+        m = Movements(robot, enabled=False)
+
+        assert m.play_body_action("teletrasporto") is False
+        assert robot.goto_calls == 0
+
+    def test_the_animation_is_released_even_if_the_gesture_fails(self):
+        # A gesture that leaves the body held would freeze Buddy for good.
+        class Breaking(DummyRobot):
+            def goto_target(self, **kwargs):
+                raise RuntimeError("IK error")
+
+        m = Movements(Breaking(), enabled=False)
+
+        m.play_body_action("cucu")
+
+        assert not m._hold.is_set()

--- a/robot/tests/test_body_tool_wiring.py
+++ b/robot/tests/test_body_tool_wiring.py
@@ -96,3 +96,39 @@ class TestThePostureSurvivesTheAnimation:
         m.play_body_action("cucu")
 
         assert not m._hold.is_set()
+
+
+class FakeClient:
+    def __init__(self):
+        self.results: list[tuple[str, str, bool]] = []
+
+    def send_function_result(self, call_id, output, respond=True):
+        self.results.append((call_id, output, respond))
+
+
+class Handler(__import__(
+    "reachy_mini_mirrorbuddy.tool_handlers", fromlist=["ToolCallMixin"]
+).ToolCallMixin):
+    def __init__(self, movements):
+        self.movements = movements
+
+
+class TestBuddyDoesNotGoSilentAfterMoving:
+    def test_the_maestro_gets_a_turn_to_acknowledge(self):
+        # respond=False here would leave the child staring at a robot that moved
+        # and then said nothing, waiting for a turn that never arrives.
+        client = FakeClient()
+        h = Handler(Movements(DummyRobot(), enabled=False))
+
+        h._handle_move_body(client, {"action": "annuisci"}, "call-1")
+
+        assert client.results, "no function result was sent at all"
+        assert client.results[0][2] is True
+
+    def test_an_unknown_gesture_is_reported_honestly(self):
+        client = FakeClient()
+        h = Handler(Movements(DummyRobot(), enabled=False))
+
+        h._handle_move_body(client, {"action": "teletrasporto"}, "call-2")
+
+        assert "Non conosco" in client.results[0][1]

--- a/robot/tests/test_prompt_roster.py
+++ b/robot/tests/test_prompt_roster.py
@@ -1,0 +1,83 @@
+"""Buddy must know who it can actually call.
+
+Roberto asked for Fratello Loto by name and was told there is no meditation
+teacher — while `call_professor` was working perfectly. The model was never
+given the roster, so it answered from its own assumptions about what a tutoring
+app contains, and a maestro it had never heard of could not exist. The journal
+shows it inventing plausible colleagues ("Manzoni per italiano") rather than
+reading a list.
+
+A tool the model refuses to reach for is the same as a tool that does not work.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reachy_mini_mirrorbuddy.mirrorbuddy_client import Maestro  # noqa: E402
+from reachy_mini_mirrorbuddy.prompt_builder import build_instructions  # noqa: E402
+
+
+def _m(mid: str, display: str, subject: str, specialty: str) -> Maestro:
+    return Maestro(
+        id=mid,
+        name=display.split()[-1],
+        display_name=display,
+        subject=subject,
+        specialty=specialty,
+        voice="alloy",
+        voice_instructions="",
+        teaching_style="",
+        system_prompt="",
+        greeting="",
+    )
+
+
+ROSTER = [
+    _m("loto", "Fratello Loto", "mindfulness", "Meditazione e Consapevolezza"),
+    _m("euclide", "Euclide", "mathematics", "Geometria"),
+    _m("omero", "Omero", "italian", "Poesia epica"),
+]
+
+
+class TestRosterIsInThePrompt:
+    def test_the_prompt_names_every_other_professor(self):
+        text = build_instructions(ROSTER[1], maestri=ROSTER)
+
+        for maestro in ROSTER:
+            if maestro.id == "euclide":
+                continue
+            assert maestro.display_name in text, maestro.display_name
+
+    def test_a_maestro_the_model_would_not_guess_is_named(self):
+        # The one that actually failed: nothing in a language model's priors says
+        # a homework app has a mindfulness teacher.
+        text = build_instructions(ROSTER[1], maestri=ROSTER)
+
+        assert "Fratello Loto" in text
+        assert "Meditazione e Consapevolezza" in text or "mindfulness" in text.lower()
+
+    def test_the_roster_is_presented_as_the_complete_truth(self):
+        # Without this the model treats the list as examples and keeps inventing.
+        text = build_instructions(ROSTER[1], maestri=ROSTER)
+
+        assert "solo" in text.lower() or "esatt" in text.lower() or "unic" in text.lower()
+
+    def test_it_still_builds_when_the_roster_is_unavailable(self):
+        # The fetch can fail; a robot with no list must still hold a conversation.
+        text = build_instructions(ROSTER[1])
+
+        assert text
+        assert "call_professor" in text
+
+    def test_the_current_maestro_is_not_offered_as_someone_to_call(self):
+        # Buddy telling a child "I can call Fratello Loto" while being Fratello Loto
+        # is how the switch loop started last time.
+        text = build_instructions(ROSTER[0], maestri=ROSTER)
+
+        assert "Euclide" in text
+        offer = text.split("Puoi passare la parola")[-1]
+        assert "Fratello Loto" not in offer


### PR DESCRIPTION
## Why

Two bugs, one root cause: Buddy could do the thing and didn't know it.

**1. "Passami Fratello Loto" → "non c'è un professore di meditazione".**
`call_professor` resolved `loto` perfectly. The system prompt just never contained the roster, so the model answered from its own priors about what a tutoring app holds — and a mindfulness teacher is not in those priors. The device journal shows it inventing colleagues ("come Manzoni per italiano") instead of reading a list.

**2. "Abbassa le antenne" → Buddy says it did, and doesn't move.**
No body-control tool was exposed to the model at all.

## What

- `build_instructions()` now takes the `maestri` and injects the real roster, stated as the complete and exact list, excluding the current Maestro. `_TOOLS_IT` also forbids claiming a professor doesn't exist without calling `call_professor` first — explicitly covering non-school topics (meditazione, mindfulness, rilassamento).
- New `body_actions.py` + `move_body` tool: `antenne_giu`, `antenne_su`, `nascondi`, `cucu`, `annuisci`, `scuoti`, `guarda_intorno`, `festeggia`, `inchino`, `riposo`. Available to every Maestro and coach.

## The two things that would have made this fail

**The idle animation writes every joint 50 times a second.** A one-shot "antennas down" is overwritten within 20ms — Mario would see them dip and spring back before he finished the sentence. Sustained postures are now a bias the animation itself honours (`Movements.apply_antenna_bias`). Head poses stay one-shot, because the head is shared with the face tracker.

**The device refuses unreachable poses** — it already logs `IK error: Collision detected or head pose not achievable!`, and a refused pose means the robot silently freezes mid-game. Every pose is clamped well inside the envelope, gestures run under `hold_still()`, and every action returns to neutral in a `finally` so the body is never abandoned mid-pose even after a failure.

## Verification

`342 passed, 1 skipped` (robot suite), ruff clean.

Mutation-tested, all caught:
- roster omitted / current maestro included / "complete list" wording dropped / block never appended
- return-to-neutral removed, unknown action performed anyway, head clamp removed, antenna clamp removed
- sustained bias never applied, `release_hold` outside `finally`, bias ignored by the 50Hz loop

The last two mutations initially **survived** — the bias was only asserted on the object, never on what the motors received. Added a test that runs the real animation thread and reads the commanded values.

## Not verified

Live on-device behaviour. The robot is off the network (`reachy-mini.local` does not resolve, MAC absent from ARP), so this is code-and-test evidence only. Deploy + live check of "passami Fratello Loto" and the cucù game once it's back on.
