### PR TITLE
chore(robot): version the robot build and say it out loud at startup

### DIFF
--- a/robot/pyproject.toml
+++ b/robot/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "reachy-mini-mirrorbuddy"
-version = "0.1.0"
+version = "0.2.0"
 description = "MirrorBuddy on Reachy Mini — the physical embodiment of MirrorBuddy (eyes, ears, mouth, movements) powered by Azure OpenAI Realtime and the MirrorBuddy Maestri."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/robot/reachy_mini_mirrorbuddy/__init__.py
+++ b/robot/reachy_mini_mirrorbuddy/__init__.py
@@ -9,4 +9,4 @@ It reuses MirrorBuddy's brain end-to-end:
 - Child-safety guardrails and DSA (accessibility) tuning mirror the MirrorBuddy web app.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/robot/reachy_mini_mirrorbuddy/main.py
+++ b/robot/reachy_mini_mirrorbuddy/main.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from reachy_mini import ReachyMini, ReachyMiniApp
 
+from . import __version__
 from .audio_io import AudioIO
 from .config import config
 from .controller import Controller
@@ -85,7 +86,7 @@ def run(
     instance_path: str | None = None,
 ) -> None:
     _setup_logging(args.debug)
-    logger.info("Starting MirrorBuddy Reachy Mini app")
+    logger.info("Starting MirrorBuddy Reachy Mini app v%s", __version__)
 
     # Load instance .env (Azure creds + MirrorBuddy config live here on the robot).
     if instance_path:

--- a/robot/tests/test_version.py
+++ b/robot/tests/test_version.py
@@ -1,0 +1,43 @@
+"""The robot must be able to say which build it is running.
+
+Today's whole debugging session was spent guessing whether the code on the device
+matched the code in the repo — a merged feature was invisible for hours and the
+only way to tell was reading journal lines for behaviour that should exist. The
+package has reported version 0.1.0 since the first commit, so it could never
+answer the question.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import reachy_mini_mirrorbuddy  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestTheBuildIdentifiesItself:
+    def test_the_package_exposes_a_version(self):
+        assert re.fullmatch(r"\d+\.\d+\.\d+", reachy_mini_mirrorbuddy.__version__)
+
+    def test_it_matches_what_gets_packaged_and_published(self):
+        # These drift the moment they are maintained in two places by hand, and a
+        # wrong version is worse than none: it is a confident lie about the device.
+        declared = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"]
+
+        assert reachy_mini_mirrorbuddy.__version__ == declared
+
+    def test_it_is_no_longer_the_placeholder(self):
+        assert reachy_mini_mirrorbuddy.__version__ != "0.1.0"
+
+    def test_startup_announces_it(self):
+        # It has to reach the journal: that is the only surface available when the
+        # robot is in another room and something is wrong.
+        source = (ROOT / "reachy_mini_mirrorbuddy" / "main.py").read_text()
+
+        assert "__version__" in source


### PR DESCRIPTION
The robot package has reported `0.1.0` since the first commit.

That is why today was slow. A merged feature (Fratello Loto) was invisible on the device for hours, and the only way to establish what was actually installed was to read the journal for *behaviour* that should have existed. The build could not identify itself.

- `__version__` → `0.2.0` (`move_body` + the injected roster are a real feature)
- the version is now the first line in the journal at startup
- a test pins `__version__` to `pyproject.toml` — two hand-maintained version strings drift, and a wrong version is worse than none: it is a confident lie about what is running

Mutation-tested: drifting the two apart fails, reverting to the placeholder fails.

`348 passed, 1 skipped`, ruff clean.