### PR TITLE
docs: 27 Maestri, not 26

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -116,7 +116,7 @@ OLLAMA_MODEL=llama3.2
 
 ## Showcase Mode (No API Required)
 
-Settings → "Modalità Showcase" or `/showcase`. Includes all 26 Maestri (simulated), demos (mind maps/flashcards/quizzes), voice UI preview (no actual voice), full accessibility.
+Settings → "Modalità Showcase" or `/showcase`. Includes all 27 Maestri (simulated), demos (mind maps/flashcards/quizzes), voice UI preview (no actual voice), full accessibility.
 
 **Perfect for:** Demos, presentations, trying before committing.
 


### PR DESCRIPTION
Production `/api/maestri` returns 27 (verified, `loto` included). SETUP.md still promised 26 in the showcase description.