### PR TITLE
chore: ignore the whole kanban/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,9 +142,7 @@ testingcase/
 study-materials/
 .gstack/
 .serena/
-kanban/todo/
-kanban/doing/
-kanban/done/
+kanban/
 handoff/latest.md
 
 # graphify knowledge graph output (regenerable, ~30k nodes)


### PR DESCRIPTION
`kanban/todo/`, `kanban/doing/` and `kanban/done/` were already ignored, but the local kanban tool also writes `kanban/.DS_Store` and `kanban/.coda-MirrorBuddy.md` at the top level. Result: `git status` showed an untracked `kanban/` on every checkout.

Local tool state, same category as `.serena/` on the line above — ignore the directory.