### PR TITLE
fix(ci): promote only Ready deployments, and read status from inspect

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -59,44 +59,7 @@ jobs:
             echo "deployment_url=${{ inputs.deployment_url }}" >> $GITHUB_OUTPUT
           else
             echo "Finding latest staging deployment..."
-            # Pick the most recent deployment that is actually Ready.
-            #
-            # Two traps live here, both of which have bitten production:
-            #
-            # 1. Only a Ready deployment can be promoted. This step used to take
-            #    the newest deployment whatever its state: on 2026-08-08 it chose
-            #    a Canceled one, promoted it and reported success while production
-            #    silently stayed on the previous build. Canceled deployments are
-            #    normal for this project — vercel.json sets `ignoreCommand: exit 0`
-            #    so Vercel never builds from git, and every git push therefore
-            #    leaves an immediately-canceled deployment at the top of the list.
-            #
-            # 2. When stdout is not a TTY, `vercel list` prints *only bare URLs*
-            #    to stdout and sends the table — status and environment included —
-            #    to stderr. With `2>/dev/null` the old `grep -v Production` had
-            #    nothing to match on and silently filtered nothing. Status has to
-            #    come from `vercel inspect`, not from parsing the list output.
-            url=""
-            candidates=$(vercel list --token=${{ secrets.VERCEL_TOKEN }} $SCOPE --meta gitSource=main 2>/dev/null | grep '^https://' | head -10)
-            if [ -z "$candidates" ]; then
-              candidates=$(vercel list --token=${{ secrets.VERCEL_TOKEN }} $SCOPE 2>/dev/null | grep '^https://' | head -10)
-            fi
-            for cand in $candidates; do
-              state=$(vercel inspect "$cand" --token=${{ secrets.VERCEL_TOKEN }} $SCOPE 2>&1 | grep -E "^[[:space:]]+status" | head -1 | awk '{print $NF}')
-              echo "  $cand -> $state"
-              if [ "$state" = "Ready" ]; then
-                url="$cand"
-                break
-              fi
-            done
-            if [ -z "$url" ]; then
-              echo "::error::No Ready deployment to promote."
-              echo "If the last merge changed no application code (a version-only"
-              echo "or chore release), CI produces no build and there is genuinely"
-              echo "nothing to promote — that is the expected outcome, not a bug."
-              echo "Otherwise pass the staging deployment URL manually."
-              exit 1
-            fi
+            url=$(bash scripts/ci/find-ready-deployment.sh "${{ secrets.VERCEL_TOKEN }}" "$SCOPE")
             echo "deployment_url=$url" >> $GITHUB_OUTPUT
             echo "Found latest deployment: $url"
           fi

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -59,17 +59,42 @@ jobs:
             echo "deployment_url=${{ inputs.deployment_url }}" >> $GITHUB_OUTPUT
           else
             echo "Finding latest staging deployment..."
-            latest=$(vercel list --token=${{ secrets.VERCEL_TOKEN }} $SCOPE --meta gitSource=main 2>/dev/null | grep -v "Production" | head -5)
-            echo "Recent deployments:"
-            echo "$latest"
-
-            url=$(echo "$latest" | grep "https://" | head -1 | awk '{for(i=1;i<=NF;i++) if($i ~ /^https:\/\//) print $i}')
-            if [ -z "$url" ]; then
-              url=$(vercel list --token=${{ secrets.VERCEL_TOKEN }} $SCOPE 2>/dev/null | grep -v "Production" | grep "https://" | head -1 | awk '{for(i=1;i<=NF;i++) if($i ~ /^https:\/\//) print $i}')
+            # Pick the most recent deployment that is actually Ready.
+            #
+            # Two traps live here, both of which have bitten production:
+            #
+            # 1. Only a Ready deployment can be promoted. This step used to take
+            #    the newest deployment whatever its state: on 2026-08-08 it chose
+            #    a Canceled one, promoted it and reported success while production
+            #    silently stayed on the previous build. Canceled deployments are
+            #    normal for this project — vercel.json sets `ignoreCommand: exit 0`
+            #    so Vercel never builds from git, and every git push therefore
+            #    leaves an immediately-canceled deployment at the top of the list.
+            #
+            # 2. When stdout is not a TTY, `vercel list` prints *only bare URLs*
+            #    to stdout and sends the table — status and environment included —
+            #    to stderr. With `2>/dev/null` the old `grep -v Production` had
+            #    nothing to match on and silently filtered nothing. Status has to
+            #    come from `vercel inspect`, not from parsing the list output.
+            url=""
+            candidates=$(vercel list --token=${{ secrets.VERCEL_TOKEN }} $SCOPE --meta gitSource=main 2>/dev/null | grep '^https://' | head -10)
+            if [ -z "$candidates" ]; then
+              candidates=$(vercel list --token=${{ secrets.VERCEL_TOKEN }} $SCOPE 2>/dev/null | grep '^https://' | head -10)
             fi
+            for cand in $candidates; do
+              state=$(vercel inspect "$cand" --token=${{ secrets.VERCEL_TOKEN }} $SCOPE 2>&1 | grep -E "^[[:space:]]+status" | head -1 | awk '{print $NF}')
+              echo "  $cand -> $state"
+              if [ "$state" = "Ready" ]; then
+                url="$cand"
+                break
+              fi
+            done
             if [ -z "$url" ]; then
-              echo "::error::Could not find a staging deployment to promote"
-              echo "Please provide the staging deployment URL manually"
+              echo "::error::No Ready deployment to promote."
+              echo "If the last merge changed no application code (a version-only"
+              echo "or chore release), CI produces no build and there is genuinely"
+              echo "nothing to promote — that is the expected outcome, not a bug."
+              echo "Otherwise pass the staging deployment URL manually."
               exit 1
             fi
             echo "deployment_url=$url" >> $GITHUB_OUTPUT

--- a/scripts/ci/find-ready-deployment.sh
+++ b/scripts/ci/find-ready-deployment.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Print the URL of the most recent Vercel deployment that is actually Ready.
+#
+# Two traps live here, both of which have bitten production:
+#
+# 1. Only a Ready deployment can be promoted. Promotion used to take the newest
+#    deployment whatever its state: on 2026-08-08 it chose a Canceled one,
+#    promoted it and reported success while production silently stayed on the
+#    previous build. Canceled deployments are *normal* for this project —
+#    vercel.json sets `ignoreCommand: exit 0`, so Vercel never builds from git
+#    and every push leaves an immediately-canceled deployment at the top of the
+#    list. Only CI produces real builds.
+#
+# 2. When stdout is not a TTY, `vercel list` prints *only bare URLs* to stdout
+#    and sends the table — status and environment included — to stderr. Piping
+#    it with `2>/dev/null` and grepping for a status therefore matches nothing
+#    and silently filters nothing. Status has to come from `vercel inspect`.
+#
+# Usage: find-ready-deployment.sh [token] <scope-arg>
+# An empty token falls back to the CLI's own credentials, so the script can be
+# run locally against the real project to verify a change to it.
+# Prints the chosen URL on stdout; progress goes to stderr so callers can
+# capture the URL cleanly. Exits 1 when no Ready deployment exists.
+
+set -euo pipefail
+
+token="${1:-}"
+scope="${2:?scope argument required}"
+
+# Deliberately a plain string, not an array: an empty array expanded under
+# `set -u` aborts on bash 3.2, and the resulting failure looks identical to
+# "no Ready deployment found" — the very outcome this script exists to report
+# accurately. The token never contains whitespace, so word splitting is safe.
+auth=""
+[ -n "$token" ] && auth="--token=$token"
+
+candidates=$(vercel list $auth "$scope" --meta gitSource=main 2>/dev/null |
+  grep '^https://' | head -10 || true)
+
+if [ -z "$candidates" ]; then
+  candidates=$(vercel list $auth "$scope" 2>/dev/null |
+    grep '^https://' | head -10 || true)
+fi
+
+for cand in $candidates; do
+  state=$(vercel inspect "$cand" $auth "$scope" 2>&1 |
+    grep -E "^[[:space:]]+status" | head -1 | awk '{print $NF}' || true)
+  echo "  $cand -> ${state:-unknown}" >&2
+  if [ "$state" = "Ready" ]; then
+    echo "$cand"
+    exit 0
+  fi
+done
+
+echo "::error::No Ready deployment to promote." >&2
+echo "If the last merge changed no application code (a version-only or chore" >&2
+echo "release), CI produces no build and there is genuinely nothing to" >&2
+echo "promote — that is the expected outcome, not a bug." >&2
+echo "Otherwise pass the staging deployment URL manually." >&2
+exit 1


### PR DESCRIPTION
## What was wrong

Promotion could pick a deployment that cannot be promoted — and then report success anyway.

- **2026-08-08**: it selected a *Canceled* deployment, promoted it, and reported ✅ while production silently stayed on the previous build. The post-promotion health check passed precisely because the old build was still serving.
- **2026-08-10**: re-running it retried that same Canceled deployment 10 times as "still building", then timed out.

Net effect: production has been pinned at 0.23.2 with no visible failure.

## Two separate defects

**1. State was never checked.** The newest deployment was taken whatever its state. Canceled deployments are *normal* in this project: `vercel.json` sets `ignoreCommand: exit 0`, so Vercel never builds from git — every push leaves an immediately-canceled deployment at the top of the list. Only CI produces real builds.

**2. The filter never actually ran.** When stdout is not a TTY, `vercel list` prints **only bare URLs** to stdout and sends the table — status *and* environment — to stderr. With `2>/dev/null`, the existing `grep -v "Production"` had nothing to match against and filtered nothing. The pipeline silently reduced to "take the first URL".

## Fix

Iterate over candidate URLs and ask `vercel inspect` for each one's status, promoting the first `Ready`. If none is Ready, fail with an explanation instead of a mystery — for a version-only or chore release, CI produces no build and there is genuinely nothing to promote.

## Verification (against the live project)

```
old logic -> https://mirrorbuddy-6ds1svt1k-...  (Canceled)   ← the bug, reproduced
new logic ->   6ds1svt1k -> Canceled
               krytctk93 -> Canceled
               f1x1irymr -> Canceled
               okm61yaq4 -> Ready      ← selected
```

`okm61yaq4` is the build currently serving production.