### PR TITLE
fix(roster): exclude dated business plans from the count check

### DIFF
--- a/scripts/sync-roster-counts.ts
+++ b/scripts/sync-roster-counts.ts
@@ -144,6 +144,9 @@ const IGNORED = [
   'docs/adr/**',
   'docs/plans/**',
   'docs/archive/**',
+  // Dated financial analyses. A January valuation modelled the roster of that
+  // January; restating it with today's number would misreport the analysis.
+  'docs/busplan/**',
   // Verbatim transcripts of simulated user sessions: a record of what was
   // said, not a claim the product makes.
   'docs/focus-group/**',


### PR DESCRIPTION
The roster gate merged in #633 immediately caught six counts in `docs/busplan/` on `main`.

Those are **dated financial analyses** — a January valuation modelled the roster as it stood that January. Restating them with today's number would misreport the analysis rather than fix it, which is the same reason `docs/adr/`, `docs/plans/` and `docs/archive/` are already exempt.

Verified: `roster:check` green across 367 files (27 maestri, 6 coaches, 6 buddies).