### PR TITLE
fix(roster): correct the site meta description in all five locales

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -42,7 +42,7 @@ export async function generateMetadata(): Promise<Metadata> {
     metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'),
     title: 'MirrorBuddy - The school we wished existed',
     description:
-      'AI-powered educational platform with 17 historical Maestros, 5 Coaches, 5 Buddies, voice tutoring, and personalized learning for students with learning differences.',
+      'AI-powered educational platform with 27 historical Maestros, 6 Coaches, 6 Buddies, voice tutoring, and personalized learning for students with learning differences.',
     keywords: ['education', 'AI', 'tutoring', 'voice', 'learning', 'DSA', 'ADHD', 'MirrorBuddy'],
     manifest: '/manifest.json',
     icons: {

--- a/apps/web/src/components/structured-data/json-ld-organization.ts
+++ b/apps/web/src/components/structured-data/json-ld-organization.ts
@@ -24,11 +24,11 @@ export interface EducationalOrganizationSchema extends OrganizationSchema {
 
 // Locale-specific descriptions
 const localeDescriptions: Record<Locale, string> = {
-  it: 'MirrorBuddy - La scuola che vorrei. Piattaforma educativa potenziata da IA per studenti con differenze di apprendimento, con 26 maestri storici, insegnanti, compagni e tutoraggio vocale personalizzato.',
-  en: 'MirrorBuddy - The school we wished existed. AI-powered educational platform for students with learning differences, featuring 26 historical maestros, coaches, buddies, and personalized voice tutoring.',
-  fr: "MirrorBuddy - L'école que nous avions souhaitée. Plateforme éducative alimentée par l'IA pour les étudiants ayant des troubles d'apprentissage, avec 26 maîtres historiques, entraîneurs, camarades et tutorat vocal personnalisé.",
-  de: 'MirrorBuddy - Die Schule, die wir uns gewünscht haben. KI-gestützte Bildungsplattform für Schüler mit Lernbehinderungen, mit 26 historischen Meistern, Trainern, Begleitern und personalisierter Sprachbetreuung.',
-  es: 'MirrorBuddy - La escuela que siempre deseamos. Plataforma educativa impulsada por IA para estudiantes con dificultades de aprendizaje, con 26 maestros históricos, entrenadores, compañeros y tutoría de voz personalizada.',
+  it: 'MirrorBuddy - La scuola che vorrei. Piattaforma educativa potenziata da IA per studenti con differenze di apprendimento, con 27 maestri storici, insegnanti, compagni e tutoraggio vocale personalizzato.',
+  en: 'MirrorBuddy - The school we wished existed. AI-powered educational platform for students with learning differences, featuring 27 historical maestros, coaches, buddies, and personalized voice tutoring.',
+  fr: "MirrorBuddy - L'école que nous avions souhaitée. Plateforme éducative alimentée par l'IA pour les étudiants ayant des troubles d'apprentissage, avec 27 maîtres historiques, entraîneurs, camarades et tutorat vocal personnalisé.",
+  de: 'MirrorBuddy - Die Schule, die wir uns gewünscht haben. KI-gestützte Bildungsplattform für Schüler mit Lernbehinderungen, mit 27 historischen Meistern, Trainern, Begleitern und personalisierter Sprachbetreuung.',
+  es: 'MirrorBuddy - La escuela que siempre deseamos. Plataforma educativa impulsada por IA para estudiantes con dificultades de aprendizaje, con 27 maestros históricos, entrenadores, compañeros y tutoría de voz personalizada.',
 };
 
 // Educational levels (locale-specific)

--- a/apps/web/src/lib/i18n/get-og-metadata.ts
+++ b/apps/web/src/lib/i18n/get-og-metadata.ts
@@ -14,27 +14,27 @@ const DEFAULT_METADATA: Record<Locale, { title: string; description: string }> =
   it: {
     title: 'MirrorBuddy - La scuola che desideravamo',
     description:
-      "Piattaforma educativa alimentata da IA con 17 maestri storici, 5 insegnanti, 5 compagni, tutoraggio vocale e apprendimento personalizzato per studenti con disturbi dell'apprendimento.",
+      "Piattaforma educativa alimentata da IA con 27 maestri storici, 6 insegnanti, 6 compagni, tutoraggio vocale e apprendimento personalizzato per studenti con disturbi dell'apprendimento.",
   },
   en: {
     title: 'MirrorBuddy - The School We Wished Existed',
     description:
-      'AI-powered educational platform with 17 historical Maestros, 5 Coaches, 5 Buddies, voice tutoring, and personalized learning for students with learning differences.',
+      'AI-powered educational platform with 27 historical Maestros, 6 Coaches, 6 Buddies, voice tutoring, and personalized learning for students with learning differences.',
   },
   fr: {
     title: "MirrorBuddy - L'école que nous aurions aimée",
     description:
-      "Plateforme éducative basée sur l'IA avec 17 maîtres historiques, 5 entraîneurs, 5 copains, tutorat vocal et apprentissage personnalisé pour les étudiants en difficulté d'apprentissage.",
+      "Plateforme éducative basée sur l'IA avec 27 maîtres historiques, 6 entraîneurs, 6 copains, tutorat vocal et apprentissage personnalisé pour les étudiants en difficulté d'apprentissage.",
   },
   de: {
     title: 'MirrorBuddy - Die Schule, die wir uns gewünscht haben',
     description:
-      'KI-gestützte Bildungsplattform mit 17 historischen Meistern, 5 Trainern, 5 Lernpartnern, Sprachtutoring und personalisiertem Lernen für Schüler mit Lernbehinderungen.',
+      'KI-gestützte Bildungsplattform mit 27 historischen Meistern, 6 Trainern, 6 Lernpartnern, Sprachtutoring und personalisiertem Lernen für Schüler mit Lernbehinderungen.',
   },
   es: {
     title: 'MirrorBuddy - La escuela que deseábamos',
     description:
-      'Plataforma educativa impulsada por IA con 17 maestros históricos, 5 entrenadores, 5 compañeros, tutoría de voz y aprendizaje personalizado para estudiantes con dificultades de aprendizaje.',
+      'Plataforma educativa impulsada por IA con 27 maestros históricos, 6 entrenadores, 6 compañeros, tutoría de voz y aprendizaje personalizado para estudiantes con dificultades de aprendizaje.',
   },
 };
 

--- a/scripts/sync-roster-counts.ts
+++ b/scripts/sync-roster-counts.ts
@@ -62,6 +62,9 @@ const NOUNS: Record<keyof typeof ROSTER, string[]> = {
     // Multi-word forms from the meta descriptions, where the noun does not
     // sit directly after the number.
     'historical Maestros',
+    'historical maestros',
+    'maestri storici',
+    'maestros históricos',
     'historische Meister',
     // German declines in the dative ("mit 17 historischen Meistern"), so the
     // inflected forms need listing or the check passes while the copy is wrong.
@@ -71,15 +74,34 @@ const NOUNS: Record<keyof typeof ROSTER, string[]> = {
     'maîtres historiques',
   ],
   coaches: [
-    'Coach', 'coach', 'Coaches', 'coaches', 'Coachs', 'coachs',
-    'Entrenadores', 'entrenadores', 'entraîneurs',
-    'Trainer', 'trainer', 'Trainern', 'trainern',
-    'insegnanti', 'Insegnanti',
+    'Coach',
+    'coach',
+    'Coaches',
+    'coaches',
+    'Coachs',
+    'coachs',
+    'Entrenadores',
+    'entrenadores',
+    'entraîneurs',
+    'Trainer',
+    'trainer',
+    'Trainern',
+    'trainern',
+    'insegnanti',
+    'Insegnanti',
   ],
   buddies: [
-    'Buddy', 'buddy', 'Buddies', 'buddies',
-    'compagni', 'Compagni', 'copains', 'Kumpel',
-    'compañeros', 'Lernpartner', 'Lernpartnern',
+    'Buddy',
+    'buddy',
+    'Buddies',
+    'buddies',
+    'compagni',
+    'Compagni',
+    'copains',
+    'Kumpel',
+    'compañeros',
+    'Lernpartner',
+    'Lernpartnern',
   ],
 };
 
@@ -150,6 +172,9 @@ const TARGETS = [
   // Meta descriptions are copy too: they reach Google and social cards.
   'apps/web/src/app/layout.tsx',
   'apps/web/src/lib/i18n/get-og-metadata.ts',
+  // The Organization JSON-LD is what Google actually reads for rich results,
+  // so a stale count here is published to search whether we notice or not.
+  'apps/web/src/components/structured-data/json-ld-organization.ts',
   'docs/**/*.md',
   'robot/**/*.py',
   'robot/**/*.html',

--- a/scripts/sync-roster-counts.ts
+++ b/scripts/sync-roster-counts.ts
@@ -59,11 +59,28 @@ const NOUNS: Record<keyof typeof ROSTER, string[]> = {
     'professeurs',
     'AI professors',
     'AI Professors',
-    'Insegnanti',
-    'insegnanti',
+    // Multi-word forms from the meta descriptions, where the noun does not
+    // sit directly after the number.
+    'historical Maestros',
+    'historische Meister',
+    // German declines in the dative ("mit 17 historischen Meistern"), so the
+    // inflected forms need listing or the check passes while the copy is wrong.
+    'historischen Meistern',
+    'Meistern',
+    'Meister',
+    'maîtres historiques',
   ],
-  coaches: ['Coach', 'coach', 'Coaches', 'coaches', 'Coachs', 'coachs', 'Entrenadores'],
-  buddies: ['Buddy', 'buddy', 'Buddies', 'buddies'],
+  coaches: [
+    'Coach', 'coach', 'Coaches', 'coaches', 'Coachs', 'coachs',
+    'Entrenadores', 'entrenadores', 'entraîneurs',
+    'Trainer', 'trainer', 'Trainern', 'trainern',
+    'insegnanti', 'Insegnanti',
+  ],
+  buddies: [
+    'Buddy', 'buddy', 'Buddies', 'buddies',
+    'compagni', 'Compagni', 'copains', 'Kumpel',
+    'compañeros', 'Lernpartner', 'Lernpartnern',
+  ],
 };
 
 interface Finding {
@@ -130,6 +147,9 @@ function reconcileJson(node: unknown, file: string, path: string, findings: Find
 
 const TARGETS = [
   'apps/web/messages/*/*.json',
+  // Meta descriptions are copy too: they reach Google and social cards.
+  'apps/web/src/app/layout.tsx',
+  'apps/web/src/lib/i18n/get-og-metadata.ts',
   'docs/**/*.md',
   'robot/**/*.py',
   'robot/**/*.html',


### PR DESCRIPTION
## What production was saying

The live site told Google and every social card that MirrorBuddy has **"17 historical Maestros, 5 Coaches, 5 Buddies"**. The real roster is **27, 6 and 6**.

The counts fixed in #633 covered translation files and docs. Meta descriptions live in `layout.tsx` and `get-og-metadata.ts` — they are copy too, and the most widely syndicated copy we have, so they kept drifting unseen.

## Two traps that had the gate reporting green on wrong text

| Trap | Why it matters |
|---|---|
| Italian says **"5 insegnanti"** for the *coaches* | Listed under maestri, the tool would have "corrected" 5 → 27, making it worse |
| German declines in the dative: **"mit 17 historischen Meistern, 5 Trainern, 5 Lernpartnern"** | None match the nominative forms, so the check passed while a whole locale stayed wrong |

Both are now handled explicitly. This is the failure mode the roster work exists to remove, so it mattered more than the numbers themselves.

## Verification

- `roster:check` green across **369 files** (27 maestri, 6 coaches, 6 buddies)
- All five descriptions verified to read 27 / 6 / 6
- `typecheck` PASS, roster binding tests 3 passed