### PR TITLE
fix(proxy): stop localising .mjs assets, which broke the PDF worker in production

### DIFF
--- a/apps/web/src/__tests__/proxy-static-assets.test.ts
+++ b/apps/web/src/__tests__/proxy-static-assets.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Guards the paths that must never be treated as localisable pages.
+ *
+ * A real production bug: `/pdf/pdf.worker.min.mjs` was 307-redirected to
+ * `/it/welcome`, because `.mjs` was missing from the static extension list.
+ * The browser asked for a worker script and got an HTML page, so the PDF
+ * viewer failed for every student in production while every local check —
+ * unit tests, build, and even a real-browser render — stayed green, since
+ * none of them go through the proxy.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    next: vi.fn(() => ({ headers: new Map() })),
+    redirect: vi.fn(() => ({ headers: new Map() })),
+  },
+}));
+
+vi.mock('next-intl/middleware', () => ({ default: vi.fn(() => vi.fn()) }));
+
+vi.mock('@/i18n/routing', () => ({
+  routing: { locales: ['it', 'en', 'fr', 'de', 'es'], defaultLocale: 'it' },
+}));
+
+vi.mock('@/lib/observability/metrics-store', () => ({
+  metricsStore: { recordLatency: vi.fn(), recordError: vi.fn() },
+}));
+
+import { shouldSkipI18n } from '../proxy';
+import { PDF_WORKER_SRC } from '@/lib/pdf/pdf-worker';
+
+describe('proxy static asset handling', () => {
+  it('does not localise the self-hosted pdf.js worker', () => {
+    // Uses the real constant, so moving the worker cannot silently
+    // reintroduce the bug.
+    expect(shouldSkipI18n(PDF_WORKER_SRC)).toBe(true);
+  });
+
+  it.each([
+    '/pdf/pdf.worker.min.mjs',
+    '/some/module.mjs',
+    '/wasm/decoder.wasm',
+    '/build/app.js.map',
+  ])('treats %s as a static asset', (path) => {
+    expect(shouldSkipI18n(path)).toBe(true);
+  });
+
+  it.each(['/welcome', '/astuccio', '/', '/study-kit/new'])(
+    'still localises the page %s',
+    (path) => {
+      expect(shouldSkipI18n(path)).toBe(false);
+    },
+  );
+});

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -115,7 +115,14 @@ function isValidVisitorId(visitorId: string | undefined): boolean {
   return UUID_V4_REGEX.test(visitorId);
 }
 
-// Static file extensions to skip
+// Static file extensions to skip.
+//
+// Anything served straight out of public/ must be listed here, or the i18n
+// layer treats it as a page and 307s it to /<locale>/... . That is how the
+// self-hosted pdf.js worker broke in production: /pdf/pdf.worker.min.mjs
+// redirected to /it/welcome, so the browser got an HTML page where it
+// expected a worker script. Keep .mjs and .wasm listed even if today only
+// the pdf.js worker uses them.
 const STATIC_EXTENSIONS = [
   '.ico',
   '.png',
@@ -130,6 +137,9 @@ const STATIC_EXTENSIONS = [
   '.otf',
   '.css',
   '.js',
+  '.mjs',
+  '.wasm',
+  '.map',
 ];
 
 function pathMatchesRoute(pathname: string, route: string): boolean {
@@ -258,7 +268,7 @@ export function buildCSPHeader(nonce: string): string {
  * Check if path should skip i18n middleware entirely
  * These paths are not localized and should not be redirected
  */
-function shouldSkipI18n(pathname: string): boolean {
+export function shouldSkipI18n(pathname: string): boolean {
   // Skip paths that start with excluded prefixes
   if (I18N_EXCLUDE_PATHS.some((prefix) => pathname.startsWith(prefix))) {
     return true;


### PR DESCRIPTION
## The bug, found live

```
$ curl -sI https://mirrorbuddy.org/pdf/pdf.worker.min.mjs
307  ->  https://mirrorbuddy.org/it/welcome
```

The browser asks for the pdf.js **worker script** and gets back the **welcome page HTML**. The PDF viewer was broken for every student on production.

`STATIC_EXTENSIONS` in `src/proxy.ts` listed `.js` but not `.mjs`, so the i18n layer treated the worker as a localisable page and redirected it. pdfjs-dist has shipped **ESM only since v5**, so the worker can only ever be `.mjs` — the list was simply out of date with the dependency.

## Why nothing caught it

Every local gate was green while production was broken: unit tests, `ci:summary`, and even the real-browser render harness (`scripts/verify-pdf-viewer.mjs`, 102400 inked pixels). **None of them go through the proxy.** That is the actual lesson here — the proof I trusted was proving the wrong layer.

## The fix

Adds `.mjs`, plus `.wasm` and `.map` which would hit the identical trap.

## Evidence — against a real production server this time

Built with `next build`, started with `next start`, real env:

```
$ curl -sI http://localhost:3111/pdf/pdf.worker.min.mjs
200  Content-Type: application/javascript; charset=UTF-8
     Content-Length: 1262398
$ curl -s  http://localhost:3111/pdf/pdf.worker.min.mjs | grep -c 6.2.108
2
```

Before the fix, that same request returned the 307.

| Check | Result |
|---|---|
| `npm run ci:summary` | OK (3 pre-existing warnings) |
| `apps/web/src/__tests__/` | **523 passed**, 1 skipped |
| Production server probe | 200, correct content-type, correct version |

## Regression guard

`proxy-static-assets.test.ts` asserts the worker path using the real `PDF_WORKER_SRC` constant, so moving or renaming the worker cannot silently reintroduce this. Reverting the one-line fix turns **5 assertions red** — verified, not assumed.

🤖 Generated with GitHub Copilot CLI